### PR TITLE
Résorption dette i18n (audit 2026-06-01) + release 8.8.2

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "description": "Multi-stack framework for Claude Code teams: 19 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.8.1 | **Languages:** en, fr, es, de, pt
+**Version:** 8.8.2 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/.claude/COMPATIBILITY.md
+++ b/.claude/COMPATIBILITY.md
@@ -1,4 +1,4 @@
-# Claude Code Compatibility — Claude Craft v8.8.1
+# Claude Code Compatibility — Claude Craft v8.8.2
 
 **Minimum Version:** 2.1.97 (elevated from 2.1.47 — see [rationale](#why-we-elevated-minimum-from-2147-to-2197))
 **Recommended Version:** 2.1.159 (Opus 4.8 + Dynamic Workflows, May 31, 2026)
@@ -352,7 +352,7 @@ Features available in Claude Code 2.1.119–2.1.145 and their adoption status in
 
 ---
 
-### Adoption Roadmap for v8.8.1
+### Adoption Roadmap for v8.8.2
 
 | Priorité | Feature | Fichier à modifier | Effort |
 |----------|---------|-------------------|--------|

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.3.2
+- **Version:** 8.8.2
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/.claude/rules/16-i18n.md
+++ b/.claude/rules/16-i18n.md
@@ -18,17 +18,18 @@ Le script `scripts/verify-i18n-parity.sh` vérifie deux niveaux :
 | Vérification | Type | Seuil |
 |---|---|---|
 | Nombre de fichiers | **Bloquant** | 100% parité avec `en` |
-| Taille des fichiers | Configurable | **0.80** (fichier traduit ≥ 80% taille en) |
+| Taille des fichiers | **Bloquant** (depuis v8.8.2) | **0.80** (fichier traduit ≥ 80% taille en) |
+
+> **Depuis v8.8.2 :** la dette i18n historique étant entièrement résorbée (gap 0),
+> le script bloque par défaut sur la taille (`STRICT_SIZE=1`, `I18N_PARITY_STRICT=1`).
+> Tout nouveau fichier sous 0.80 est désormais une régression qui fait échouer la CI.
 
 ```bash
-# Vérifier la parité (bloquant sur count, configurable sur taille)
+# Vérifier la parité (bloquant sur count ET sur taille < 0.80)
 bash scripts/verify-i18n-parity.sh
 
-# Mode strict sur la taille (bloquant si ratio < 0.80)
-STRICT_SIZE=1 bash scripts/verify-i18n-parity.sh
-
-# Mode permissif (PR transitionnelle)
-I18N_PARITY_STRICT=0 bash scripts/verify-i18n-parity.sh
+# Mode permissif (PR transitionnelle uniquement — désactive le blocage taille)
+STRICT_SIZE=0 I18N_PARITY_STRICT=0 bash scripts/verify-i18n-parity.sh
 ```
 
 Le rapport CSV des fichiers sous seuil est généré dans `audit/phases/i18n-gap.csv`.

--- a/.github/workflows/i18n-parity.yml
+++ b/.github/workflows/i18n-parity.yml
@@ -19,20 +19,22 @@ permissions:
 
 jobs:
   parity:
-    name: File count parity (blocking)
+    name: File count + size parity (blocking)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pinned: v4.2.2
-      - name: Check count parity
+      # Since v8.8.2 the script defaults to STRICT_SIZE=1 + I18N_PARITY_STRICT=1,
+      # so this job now blocks on both file-count AND size-ratio (< 0.80) gaps.
+      - name: Check count + strict size parity
         run: bash scripts/verify-i18n-parity.sh
 
-  size-advisory:
-    name: Size parity advisory (non-blocking)
+  size-report:
+    name: Size gap snapshot (reporting only)
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # pinned: v4.2.2
-      - name: Check size ratio (threshold 0.80, strict mode)
+      - name: Generate size gap report (threshold 0.80)
         env:
           STRICT_SIZE: '1'
           I18N_SIZE_THRESHOLD: '0.80'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.8.2] - 2026-06-02
+
+Résorption complète de la dette de traduction i18n résiduelle de l'audit 2026-06-01. PATCH release. Backwards compatible.
+
+### Changed
+
+- **Dette de traduction i18n résorbée (101 → 0)** : les 101 fichiers qui restaient sous le seuil de parité de taille 0.80 sont désormais traduits intégralement depuis la référence `Dev/i18n/en/<...>` (frontmatter conservé, accents/caractères natifs respectés). Répartition : **pt** (48), **de** (23), **es** (21), **fr** (9), couvrant commandes, règles, agents (`Dev/i18n` + `Project/i18n`) et guides utilisateur (`docs/guides`). Le portugais, le plus dégradé (ratios ~0.10 sur les commandes Flutter), est entièrement reconstitué.
+- **Parité de taille i18n désormais bloquante** : la dette historique étant résorbée, `scripts/verify-i18n-parity.sh` bascule ses défauts en mode strict (`STRICT_SIZE=1`, `I18N_PARITY_STRICT=1`). Le job CI `parity` bloque maintenant sur le count **et** la taille (< 0.80) ; tout nouveau fichier sous-traduit est traité comme une régression. Documentation mise à jour dans `.claude/rules/16-i18n.md`.
+
 ## [8.8.1] - 2026-06-02
 
 Clôture des items P2 différés de l'audit 2026-06-01 + complétion de la distribution i18n. PATCH release. Backwards compatible.

--- a/Dev/i18n/de/Angular/commands/check-compliance.md
+++ b/Dev/i18n/de/Angular/commands/check-compliance.md
@@ -1,203 +1,253 @@
 ---
-description: Angular Standards Compliance Check
+description: Vollständige Angular-Compliance-Prüfung durchführen
+argument-hint: [arguments]
 ---
 
-# Angular Standards Compliance Check
+# Vollständige Angular-Compliance-Prüfung
 
-Verify that the Angular project follows established coding standards and best practices.
+## Argumente
 
-## What This Command Does
-
-1. **Standards Verification**
-   - Check coding conventions
-   - Verify naming conventions
-   - Validate file organization
-   - Check import order
-   - Verify documentation standards
-
-2. **Angular-Specific Checks**
-   - Standalone components usage
-   - Signals implementation
-   - OnPush change detection
-   - Modern control flow (@if, @for)
-   - Typed forms
-
-3. **Generated Report**
-   - Non-compliant files
-   - Severity levels
-   - Remediation recommendations
-   - Compliance score (/100)
+$ARGUMENTS (optional: Pfad zum zu analysierenden Projekt)
 
 ## Plan-Modus
 
-> Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine modulübergreifende Untersuchung erfordert.
+> Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine übergreifende Untersuchung erfordert.
 
-## Compliance Areas
+## AUFTRAG
 
-### 1. Component Standards
+Führen Sie ein vollständiges Compliance-Audit des Angular-Projekts durch, indem Sie die 4 Hauptprüfungen orchestrieren: Architektur, Code-Qualität, Tests und Sicherheit. Erstellen Sie einen konsolidierten Bericht mit einer Gesamtpunktzahl von 100 Punkten.
 
-```typescript
-// ✅ Compliant
-@Component({
-  selector: 'app-user-profile',
-  standalone: true,
-  imports: [CommonModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `...`
-})
-export class UserProfileComponent {}
+### Schritt 1: Audit-Vorbereitung
 
-// ❌ Non-compliant
-@Component({
-  selector: 'user-profile',     // Missing app- prefix
-  // standalone: missing       // Not standalone
-  // changeDetection: missing  // Not OnPush
-})
-export class UserProfile {}    // Missing Component suffix
+Audit-Umgebung vorbereiten:
+- [ ] Zu prüfenden Projektpfad identifizieren
+- [ ] Vorhandensein von Konfigurationsdateien prüfen (angular.json, tsconfig.json, package.json)
+- [ ] Hauptverzeichnisse auflisten (src/app/, e2e/, usw.)
+- [ ] Projektstruktur und Angular-Version identifizieren
+
+**Hinweis**: Wenn $ARGUMENTS angegeben ist, diesen als Projektpfad verwenden, andernfalls das aktuelle Verzeichnis verwenden.
+
+### Schritt 2: Architektur-Audit (25 Punkte)
+
+Vollständige Architekturprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/angular:check-architecture` verwenden oder die Schritte in `check-architecture.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- Domain-getriebene Modulstruktur (6 Pkt.)
+- Verwendung von Standalone-Komponenten (6 Pkt.)
+- Lazy Loading und Routing (4 Pkt.)
+- Core/Shared/Feature-Trennung (4 Pkt.)
+- Organisation der Service-Schicht (3 Pkt.)
+- Dependency-Injection-Muster (2 Pkt.)
+
+**Referenz**: `check-architecture.md`
+
+### Schritt 3: Code-Qualitäts-Audit (25 Punkte)
+
+Code-Qualitätsprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/angular:check-code-quality` verwenden oder die Schritte in `check-code-quality.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- TypeScript-Strict-Modus und Typsicherheit (5 Pkt.)
+- ESLint-Konformität (5 Pkt.)
+- Signals und moderne Angular-Muster (4 Pkt.)
+- KISS/DRY/YAGNI-Prinzipien (4 Pkt.)
+- Namenskonventionen und Dateistruktur (4 Pkt.)
+- OnPush-Change-Detection (3 Pkt.)
+
+**Referenz**: `check-code-quality.md`
+
+### Schritt 4: Test-Audit (25 Punkte)
+
+Testprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/angular:check-testing` verwenden oder die Schritte in `check-testing.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- Code-Abdeckung (7 Pkt.)
+- Unit-Tests für Services und Pipes (6 Pkt.)
+- Komponenten-Tests mit TestBed (4 Pkt.)
+- Integrationstests (3 Pkt.)
+- E2E-Tests (3 Pkt.)
+- Test-Isolation und Mocks (2 Pkt.)
+
+**Referenz**: `check-testing.md`
+
+### Schritt 5: Sicherheits-Audit (25 Punkte)
+
+Sicherheitsprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/angular:check-security` verwenden oder die Schritte in `check-security.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- XSS-Prävention und DomSanitizer (6 Pkt.)
+- Verwaltung von Geheimnissen und Anmeldedaten (5 Pkt.)
+- Eingabevalidierung und -bereinigung (4 Pkt.)
+- Schwachstellen in Abhängigkeiten (4 Pkt.)
+- Authentifizierung und Route Guards (3 Pkt.)
+- CSRF und HTTP-Interceptors (2 Pkt.)
+- Content Security Policy (1 Pkt.)
+
+**Referenz**: `check-security.md`
+
+### Schritt 6: Konsolidierung und Gesamtbewertung
+
+Gesamtpunktzahl berechnen und konsolidierten Bericht erstellen:
+- [ ] Die 4 Punktzahlen addieren (max. 100 Punkte)
+- [ ] Kritische Kategorien identifizieren (<50%)
+- [ ] Alle kritischen übergreifenden Probleme auflisten
+- [ ] Maßnahmen nach Auswirkung/Aufwand priorisieren
+- [ ] Abschließenden konsolidierten Bericht erstellen
+
+**Bewertungsskala**:
+- 90-100: Ausgezeichnet — Referenzprojekt
+- 75-89: Sehr gut — Einige geringfügige Verbesserungen
+- 60-74: Akzeptabel — Verbesserungen erforderlich
+- 40-59: Unzureichend — Größeres Refactoring erforderlich
+- 0-39: Kritisch — Vollständige Überarbeitung notwendig
+
+### Schritt 7: Empfehlungen und Aktionsplan
+
+Abschließende Empfehlungen erstellen:
+- [ ] Top-3-Prioritätsmaßnahmen über alle Kategorien hinweg identifizieren
+- [ ] Aufwand (Gering/Mittel/Hoch) für jede Maßnahme schätzen
+- [ ] Auswirkung (Gering/Mittel/Hoch) für jede Maßnahme schätzen
+- [ ] Umsetzungsreihenfolge vorschlagen
+- [ ] Quick Wins vorschlagen (hohes Auswirkungs-/Aufwandsverhältnis)
+
+## AUSGABEFORMAT
+
+```
+ANGULAR COMPLIANCE AUDIT - VOLLSTÄNDIGER BERICHT
+=================================================
+
+GESAMTPUNKTZAHL: XX/100
+
+COMPLIANCE-NIVEAU: [Ausgezeichnet/Sehr gut/Akzeptabel/Unzureichend/Kritisch]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PUNKTE NACH KATEGORIE:
+
+ARCHITEKTUR       : XX/25  [██████████░░░░░░░░░░] XX%
+CODE-QUALITÄT     : XX/25  [██████████░░░░░░░░░░] XX%
+TESTS             : XX/25  [██████████░░░░░░░░░░] XX%
+SICHERHEIT        : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GESAMTSTÄRKEN:
+1. [In mehreren Kategorien identifizierte Stärke]
+2. [Weitere wichtige Stärke]
+3. [Dritte Stärke]
+
+GESAMTVERBESSERUNGEN:
+1. [Geringfügige übergreifende Verbesserung]
+2. [Weitere empfohlene Verbesserung]
+3. [Dritte Verbesserung]
+
+KRITISCHE PROBLEME:
+1. [Kritisches Problem Nr. 1 — betroffene Kategorie]
+2. [Kritisches Problem Nr. 2 — betroffene Kategorie]
+3. [Kritisches Problem Nr. 3 — betroffene Kategorie]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETAILS NACH KATEGORIE:
+
+┌─────────────────────────────────────────────┐
+│ ARCHITEKTUR (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Teilpunkte:
+  • Domain-getriebene Module        : XX/6
+  • Standalone-Komponenten          : XX/6
+  • Lazy Loading und Routing        : XX/4
+  • Core/Shared/Feature             : XX/4
+  • Service-Schicht                 : XX/3
+  • Dependency Injection            : XX/2
+
+Stärken:
+- [Architekturstärken]
+
+Probleme:
+- [Architekturprobleme]
+
+[Ähnliche Abschnitte für Code-Qualität, Tests und Sicherheit...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 PRIORITÄTSMASSNAHMEN (ALLE KATEGORIEN):
+
+1. KRITISCH - [Maßnahme Nr. 1]
+   Kategorie  : [Architektur/Qualität/Tests/Sicherheit]
+   Auswirkung : [Hoch/Mittel/Gering]
+   Aufwand    : [Hoch/Mittel/Gering]
+   Priorität  : SOFORT
+
+   Detaillierte Beschreibung:
+   [Erläuterung des Problems und vorgeschlagene Lösung]
+
+   Betroffene Dateien:
+   - [datei:zeile]
+
+   Korrekturbeispiel:
+   [Code oder Korrekturbefehl]
+
+2. WICHTIG - [Maßnahme Nr. 2]
+   [Gleiches Format...]
+
+3. EMPFOHLEN - [Maßnahme Nr. 3]
+   [Gleiches Format...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+QUICK WINS (Hohe Auswirkung / Geringer Aufwand):
+
+- [Quick Win Nr. 1] - Kategorie: [X] - Auswirkung: [X] - Aufwand: [X]
+- [Quick Win Nr. 2] - Kategorie: [X] - Auswirkung: [X] - Aufwand: [X]
+- [Quick Win Nr. 3] - Kategorie: [X] - Auswirkung: [X] - Aufwand: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+EMPFOHLENER AKTIONSPLAN:
+
+WOCHE 1 (Sofort):
+- [ ] [Kritische Maßnahme Nr. 1]
+- [ ] [Prioritäts-Quick-Win]
+
+WOCHE 2-4 (Kurzfristig):
+- [ ] [Wichtige Maßnahme Nr. 2]
+- [ ] [Weitere Quick Wins]
+
+MONAT 2-3 (Mittelfristig):
+- [ ] [Empfohlene Maßnahme Nr. 3]
+- [ ] [Schrittweise Verbesserungen]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ZUSAMMENFASSUNG FÜR DIE GESCHÄFTSLEITUNG:
+
+[Zusammenfassender Absatz zum Gesamtzustand des Projekts, zu den wichtigsten Stärken,
+den wichtigsten Schwächen und zur empfohlenen Entwicklung zur Verbesserung
+der Compliance. Angeben, ob das Projekt produktionsreif ist,
+Korrekturen erfordert oder refaktoriert werden muss.]
+
+Allgemeine Empfehlung: [Produktionsreif / Geringfügige Korrekturen /
+Größeres Refactoring / Überarbeitung notwendig]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Signal Usage
+## WICHTIGE HINWEISE
 
-```typescript
-// ✅ Compliant - Using signals
-export class CounterComponent {
-  count = signal(0);
-  doubleCount = computed(() => this.count() * 2);
-}
-
-// ❌ Non-compliant - Using observables for local state
-export class CounterComponent {
-  count$ = new BehaviorSubject(0);
-}
-```
-
-### 3. Template Syntax
-
-```html
-<!-- ✅ Compliant - Modern control flow -->
-@if (loading()) {
-  <app-spinner />
-}
-
-@for (item of items(); track item.id) {
-  <app-item [data]="item" />
-}
-
-<!-- ❌ Non-compliant - Legacy syntax -->
-<app-spinner *ngIf="loading"></app-spinner>
-<app-item *ngFor="let item of items" [data]="item"></app-item>
-```
-
-### 4. Dependency Injection
-
-```typescript
-// ✅ Compliant - inject() function
-export class MyComponent {
-  private readonly userService = inject(UserService);
-}
-
-// ⚠️ Warning - Constructor injection (valid but verbose)
-export class MyComponent {
-  constructor(private userService: UserService) {}
-}
-```
-
-### 5. File Naming
-
-```
-✅ Compliant:
-- user-profile.component.ts
-- auth.service.ts
-- auth.guard.ts
-- date-format.pipe.ts
-
-❌ Non-compliant:
-- UserProfile.component.ts (PascalCase)
-- authService.ts (missing suffix)
-- AuthGuard.ts (PascalCase)
-```
-
-## Scoring Criteria
-
-| Category | Weight | Criteria |
-|----------|--------|----------|
-| Standalone Components | 20% | All components are standalone |
-| Signals Usage | 15% | Local state uses signals |
-| OnPush Strategy | 15% | All components use OnPush |
-| Modern Control Flow | 10% | @if/@for instead of *ngIf/*ngFor |
-| Typed Forms | 10% | Forms are strongly typed |
-| Naming Conventions | 10% | Correct file/class naming |
-| Import Organization | 10% | Imports properly ordered |
-| Documentation | 10% | Key components documented |
-
-## Output Format
-
-```
-══════════════════════════════════════════════════════════════
-ANGULAR COMPLIANCE REPORT
-══════════════════════════════════════════════════════════════
-
-📊 SCORE: 85/100
-
-✅ PASSING (6)
-──────────────────────────────────────────────────────────────
-• Standalone components: 100% (24/24 components)
-• OnPush strategy: 100% (24/24 components)
-• Typed forms: 100% (8/8 forms)
-• Import organization: 100%
-• File naming: 100%
-• Documentation: 90%
-
-⚠️ WARNINGS (2)
-──────────────────────────────────────────────────────────────
-• Modern control flow: 75% (18/24 templates)
-  - src/app/features/users/user-list.component.html:15 - Uses *ngFor
-  - src/app/shared/modal/modal.component.html:8 - Uses *ngIf
-
-• Signals usage: 80% (16/20 components with local state)
-  - src/app/features/auth/login.component.ts - Uses BehaviorSubject
-
-❌ ERRORS (1)
-──────────────────────────────────────────────────────────────
-• Constructor injection detected (prefer inject()):
-  - src/app/core/services/api.service.ts:15
-
-📋 RECOMMENDATIONS
-──────────────────────────────────────────────────────────────
-1. Migrate remaining *ngFor to @for with track
-2. Replace BehaviorSubject with signal() for local state
-3. Use inject() function instead of constructor injection
-
-══════════════════════════════════════════════════════════════
-```
-
-## Automated Checks
-
-Run these commands to verify compliance:
-
-```bash
-# Lint check
-ng lint
-
-# Type check
-npx tsc --noEmit
-
-# Test coverage
-npm run test:ci
-
-# Build check
-ng build --configuration=production
-```
-
-## Checklist
-
-- [ ] All components are standalone
-- [ ] All components use OnPush change detection
-- [ ] Local state uses signals (not BehaviorSubject)
-- [ ] Templates use @if/@for/@switch
-- [ ] Forms are typed (FormGroup<T>)
-- [ ] inject() used for dependency injection
-- [ ] File naming follows conventions
-- [ ] Imports are organized
-- [ ] Public API documented
-- [ ] Tests pass with >80% coverage
+- Dieser Befehl orchestriert die 4 spezialisierten Audits
+- Docker für alle Analysewerkzeuge verwenden
+- Konkrete Beispiele mit datei:zeile für jedes Problem bereitstellen
+- Maßnahmen auf der Grundlage der Auswirkungs-/Aufwandsmatrix priorisieren
+- Sicherheitsprobleme haben IMMER höchste Priorität
+- Automatisierbare Korrekturen vorschlagen (Skripte, Pre-Commit-Hooks)
+- Der Bericht muss umsetzbar sein, nicht nur beschreibend
+- Empfehlungen an den geschäftlichen Kontext des Projekts anpassen

--- a/Dev/i18n/de/Common/agents/refactoring-specialist.md
+++ b/Dev/i18n/de/Common/agents/refactoring-specialist.md
@@ -1,67 +1,77 @@
 ---
 name: refactoring-specialist
-description: Safe code refactoring expert
+description: Experte für sicheres Code-Refactoring
 model: sonnet
 effort: medium
 maxTurns: 8
-tools: [Read, Glob, Grep, Edit, Write, Bash, WebFetch, WebSearch]
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Edit
+  - Write
+  - Bash
+  - WebFetch
 permissionMode: default
-skills: [solid-principles, testing, kiss-dry-yagni]
+skills:
+  - solid-principles
+  - kiss-dry-yagni
+  - testing
 ---
 
-# Refactoring Specialist Agent
+# Refactoring-Spezialist-Agent
 
 ## Identität
 
-Sie sind ein **Senior Refactoring Specialist** mit über 15 Jahren Erfahrung in Legacy-Code-Modernisierung, technischer Schulden-Reduzierung und Codebase-Transformation. Sie beherrschen sichere Refactoring-Techniken ohne Funktionalitätsverlust.
+Sie sind ein **Senior Refactoring-Spezialist** mit mehr als 15 Jahren Erfahrung in der Modernisierung von Legacy-Code, dem Abbau technischer Schulden und der Transformation von Codebases. Sie beherrschen sichere Refactoring-Techniken, ohne die bestehende Funktionalität zu beeinträchtigen.
 
-## Technisches Fachwissen
+## Technische Expertise
 
 ### Code Smells
 | Smell | Symptome | Refactoring |
-|-------|-----------|-------------|
-| Long Method | > 20 Zeilen, mehrere Verantwortlichkeiten | Extract Method |
-| Large Class | > 500 Zeilen, God Object | Extract Class |
-| Feature Envy | Methode nutzt andere Klasse mehr | Move Method |
-| Data Clumps | Gleiche Parameter wiederholt | Extract Class/Parameter Object |
+|-------|----------|-------------|
+| Lange Methode | > 20 Zeilen, mehrere Verantwortlichkeiten | Methode extrahieren |
+| Große Klasse | > 500 Zeilen, God Object | Klasse extrahieren |
+| Feature Envy | Methode nutzt eine andere Klasse häufiger | Methode verschieben |
+| Data Clumps | Gleiche Parameter wiederholen sich | Klasse/Parameter-Objekt extrahieren |
 | Primitive Obsession | Strings/Ints statt Typen | Value Objects |
-| Switch Statements | Wiederholte Switches auf Typ | Polymorphismus |
-| Parallel Inheritance | Spiegel-Hierarchien | Hierarchien zusammenführen |
-| Comments | Kommentare = unklarer Code | Umbenennen, Extract Method |
+| Switch-Anweisungen | Wiederholte Switches auf Typ | Polymorphismus |
+| Parallele Vererbung | Spiegelnde Hierarchien | Hierarchien zusammenführen |
+| Kommentare | Kommentare = unklarer Code | Umbenennen, Methode extrahieren |
 
-### Refactoring-Patterns
-| Pattern | Verwendung |
-|---------|-------|
-| Extract Method | Verantwortlichkeit isolieren |
-| Extract Class | Zu große Klasse trennen |
-| Move Method/Field | An passende Klasse verschieben |
-| Replace Conditional | Polymorphismus statt if/switch |
-| Introduce Parameter Object | Verwandte Parameter gruppieren |
-| Replace Temp with Query | Variable durch Methode ersetzen |
-| Decompose Conditional | Komplexe Bedingungen extrahieren |
-| Replace Magic Number | Benannte Konstanten |
+### Refactoring-Muster
+| Muster | Verwendung |
+|--------|------------|
+| Methode extrahieren | Eine Verantwortlichkeit isolieren |
+| Klasse extrahieren | Zu große Klasse aufteilen |
+| Methode/Feld verschieben | In geeignete Klasse verlagern |
+| Bedingte ersetzen | Polymorphismus statt if/switch |
+| Parameter-Objekt einführen | Zusammengehörige Parameter gruppieren |
+| Temp durch Query ersetzen | Variable durch Methode ersetzen |
+| Bedingte dekomponieren | Komplexe Bedingungen extrahieren |
+| Magic Number ersetzen | Benannte Konstanten verwenden |
 
-### Legacy-Patterns
-| Pattern | Beschreibung |
-|---------|-------------|
-| Strangler Fig | Legacy progressiv ersetzen |
-| Branch by Abstraction | Abstraktion vor Änderung einführen |
+### Legacy-Muster
+| Muster | Beschreibung |
+|--------|-------------|
+| Strangler Fig | Legacy schrittweise ersetzen |
+| Branch by Abstraction | Abstraktion einführen vor Änderung |
 | Sprout Method/Class | Neues hinzufügen ohne Altes anzufassen |
-| Wrap Method | Kapseln um Verhalten hinzuzufügen |
+| Wrap Method | Kapseln, um Verhalten hinzuzufügen |
 | Seam | Einstiegspunkt für Tests |
 
 ## Methodik
 
-### Analyse vor Refactoring
+### Analyse vor dem Refactoring
 
 1. **Code kartieren**
    - Abhängigkeiten identifizieren
    - Zyklomatische Komplexität messen
-   - Hotspots erkennen (Änderungshäufigkeit)
-   - Testabdeckung bewerten
+   - Hotspots aufspüren (Änderungshäufigkeit)
+   - Test-Coverage bewerten
 
 2. **Refactorings priorisieren**
-   - Geschäftsauswirkung (häufig geänderter Code)
+   - Geschäftliche Auswirkung (häufig geänderter Code)
    - Risiko (Kopplung, Komplexität)
    - Aufwand vs. Nutzen
    - Voraussetzungen (benötigte Tests)
@@ -75,32 +85,32 @@ Sie sind ein **Senior Refactoring Specialist** mit über 15 Jahren Erfahrung in 
 ### Sicherer Refactoring-Prozess
 
 ```
-1. TESTS SCHREIBEN (falls fehlend)
+1. TESTS SCHREIBEN (falls nicht vorhanden)
    ↓
-2. KLEINE ÄNDERUNG MACHEN
+2. KLEINE ÄNDERUNG VORNEHMEN
    ↓
 3. TESTS AUSFÜHREN
    ↓
-4. COMMITTEN WENN GRÜN
+4. COMMITTEN, WENN GRÜN
    ↓
 5. WIEDERHOLEN
 ```
 
 ### Goldene Regel
-> "Refactoring: Code-Struktur ändern ohne Verhalten zu ändern"
+> „Refactoring: Code-Struktur ändern, ohne sein Verhalten zu ändern"
 
 ## Techniken nach Smell
 
-### Long Method → Extract Method
+### Lange Methode → Methode extrahieren
 
 ```php
 // VORHER
 function processOrder($order) {
     // Validierung
-    if (!$order->hasItems()) throw new Exception('Keine Artikel');
-    if (!$order->hasCustomer()) throw new Exception('Kein Kunde');
+    if (!$order->hasItems()) throw new Exception('No items');
+    if (!$order->hasCustomer()) throw new Exception('No customer');
 
-    // Gesamtsumme berechnen
+    // Gesamtbetrag berechnen
     $total = 0;
     foreach ($order->items as $item) {
         $total += $item->price * $item->quantity;
@@ -134,9 +144,9 @@ private function applyDiscounts($order, $total) { /* ... */ }
 # VORHER
 def create_user(email: str, phone: str):
     if not "@" in email:
-        raise ValueError("Ungültige E-Mail")
+        raise ValueError("Invalid email")
     if not phone.startswith("+"):
-        raise ValueError("Ungültige Telefonnummer")
+        raise ValueError("Invalid phone")
 
 # NACHHER
 @dataclass(frozen=True)
@@ -145,7 +155,7 @@ class Email:
 
     def __post_init__(self):
         if "@" not in self.value:
-            raise ValueError("Ungültige E-Mail")
+            raise ValueError("Invalid email")
 
 @dataclass(frozen=True)
 class Phone:
@@ -153,25 +163,92 @@ class Phone:
 
     def __post_init__(self):
         if not self.value.startswith("+"):
-            raise ValueError("Ungültige Telefonnummer")
+            raise ValueError("Invalid phone")
 
 def create_user(email: Email, phone: Phone):
     # Validierung bereits durch Value Objects erledigt
     pass
 ```
 
+### Bedingungen durch Polymorphismus ersetzen
+
+```typescript
+// VORHER
+function calculateShipping(order: Order): number {
+    switch (order.shippingMethod) {
+        case 'standard':
+            return order.weight * 0.5;
+        case 'express':
+            return order.weight * 1.5 + 10;
+        case 'overnight':
+            return order.weight * 3 + 25;
+        default:
+            throw new Error('Unknown method');
+    }
+}
+
+// NACHHER
+interface ShippingCalculator {
+    calculate(order: Order): number;
+}
+
+class StandardShipping implements ShippingCalculator {
+    calculate(order: Order): number {
+        return order.weight * 0.5;
+    }
+}
+
+class ExpressShipping implements ShippingCalculator {
+    calculate(order: Order): number {
+        return order.weight * 1.5 + 10;
+    }
+}
+
+// Factory, um den richtigen Kalkulator zu ermitteln
+```
+
+### Strangler-Fig-Muster
+
+```
+Schritt 1: Fassade vor Legacy erstellen
+┌─────────────────────────────────────┐
+│           Fassade                   │
+│  ┌─────────────┐  ┌──────────────┐ │
+│  │   Legacy    │  │    (leer)    │ │
+│  └─────────────┘  └──────────────┘ │
+└─────────────────────────────────────┘
+
+Schritt 2: Schrittweise migrieren
+┌─────────────────────────────────────┐
+│           Fassade                   │
+│  ┌─────────────┐  ┌──────────────┐ │
+│  │   Legacy    │  │     Neu      │ │
+│  │   (50%)     │  │   (50%)      │ │
+│  └─────────────┘  └──────────────┘ │
+└─────────────────────────────────────┘
+
+Schritt 3: Legacy entfernen
+┌─────────────────────────────────────┐
+│       Fassade (optional)            │
+│  ┌──────────────────────────────┐  │
+│  │            Neu               │  │
+│  │          (100%)              │  │
+│  └──────────────────────────────┘  │
+└─────────────────────────────────────┘
+```
+
 ## Refactoring-Checkliste
 
 ### Vor dem Start
-- [ ] Vorhandene Tests bestehen
-- [ ] Ausreichende Abdeckung auf zu refaktorierendem Bereich
+- [ ] Bestehende Tests bestehen
+- [ ] Ausreichende Coverage im zu refaktorierenden Bereich
 - [ ] Änderungen in kleinen Schritten geplant
 - [ ] Feature-Branch erstellt
 - [ ] Rollback-Plan definiert
 
 ### Während des Refactorings
-- [ ] Jeweils eine Art von Änderung
-- [ ] Tests nach jeder Änderung
+- [ ] Jeweils nur eine Art von Änderung
+- [ ] Tests nach jeder Änderung ausführen
 - [ ] Atomare und beschreibende Commits
 - [ ] Keine Verhaltensänderung
 
@@ -179,16 +256,16 @@ def create_user(email: Email, phone: Phone):
 - [ ] Alle Tests bestehen
 - [ ] Code Review durchgeführt
 - [ ] Dokumentation bei Bedarf aktualisiert
-- [ ] Verbesserte Metriken (Komplexität, Duplikation)
+- [ ] Verbesserte Metriken (Komplexität, Duplizierung)
 
-## Analysetools
+## Analysewerkzeuge
 
 ### PHP
 ```bash
 # Zyklomatische Komplexität
 phpmd src/ text codesize
 
-# Duplikation
+# Duplizierung
 phpcpd src/
 
 # Metriken
@@ -213,30 +290,30 @@ pylint src/
 # Komplexität
 npx complexity-report src/
 
-# Duplikation
+# Duplizierung
 npx jscpd src/
 
 # Linting
 npx eslint src/
 ```
 
-## Refactoring-Anti-Patterns
+## Refactoring-Anti-Muster
 
-| Anti-Pattern | Problem | Lösung |
-|--------------|----------|----------|
-| Big Bang Rewrite | Riesiges Risiko, nie fertig | Strangler Fig |
-| Refactoring ohne Tests | Garantierte Regression | Tests zuerst |
-| Änderung + Refactoring | Schwer zu debuggen | Getrennte Commits |
-| Perfektionismus | Nie fertig | "Gut genug" |
-| Unsichtbares Refactoring | Kein wahrgenommener Wert | Gewinne kommunizieren |
+| Anti-Muster | Problem | Lösung |
+|-------------|---------|--------|
+| Big-Bang-Neuentwicklung | Riesiges Risiko, nie fertig | Strangler Fig |
+| Refactoring ohne Tests | Garantierte Regression | Zuerst Tests schreiben |
+| Änderung + Refactoring | Schwer zu debuggen | Separate Commits |
+| Perfektionismus | Nie fertig | „Gut genug" |
+| Unsichtbares Refactoring | Kein wahrgenommener Mehrwert | Gewinne kommunizieren |
 
 ## Zu überwachende Metriken
 
 | Metrik | Vorher | Ziel |
-|----------|-------|----------|
+|--------|--------|------|
 | Zyklomatische Komplexität | > 10 | < 10 |
 | Methodenlänge | > 50 Zeilen | < 20 Zeilen |
-| Parameteranzahl | > 5 | < 4 |
+| Anzahl Parameter | > 5 | < 4 |
 | Verschachtelungstiefe | > 4 | < 3 |
-| Duplikation | > 5% | < 3% |
-| Testabdeckung | < 50% | > 80% |
+| Duplizierung | > 5% | < 3% |
+| Test-Coverage | < 50% | > 80% |

--- a/Dev/i18n/de/Common/commands/add-technology.md
+++ b/Dev/i18n/de/Common/commands/add-technology.md
@@ -1,97 +1,97 @@
 ---
-description: Eine neue Technologie zu claude-craft hinzufügen mit Best Practices von Context7 und Websuche
-argument-hint: <technologie-name>
+description: Eine neue Technologie zu claude-craft hinzufügen mit Best Practices aus Context7 und Web-Suche
+argument-hint: <technology-name>
 ---
 
-# Technologie Hinzufügen
+# Technologie hinzufügen
 
-Sie sind ein Experte für Technologie-Integration bei claude-craft. Ihre Mission ist es, einen neuen Technologie-Stack hinzuzufügen:
-1. Best Practices recherchieren mit Context7 MCP und Websuche
-2. Alle notwendigen Dateien generieren (rules, commands, templates, skills, agents)
+Sie sind ein erfahrener Technologie-Integrator für claude-craft. Ihr Auftrag ist es, einen neuen Technologie-Stack hinzuzufügen, indem Sie:
+1. Best Practices mithilfe von Context7 MCP und Web-Suche recherchieren
+2. Alle erforderlichen Dateien generieren (Regeln, Befehle, Templates, Skills, Agenten)
 3. Das Installationsskript erstellen
-4. Dokumentation und Präsentationsseite aktualisieren
+4. Dokumentation und Landing Page aktualisieren
 
 ## Argumente
 $ARGUMENTS
 
 Argumente:
-- `technologie-name`: Name der hinzuzufügenden Technologie (z.B. "nextjs", "nestjs", "golang", "laravel")
-- (Optional) `kategorie`: Kategorie der Technologie (frontend, backend, mobile, devops, fullstack)
+- `technology-name`: Name der hinzuzufügenden Technologie (z. B. „nextjs", „nestjs", „golang", „laravel")
+- (Optional) `category`: Kategorie der Technologie (frontend, backend, mobile, devops, fullstack)
 
 Beispiel: `/common:add-technology "nestjs"` oder `/common:add-technology "golang" backend`
 
 ## Plan-Modus
 
-> **Der Plan-Modus ist obligatorisch.** Vor der Ausführung aktiviert Claude den Plan-Modus, um betroffenen Code zu analysieren, einen Implementierungsplan vorzuschlagen und auf Ihre Validierung zu warten, bevor Änderungen vorgenommen werden.
+> **Plan-Modus ist obligatorisch.** Vor der Ausführung aktiviert Claude den Plan-Modus, um betroffenen Code zu analysieren, einen Implementierungsplan vorzuschlagen und Ihre Bestätigung abzuwarten, bevor Änderungen vorgenommen werden.
 
-## MISSION
+## AUFTRAG
 
-### Schritt 1: Technologie Analysieren
+### Schritt 1: Technologie analysieren
 
-Identifizieren:
-- Offizieller Name und gängige Aliase
-- Typ: Framework, Bibliothek, Sprache, Tool
+Folgendes identifizieren:
+- Offizieller Name und gebräuchliche Aliase
+- Typ: Framework, Bibliothek, Sprache, Werkzeug
 - Kategorie: frontend, backend, mobile, devops, fullstack
-- Ökosystem: verwandte Tools, Test-Frameworks, Deployment-Optionen
-- Zielgruppe: Web, Mobile, API, CLI, etc.
+- Ökosystem: zugehörige Werkzeuge, Test-Frameworks, Deployment-Optionen
+- Zielgruppe: Web, Mobile, API, CLI, usw.
 
-### Schritt 2: Mit Context7 Recherchieren (MCP)
+### Schritt 2: Mit Context7 recherchieren (MCP)
 
-**Context7 für offizielle Dokumentation nutzen:**
+**Context7 für den Zugriff auf offizielle Dokumentation verwenden:**
 
 ```
 Context7 abfragen für:
-1. Offizieller Einstiegsleitfaden
+1. Offiziellen Einstiegsleitfaden
 2. Empfohlene Projektstruktur
-3. Best Practices und Design Patterns
+3. Best Practices und Entwurfsmuster
 4. Teststrategien (Unit, Integration, E2E)
 5. Sicherheits-Best-Practices
-6. Tipps zur Performance-Optimierung
+6. Tipps zur Leistungsoptimierung
 7. Deployment-Empfehlungen
 ```
 
-#### Zu Extrahierende Informationen
+#### Zu extrahierende Informationen
 
-| Thema | Zu Findende Details |
+| Thema | Zu findende Details |
 |-------|---------------------|
-| Architektur | Empfohlene Patterns (MVC, Clean, Hexagonal, etc.) |
-| Code-Standards | Stilrichtlinien, Namenskonventionen, Dateistruktur |
-| Werkzeuge | CLI-Tools, Formatter, Linter, Bundler |
-| Testing | Test-Frameworks, Coverage-Tools, Mocking-Strategien |
+| Architektur | Empfohlene Muster (MVC, Clean, Hexagonal, usw.) |
+| Coding-Standards | Style Guide, Namenskonventionen, Dateistruktur |
+| Werkzeuge | CLI-Tools, Formatierer, Linter, Bundler |
+| Tests | Test-Frameworks, Coverage-Tools, Mocking-Strategien |
 | Sicherheit | Authentifizierung, Autorisierung, häufige Schwachstellen |
-| Qualität | Statische Analyse, Typprüfung, Review-Praktiken |
+| Qualität | Statische Analyse, Typprüfung, Code-Review-Praktiken |
 
-### Schritt 3: Mit Websuche Ergänzen
+### Schritt 3: Mit Web-Suche ergänzen
 
 **Nach 2026-Trends und Community-Praktiken suchen:**
 
 1. **Neueste Trends**
    - Aktuelle stabile Version
-   - Kommende Features
-   - Deprecation-Warnungen
+   - Kommende Funktionen
+   - Veraltungswarnungen
    - Migrationsleitfäden
 
-2. **Community Best Practices**
+2. **Community-Best-Practices**
    - Beliebte Boilerplates
    - Produktionskonfigurationen
-   - Performance-Benchmarks
-   - Reale Architekturen
+   - Leistungs-Benchmarks
+   - Architekturen aus der Praxis
 
 3. **Häufige Fallstricke**
    - Häufige Fehler
-   - Anti-Patterns
+   - Anti-Muster
    - Sicherheitslücken
-   - Performance-Engpässe
+   - Leistungsengpässe
 
 4. **Ökosystem**
    - Empfohlene Bibliotheken
-   - Test-Tools
+   - Test-Werkzeuge
    - DevOps-Integrationen
    - Monitoring-Lösungen
 
-### Schritt 4: Technologie-Dateien Generieren
+### Schritt 4: Technologie-Dateien generieren
 
-**Vollständige Struktur in allen 5 Sprachen erstellen (en, fr, es, de, pt):**
+**Die vollständige Dateistruktur in allen 5 Sprachen (en, fr, es, de, pt) erstellen:**
 
 ```
 Dev/i18n/{lang}/{TECHNOLOGY}/
@@ -110,90 +110,188 @@ Dev/i18n/{lang}/{TECHNOLOGY}/
 │   ├── check-code-quality.md
 │   ├── check-testing.md
 │   ├── check-security.md
-│   └── [generate-*.md falls anwendbar]
+│   └── [generate-*.md falls zutreffend]
 ├── templates/
-│   └── [technologie-spezifische Templates]
+│   └── [technologiespezifische Templates]
 ├── checklists/
 │   ├── pre-commit.md
 │   └── new-feature.md
 ├── agents/
 │   └── {tech}-reviewer.md
 └── skills/
-    └── [technologie-spezifische Skills]
+    └── [technologiespezifische Skills]
 ```
 
-### Schritt 5: Installationsskript Erstellen
+#### Zu generierende Regeln
+
+| Datei | Inhalt |
+|-------|--------|
+| `02-architecture-{tech}.md` | Architekturmuster, Ordnerstruktur, Clean-Architecture-Prinzipien |
+| `03-coding-standards.md` | Style Guide, Namenskonventionen, Dateiorganisation |
+| `06-tooling.md` | CLI-Befehle, Formatierer, Linter, Build-Tools |
+| `07-testing-{tech}.md` | Teststrategien, Frameworks, Coverage-Anforderungen |
+| `08-quality-tools.md` | Statische Analyse, Typprüfung, CI/CD-Integration |
+| `11-security-{tech}.md` | Sicherheitspraktiken, häufige Schwachstellen, Authentifizierung |
+
+#### Zu generierende Befehle
+
+| Befehl | Zweck |
+|--------|-------|
+| `check-compliance.md` | Vollständiges Compliance-Audit (Punktzahl /100) |
+| `check-architecture.md` | Architekturüberprüfung |
+| `check-code-quality.md` | Code-Qualitätsanalyse |
+| `check-testing.md` | Test-Coverage und -Qualität |
+| `check-security.md` | Sicherheits-Audit |
+
+### Schritt 5: Installationsskript erstellen
 
 **`Dev/scripts/install-{tech}-rules.sh` generieren:**
 
-Muster bestehender Skripte folgen:
-- Unterstützung von `--lang`, `--force`, `--update`, `--dry-run`, `--backup` Optionen
-- Generische Regeln von Common/ kopieren
-- Technologie-spezifische Regeln kopieren
+Am Muster bestehender Skripte orientieren:
+- Optionen `--lang`, `--force`, `--update`, `--dry-run`, `--backup` unterstützen
+- Generische Regeln aus Common/ kopieren
+- Technologiespezifische Regeln kopieren
 - CLAUDE.md und 00-project-context.md generieren
 - Installationszusammenfassung anzeigen
 
-### Schritt 6: Dokumentation Aktualisieren
+### Schritt 6: Dokumentation aktualisieren
 
 **Zu aktualisierende Dateien:**
 
 | Datei | Änderungen |
 |-------|------------|
 | `README.md` | Technologie zur Liste der unterstützten Stacks hinzufügen |
-| `docs/index.html` | Stats erhöhen, Technologie-Karte hinzufügen |
+| `docs/index.html` | Statistiken erhöhen, Technologie-Karte hinzufügen |
 | `docs/COMMANDS.md` | Neue Befehle dokumentieren |
-| `Makefile` | `install-{tech}` Target hinzufügen |
+| `Makefile` | `install-{tech}`-Ziel hinzufügen |
+
+#### Landing-Page-Aktualisierungen (docs/index.html)
+
+1. **Statistikbereich**: Zähler „Tech Stacks" erhöhen
+2. **Technologie-Raster**: Neue Technologie-Karte hinzufügen:
+
+```html
+<div class="bg-slate-800/50 p-6 rounded-xl border border-white/5 hover:border-brand-500/50 transition-colors text-center group">
+    <div class="h-16 w-16 mx-auto bg-black rounded-full flex items-center justify-center mb-4 shadow-lg group-hover:scale-110 transition-transform">
+        <span class="text-2xl font-bold text-white">{ICON}</span>
+    </div>
+    <h3 class="font-bold text-white">{TECH_NAME}</h3>
+    <p class="text-xs text-slate-400 mt-2" data-i18n="tech_{tech}_desc">{DESCRIPTION}</p>
+</div>
+```
+
+3. **Übersetzungen**: i18n-Schlüssel für alle 5 Sprachen hinzufügen
+
+#### Makefile-Ziel
+
+```makefile
+install-{tech}:
+	./Dev/scripts/install-{tech}-rules.sh --lang=$(RULES_LANG) $(OPTIONS) $(TARGET)
+```
 
 ### Schritt 7: Validierung
 
-#### Definition of Done Checkliste
+#### Definition-of-Done-Checkliste
 
 ```
 ══════════════════════════════════════════════════════════════
-✅ DEFINITION OF DONE: Technologie Hinzufügen [{TECH_NAME}]
+✅ DEFINITION OF DONE: Technologie hinzufügen [{TECH_NAME}]
 ══════════════════════════════════════════════════════════════
 
 📁 ERSTELLTE DATEIEN
 ──────────────────────────────────────────────────────────────
-- [ ] Rules (7 Dateien × 5 Sprachen = 35 Dateien)
-- [ ] Commands (5 Dateien × 5 Sprachen = 25 Dateien)
+- [ ] Regeln (7 Dateien × 5 Sprachen = 35 Dateien)
+- [ ] Befehle (5 Dateien × 5 Sprachen = 25 Dateien)
 - [ ] Templates (mindestens 2 pro Sprache)
-- [ ] Checklists (2 Dateien × 5 Sprachen = 10 Dateien)
+- [ ] Checklisten (2 Dateien × 5 Sprachen = 10 Dateien)
 - [ ] Agent {tech}-reviewer (1 Datei × 5 Sprachen = 5 Dateien)
 - [ ] CLAUDE.md.template (× 5 Sprachen)
 - [ ] Installationsskript (Dev/scripts/install-{tech}-rules.sh)
 
-📄 AKTUALISIERTE DOKUMENTATION
+📄 DOKUMENTATION AKTUALISIERT
 ──────────────────────────────────────────────────────────────
 - [ ] README.md: Technologie zu unterstützten Stacks hinzugefügt
-- [ ] docs/index.html: Stats erhöht
+- [ ] docs/index.html: Statistiken erhöht
 - [ ] docs/index.html: Technologie-Karte hinzugefügt
 - [ ] docs/index.html: i18n-Übersetzungen hinzugefügt (5 Sprachen)
 - [ ] docs/COMMANDS.md: Neue Befehle dokumentiert
-- [ ] Makefile: install-{tech} Target hinzugefügt
+- [ ] Makefile: install-{tech}-Ziel hinzugefügt
 
-🧪 VERIFIZIERUNG
+🧪 VERIFIKATION
 ──────────────────────────────────────────────────────────────
 - [ ] Installationsskript läuft fehlerfrei
 - [ ] Alle Dateien sind korrekt formatiert
-- [ ] Befehle sind funktional
+- [ ] Befehle sind funktionsfähig
 - [ ] Dokumentation ist korrekt
 
 ══════════════════════════════════════════════════════════════
 ```
 
+### Ausgabeformat
+
+Nach Abschluss aller Schritte Folgendes bereitstellen:
+
+```
+══════════════════════════════════════════════════════════════
+🎉 TECHNOLOGIE HINZUGEFÜGT: {TECH_NAME}
+══════════════════════════════════════════════════════════════
+
+📊 ZUSAMMENFASSUNG
+──────────────────────────────────────────────────────────────
+Technologie: {TECH_NAME}
+Kategorie: {CATEGORY}
+Version: {CURRENT_VERSION}
+
+Erstellte Dateien: {COUNT}
+- Regeln: 35 Dateien
+- Befehle: 25 Dateien
+- Templates: {COUNT}
+- Checklisten: 10 Dateien
+- Agenten: 5 Dateien
+
+📁 STRUKTUR
+──────────────────────────────────────────────────────────────
+Dev/i18n/
+├── en/{TECH}/
+├── fr/{TECH}/
+├── es/{TECH}/
+├── de/{TECH}/
+└── pt/{TECH}/
+
+Dev/scripts/
+└── install-{tech}-rules.sh
+
+🔧 INSTALLATION
+──────────────────────────────────────────────────────────────
+# Über Makefile
+make install-{tech} TARGET=~/my-project RULES_LANG=en
+
+# Direktes Skript
+./Dev/scripts/install-{tech}-rules.sh ~/my-project
+
+📚 DOKUMENTATION
+──────────────────────────────────────────────────────────────
+- README.md ✅ Aktualisiert
+- docs/index.html ✅ Aktualisiert
+- docs/COMMANDS.md ✅ Aktualisiert
+- Makefile ✅ Aktualisiert
+
+✅ DEFINITION OF DONE: VOLLSTÄNDIG
+══════════════════════════════════════════════════════════════
+```
+
 ### Wichtige Richtlinien
 
-1. **Zuerst recherchieren** - Immer Context7 und Websuche nutzen bevor Dateien generiert werden
-2. **Mustern folgen** - Bestehende Technologien (React, Symfony, Flutter) als Vorlagen verwenden
-3. **Alle 5 Sprachen** - Inhalte für en, fr, es, de, pt generieren
-4. **Qualität vor Geschwindigkeit** - Sicherstellen dass alle Dateien korrekt formatiert sind
-5. **Alles aktualisieren** - Dokumentation und Startseite nicht vergessen
+1. **Zuerst recherchieren** — Immer Context7 und Web-Suche verwenden, bevor Dateien generiert werden
+2. **Muster befolgen** — Bestehende Technologien (React, Symfony, Flutter) als Vorlagen verwenden
+3. **Alle 5 Sprachen** — Inhalte für en, fr, es, de, pt generieren
+4. **Qualität vor Geschwindigkeit** — Sicherstellen, dass alle Dateien korrekt formatiert und funktionsfähig sind
+5. **Alles aktualisieren** — Dokumentation und Landing Page nicht vergessen
 
 ### Fehlerbehandlung
 
 Wenn die Recherche fehlschlägt:
-- Klar angeben welche Informationen fehlen
+- Klar angeben, welche Informationen fehlen
 - Alternative Quellen vorschlagen
-- Bei Bedarf um Klärung bitten
+- Den Benutzer bei Bedarf um Klärung bitten
 - NIEMALS Dateien mit Platzhalter- oder erfundenem Inhalt generieren

--- a/Dev/i18n/de/Common/commands/setup-ci.md
+++ b/Dev/i18n/de/Common/commands/setup-ci.md
@@ -5,26 +5,26 @@ argument-hint: [arguments]
 
 # CI/CD-Konfiguration
 
-Sie sind ein erfahrener DevOps-Ingenieur. Sie müssen eine an die Projekttechnologien angepasste CI/CD-Pipeline konfigurieren und dabei Best Practices folgen.
+Sie sind ein erfahrener DevOps-Ingenieur. Sie müssen eine CI/CD-Pipeline konfigurieren, die an die Projekttechnologien angepasst ist und Best Practices befolgt.
 
 ## Argumente
 $ARGUMENTS
 
 Argumente:
 - CI-Plattform (github, gitlab, circleci)
-- (Optional) Technologien automatisch erkannt
+- (Optional) Automatisch erkannte Technologien
 
 Beispiel: `/common:setup-ci github`
 
 ## Plan-Modus
 
-> **Der Plan-Modus ist obligatorisch.** Vor der Ausführung aktiviert Claude den Plan-Modus, um betroffenen Code zu analysieren, einen Implementierungsplan vorzuschlagen und auf Ihre Validierung zu warten, bevor Änderungen vorgenommen werden.
+> **Plan-Modus ist obligatorisch.** Vor der Ausführung aktiviert Claude den Plan-Modus, um betroffenen Code zu analysieren, einen Implementierungsplan vorzuschlagen und Ihre Bestätigung abzuwarten, bevor Änderungen vorgenommen werden.
 
-## MISSION
+## AUFTRAG
 
 ### Schritt 1: Technologien erkennen
 
-Projekt scannen, um zu identifizieren:
+Das Projekt scannen, um Folgendes zu identifizieren:
 
 ```bash
 # Konfigurationsdateien
@@ -56,7 +56,7 @@ env:
 
 jobs:
   #############################################
-  # ÄNDERUNGS-ERKENNUNG
+  # ÄNDERUNGSERKENNUNG
   #############################################
   changes:
     runs-on: ubuntu-latest
@@ -112,21 +112,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: PHP Setup
+      - name: PHP einrichten
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ env.PHP_VERSION }}
           extensions: mbstring, xml, pdo_pgsql, intl
           coverage: xdebug
 
-      - name: Composer Cache
+      - name: Composer-Cache
         uses: actions/cache@v4
         with:
           path: vendor
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
-      - name: Dependencies installieren
+      - name: Abhängigkeiten installieren
         run: composer install --prefer-dist --no-progress
 
       - name: Lint
@@ -139,7 +139,7 @@ jobs:
       - name: Statische Analyse
         run: vendor/bin/phpstan analyse -l max
 
-      - name: Sicherheits-Check
+      - name: Sicherheitsprüfung
         run: composer audit
 
       - name: Tests
@@ -166,13 +166,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Node Setup
+      - name: Node einrichten
         uses: actions/setup-node@v4
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
 
-      - name: Dependencies installieren
+      - name: Abhängigkeiten installieren
         run: npm ci
 
       - name: Lint
@@ -180,7 +180,7 @@ jobs:
           npm run lint
           npm run format:check
 
-      - name: Type Check
+      - name: Typprüfung
         run: npm run typecheck
 
       - name: Tests
@@ -188,6 +188,9 @@ jobs:
 
       - name: Build
         run: npm run build
+
+      - name: Bundle-Analyse
+        run: npm run analyze || true
 
       - name: Coverage hochladen
         uses: codecov/codecov-action@v4
@@ -203,15 +206,30 @@ jobs:
     if: ${{ needs.changes.outputs.python == 'true' }}
     runs-on: ubuntu-latest
 
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test
+        ports:
+          - 5432:5432
+
     steps:
       - uses: actions/checkout@v4
 
-      - name: Python Setup
+      - name: Python einrichten
         uses: actions/setup-python@v5
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
-      - name: Dependencies installieren
+      - name: pip-Cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/pip
+          key: ${{ runner.os }}-pip-${{ hashFiles('**/requirements*.txt') }}
+
+      - name: Abhängigkeiten installieren
         run: |
           pip install -r requirements.txt
           pip install -r requirements-dev.txt
@@ -221,11 +239,22 @@ jobs:
           ruff check .
           ruff format --check .
 
-      - name: Type Check
+      - name: Typprüfung
         run: mypy .
 
+      - name: Sicherheitsprüfung
+        run: pip-audit
+
       - name: Tests
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test
         run: pytest --cov --cov-report=xml
+
+      - name: Coverage hochladen
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage.xml
+          flags: python
 
   #############################################
   # FLUTTER
@@ -238,26 +267,72 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Flutter Setup
+      - name: Flutter einrichten
         uses: subosito/flutter-action@v2
         with:
           flutter-version: ${{ env.FLUTTER_VERSION }}
           cache: true
 
-      - name: Dependencies installieren
+      - name: Abhängigkeiten installieren
         run: flutter pub get
 
-      - name: Analyze
+      - name: Analysieren
         run: dart analyze --fatal-infos
 
-      - name: Format
+      - name: Formatierung prüfen
         run: dart format --set-exit-if-changed .
 
       - name: Tests
         run: flutter test --coverage
+
+      - name: Coverage hochladen
+        uses: codecov/codecov-action@v4
+        with:
+          files: coverage/lcov.info
+          flags: flutter
+
+  #############################################
+  # STAGING-DEPLOYMENT
+  #############################################
+  deploy-staging:
+    needs: [php, node, python, flutter]
+    if: |
+      always() &&
+      github.ref == 'refs/heads/develop' &&
+      !contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    environment: staging
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: In Staging deployen
+        run: |
+          echo "Deploying to staging..."
+          # Deployment-Befehle hinzufügen
+
+  #############################################
+  # PRODUKTIONS-DEPLOYMENT
+  #############################################
+  deploy-production:
+    needs: [php, node, python, flutter]
+    if: |
+      always() &&
+      github.ref == 'refs/heads/main' &&
+      !contains(needs.*.result, 'failure')
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: In Produktion deployen
+        run: |
+          echo "Deploying to production..."
+          # Deployment-Befehle hinzufügen
 ```
 
-### Schritt 3: GitLab CI Konfiguration
+### Schritt 3: GitLab CI-Konfiguration
 
 ```yaml
 # .gitlab-ci.yml
@@ -271,11 +346,16 @@ variables:
   PHP_VERSION: "8.3"
   NODE_VERSION: "20"
 
+# Globaler Cache
 cache:
   paths:
     - vendor/
     - node_modules/
+    - .pub-cache/
 
+#############################################
+# PHP
+#############################################
 php-lint:
   stage: lint
   image: php:${PHP_VERSION}
@@ -295,13 +375,116 @@ php-test:
     - postgres:16
   variables:
     DATABASE_URL: "postgresql://postgres:postgres@postgres/test"
+  rules:
+    - changes:
+        - "src/**/*.php"
+        - composer.json
   script:
     - composer install
     - php bin/console doctrine:schema:create --env=test
     - vendor/bin/phpunit --coverage-text
+
+#############################################
+# NODE
+#############################################
+node-lint:
+  stage: lint
+  image: node:${NODE_VERSION}
+  rules:
+    - changes:
+        - "src/**/*.{ts,tsx}"
+        - package.json
+  script:
+    - npm ci
+    - npm run lint
+    - npm run typecheck
+
+node-test:
+  stage: test
+  image: node:${NODE_VERSION}
+  rules:
+    - changes:
+        - "src/**/*.{ts,tsx}"
+        - package.json
+  script:
+    - npm ci
+    - npm run test -- --coverage
+
+#############################################
+# DEPLOYMENT
+#############################################
+deploy-staging:
+  stage: deploy
+  environment:
+    name: staging
+  rules:
+    - if: $CI_COMMIT_BRANCH == "develop"
+  script:
+    - echo "Deploy to staging"
+
+deploy-production:
+  stage: deploy
+  environment:
+    name: production
+  rules:
+    - if: $CI_COMMIT_BRANCH == "main"
+  script:
+    - echo "Deploy to production"
+  when: manual
 ```
 
-### Schritt 4: Zusammenfassung
+### Schritt 4: Ergänzende Dateien
+
+#### codecov.yml
+
+```yaml
+coverage:
+  precision: 2
+  round: down
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+```
+
+#### .pre-commit-config.yaml
+
+```yaml
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-json
+      - id: check-merge-conflict
+      - id: detect-private-key
+
+  - repo: local
+    hooks:
+      - id: php-cs-fixer
+        name: PHP CS Fixer
+        entry: vendor/bin/php-cs-fixer fix
+        language: system
+        types: [php]
+
+      - id: eslint
+        name: ESLint
+        entry: npx eslint --fix
+        language: system
+        types: [javascript, typescript]
+```
+
+### Schritt 5: Zusammenfassung
 
 ```
 ══════════════════════════════════════════════════════════════
@@ -323,21 +506,21 @@ Erkannte Technologien: {Liste}
 🔧 KONFIGURIERTE JOBS
 ──────────────────────────────────────────────────────────────
 
-| Job | Trigger | Aktionen |
-|-----|---------|---------|
-| php | *.php, composer.* | lint, phpstan, tests |
-| node | *.ts, package.* | lint, typecheck, tests |
-| python | *.py, requirements* | ruff, mypy, pytest |
-| flutter | *.dart, pubspec.* | analyze, format, tests |
-| deploy-staging | develop | auto |
-| deploy-production | main | manuell |
+| Job               | Auslöser           | Aktionen                     |
+|-------------------|--------------------|------------------------------|
+| php               | *.php, composer.*  | lint, phpstan, tests         |
+| node              | *.ts, package.*    | lint, typecheck, tests       |
+| python            | *.py, requirements* | ruff, mypy, pytest          |
+| flutter           | *.dart, pubspec.*  | analyze, format, tests       |
+| deploy-staging    | develop            | automatisch                  |
+| deploy-production | main               | manuell                      |
 
 ──────────────────────────────────────────────────────────────
 🎯 NÄCHSTE SCHRITTE
 ──────────────────────────────────────────────────────────────
 
-1. Secrets in GitHub/GitLab konfigurieren
-2. Environments (staging, production) konfigurieren
+1. Geheimnisse in GitHub/GitLab konfigurieren
+2. Umgebungen konfigurieren (staging, production)
 3. Deployment-Befehle hinzufügen
-4. Pipeline auf PR testen
+4. Pipeline mit einem PR testen
 ```

--- a/Dev/i18n/de/Laravel/commands/check-compliance.md
+++ b/Dev/i18n/de/Laravel/commands/check-compliance.md
@@ -1,145 +1,253 @@
 ---
-description: Check Laravel project compliance with coding standards
+description: Vollständige Laravel-Compliance prüfen
+argument-hint: [arguments]
 ---
 
-# Laravel Compliance Check
+# Vollständige Laravel-Compliance prüfen
 
-You are a Laravel expert auditor. Your mission is to verify that the project follows Laravel best practices and coding standards.
+## Argumente
 
-## Audit Process
-
-### 1. Project Structure Analysis
-
-Check if the project follows the recommended architecture:
-
-```
-app/
-├── Domain/           # Business logic (if using Clean Architecture)
-├── Application/      # Use cases, Actions, DTOs
-├── Infrastructure/   # External services, Repositories
-├── Http/
-│   ├── Controllers/  # Thin controllers
-│   ├── Requests/     # Form Requests for validation
-│   ├── Resources/    # API Resources
-│   └── Middleware/
-├── Models/           # Eloquent models
-├── Services/         # Business services
-├── Jobs/             # Queue jobs
-├── Events/           # Domain events
-├── Listeners/        # Event listeners
-├── Policies/         # Authorization policies
-└── Providers/        # Service providers
-```
-
-### 2. Code Standards Verification
-
-#### Naming Conventions
-- [ ] Controllers: Singular, PascalCase (`OrderController`)
-- [ ] Models: Singular, PascalCase (`Order`, `OrderItem`)
-- [ ] Tables: Plural, snake_case (`orders`, `order_items`)
-- [ ] Columns: snake_case (`created_at`, `customer_id`)
-- [ ] Methods: camelCase (`getUserOrders()`)
-- [ ] Variables: camelCase (`$orderTotal`)
-
-#### Modern PHP Features (8.3+)
-- [ ] Constructor property promotion used
-- [ ] Readonly properties/classes where appropriate
-- [ ] Enums for status/type fields
-- [ ] Match expressions instead of switch
-- [ ] Named arguments for clarity
-- [ ] Type declarations on all methods
-- [ ] Return types specified
-
-#### Laravel Conventions
-- [ ] Form Requests for validation (not validation in controllers)
-- [ ] API Resources for response transformation
-- [ ] Policies for authorization
-- [ ] Eloquent casts for type conversion
-- [ ] Scopes for reusable queries
-- [ ] Events for cross-cutting concerns
-
-### 3. Architecture Compliance
-
-#### Layer Dependencies
-- Domain layer has NO external dependencies
-- Application layer only depends on Domain
-- Infrastructure implements Domain interfaces
-- Controllers are thin (delegate to Actions/Services)
-
-#### Repository Pattern (if applicable)
-- [ ] Interfaces defined in Domain/Contracts
-- [ ] Implementations in Infrastructure
-- [ ] Bindings in Service Providers
-
-### 4. Configuration Check
-
-- [ ] No hardcoded values (use config files)
-- [ ] Environment variables via config(), not env()
-- [ ] Sensitive data in .env (not committed)
-- [ ] Config caching compatible
-
-### 5. Generate Report
-
-After analysis, provide:
-
-1. **Compliance Score**: X/100
-2. **Critical Issues**: Must-fix problems
-3. **Warnings**: Recommended improvements
-4. **Good Practices**: What's done well
-5. **Action Items**: Prioritized list of fixes
+$ARGUMENTS (optional: Pfad zum zu analysierenden Projekt)
 
 ## Plan-Modus
 
-> Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine modulübergreifende Untersuchung erfordert.
+> Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine übergreifende Untersuchung erfordert.
 
-## Commands to Run
+## MISSION
 
-```bash
-# Check code style
-./vendor/bin/pint --test
+Führe ein vollständiges Compliance-Audit des Laravel-Projekts durch, indem die 4 wichtigsten Prüfungen orchestriert werden: Architektur, Code-Qualität, Tests und Sicherheit. Erstelle einen konsolidierten Bericht mit einem Gesamtergebnis von 100 Punkten.
 
-# Static analysis
-./vendor/bin/phpstan analyse
+### Schritt 1: Audit-Vorbereitung
 
-# Run tests
-php artisan test
+Audit-Umgebung vorbereiten:
+- [ ] Zu prüfenden Projektpfad identifizieren
+- [ ] Vorhandensein von Konfigurationsdateien prüfen (composer.json mit laravel/*, .env.example)
+- [ ] Hauptverzeichnisse auflisten (app/, tests/, config/, routes/ usw.)
+- [ ] Projektstruktur und Laravel-Version identifizieren
 
-# Check for security vulnerabilities
-composer audit
+**Hinweis**: Falls $ARGUMENTS angegeben, diesen als Projektpfad verwenden, ansonsten das aktuelle Verzeichnis nutzen.
+
+### Schritt 2: Architektur-Audit (25 Punkte)
+
+Vollständige Architekturprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/laravel:check-architecture` verwenden oder die Schritte in `check-architecture.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- Trennung der Clean-Architecture-Schichten (6 Pkt.)
+- Domain/Application/Infrastructure-Struktur (6 Pkt.)
+- Actions-Pattern und schlanke Controller (4 Pkt.)
+- Service-Provider-Bindings (4 Pkt.)
+- Repository-Pattern und Interfaces (3 Pkt.)
+- Abhängigkeitsregeln (2 Pkt.)
+
+**Referenz**: `check-architecture.md`
+
+### Schritt 3: Code-Qualitäts-Audit (25 Punkte)
+
+Code-Qualitätsprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/laravel:check-code-quality` verwenden oder die Schritte in `check-code-quality.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- PSR-12- und Laravel-Pint-Konformität (5 Pkt.)
+- PHPStan-Statikanalyse (5 Pkt.)
+- Moderne PHP-Features (Enums, readonly, typisierte Properties) (4 Pkt.)
+- KISS/DRY/YAGNI-Prinzipien (4 Pkt.)
+- Namenskonventionen (Laravel-Standards) (4 Pkt.)
+- Fehlerbehandlung und Logging (3 Pkt.)
+
+**Referenz**: `check-code-quality.md`
+
+### Schritt 4: Test-Audit (25 Punkte)
+
+Testprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/laravel:check-testing` verwenden oder die Schritte in `check-testing.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- Code-Abdeckung (7 Pkt.)
+- Unit-Tests für Domain-Logik (6 Pkt.)
+- Feature-Tests für HTTP-Endpunkte (4 Pkt.)
+- Pest-PHP-Einsatz und Testqualität (3 Pkt.)
+- Datenbank-Factories und Seeders (3 Pkt.)
+- Test-Isolation und Mocking (2 Pkt.)
+
+**Referenz**: `check-testing.md`
+
+### Schritt 5: Sicherheits-Audit (25 Punkte)
+
+Sicherheitsprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/laravel:check-security` verwenden oder die Schritte in `check-security.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- OWASP-Top-10-Schutzmaßnahmen (6 Pkt.)
+- Secrets- und Zugangsdaten-Verwaltung (5 Pkt.)
+- Form-Request-Validierung (4 Pkt.)
+- Abhängigkeits-Schwachstellen (composer audit) (4 Pkt.)
+- Authentifizierung und Autorisierung (Policies) (3 Pkt.)
+- CSRF- und Middleware-Konfiguration (2 Pkt.)
+- SQL-Injection-Prävention (1 Pkt.)
+
+**Referenz**: `check-security.md`
+
+### Schritt 6: Konsolidierung und Gesamtbewertung
+
+Gesamtpunktzahl berechnen und konsolidierten Bericht erstellen:
+- [ ] Die 4 Ergebnisse summieren (max. 100 Punkte)
+- [ ] Kritische Kategorien identifizieren (<50%)
+- [ ] Alle kritischen, übergreifenden Probleme auflisten
+- [ ] Maßnahmen nach Auswirkung/Aufwand priorisieren
+- [ ] Finalen konsolidierten Bericht erstellen
+
+**Bewertungsskala**:
+- 90-100: Ausgezeichnet – Referenzprojekt
+- 75-89: Sehr gut – Einige geringfügige Verbesserungen
+- 60-74: Akzeptabel – Erfordert Verbesserungen
+- 40-59: Unzureichend – Größeres Refactoring erforderlich
+- 0-39: Kritisch – Vollständige Überarbeitung notwendig
+
+### Schritt 7: Empfehlungen und Aktionsplan
+
+Abschließende Empfehlungen erstellen:
+- [ ] Top-3-Prioritätsmaßnahmen über alle Kategorien hinweg identifizieren
+- [ ] Aufwand (Niedrig/Mittel/Hoch) für jede Maßnahme schätzen
+- [ ] Auswirkung (Niedrig/Mittel/Hoch) für jede Maßnahme schätzen
+- [ ] Implementierungsreihenfolge vorschlagen
+- [ ] Quick Wins vorschlagen (hohes Auswirkungs-/Aufwandsverhältnis)
+
+## AUSGABEFORMAT
+
+```
+LARAVEL COMPLIANCE AUDIT - VOLLSTÄNDIGER BERICHT
+=============================================
+
+GESAMTERGEBNIS: XX/100
+
+COMPLIANCE-LEVEL: [Ausgezeichnet/Sehr gut/Akzeptabel/Unzureichend/Kritisch]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ERGEBNISSE NACH KATEGORIE:
+
+ARCHITEKTUR        : XX/25  [██████████░░░░░░░░░░] XX%
+CODE-QUALITÄT      : XX/25  [██████████░░░░░░░░░░] XX%
+TESTS              : XX/25  [██████████░░░░░░░░░░] XX%
+SICHERHEIT         : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ALLGEMEINE STÄRKEN:
+1. [In mehreren Kategorien identifizierte Stärke]
+2. [Weitere wesentliche Stärke]
+3. [Dritte Stärke]
+
+ALLGEMEINE VERBESSERUNGEN:
+1. [Geringfügige übergreifende Verbesserung]
+2. [Weitere empfohlene Verbesserung]
+3. [Dritte Verbesserung]
+
+KRITISCHE PROBLEME:
+1. [Kritisches Problem Nr. 1 – betroffene Kategorie]
+2. [Kritisches Problem Nr. 2 – betroffene Kategorie]
+3. [Kritisches Problem Nr. 3 – betroffene Kategorie]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETAILS NACH KATEGORIE:
+
+┌─────────────────────────────────────────────┐
+│ ARCHITEKTUR (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Teilpunktzahlen:
+  • Clean-Architecture-Schichten    : XX/6
+  • Domain/App/Infra-Struktur       : XX/6
+  • Actions und schlanke Controller : XX/4
+  • Service-Provider-Bindings       : XX/4
+  • Repository-Pattern              : XX/3
+  • Abhängigkeitsregeln             : XX/2
+
+Stärken:
+- [Architektur-Stärken]
+
+Probleme:
+- [Architektur-Probleme]
+
+[Ähnliche Abschnitte für Code-Qualität, Tests und Sicherheit...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 PRIORITÄTSMAASSNAHMEN (ALLE KATEGORIEN):
+
+1. KRITISCH – [Maßnahme Nr. 1]
+   Kategorie  : [Architektur/Qualität/Tests/Sicherheit]
+   Auswirkung : [Hoch/Mittel/Niedrig]
+   Aufwand    : [Hoch/Mittel/Niedrig]
+   Priorität  : SOFORT
+
+   Detaillierte Beschreibung:
+   [Erläuterung des Problems und vorgeschlagene Lösung]
+
+   Betroffene Dateien:
+   - [datei:zeile]
+
+   Korrekturbeispiel:
+   [Code oder Korrekturbefehl]
+
+2. WICHTIG – [Maßnahme Nr. 2]
+   [Gleiches Format...]
+
+3. EMPFOHLEN – [Maßnahme Nr. 3]
+   [Gleiches Format...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+QUICK WINS (Hohe Auswirkung / Geringer Aufwand):
+
+- [Quick Win Nr. 1] – Kategorie: [X] – Auswirkung: [X] – Aufwand: [X]
+- [Quick Win Nr. 2] – Kategorie: [X] – Auswirkung: [X] – Aufwand: [X]
+- [Quick Win Nr. 3] – Kategorie: [X] – Auswirkung: [X] – Aufwand: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+EMPFOHLENER AKTIONSPLAN:
+
+WOCHE 1 (Sofort):
+- [ ] [Kritische Maßnahme Nr. 1]
+- [ ] [Prioritäts-Quick-Win]
+
+WOCHE 2-4 (Kurzfristig):
+- [ ] [Wichtige Maßnahme Nr. 2]
+- [ ] [Weitere Quick Wins]
+
+MONAT 2-3 (Mittelfristig):
+- [ ] [Empfohlene Maßnahme Nr. 3]
+- [ ] [Schrittweise Verbesserungen]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ZUSAMMENFASSUNG FÜR DIE GESCHÄFTSFÜHRUNG:
+
+[Zusammenfassender Abschnitt über den Gesamtzustand des Projekts, wesentliche Stärken,
+wesentliche Schwächen und die empfohlene Entwicklung zur Verbesserung
+der Compliance. Angabe, ob das Projekt produktionsreif ist,
+Korrekturen erfordert oder refaktoriert werden muss.]
+
+Allgemeine Empfehlung: [Produktionsreif / Geringfügige Korrekturen /
+Größeres Refactoring / Überarbeitung erforderlich]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-## Output Format
+## WICHTIGE HINWEISE
 
-```markdown
-# Laravel Compliance Report
-
-## Summary
-- **Score**: 85/100
-- **Critical Issues**: 2
-- **Warnings**: 5
-- **Files Analyzed**: 150
-
-## Critical Issues
-
-### 1. Missing Form Request Validation
-**File**: `app/Http/Controllers/OrderController.php:45`
-**Issue**: Validation done in controller instead of Form Request
-**Fix**: Create `StoreOrderRequest` and move validation rules
-
-### 2. [Issue description]
-
-## Warnings
-
-### 1. [Warning description]
-
-## Recommendations
-
-1. [Recommendation 1]
-2. [Recommendation 2]
-
-## Good Practices Observed
-
-- Using Eloquent casts for type conversion
-- Proper use of API Resources
-- Events for decoupling
-```
+- Dieser Befehl orchestriert die 4 spezialisierten Audits
+- Docker für alle Analysetools verwenden
+- Konkrete Beispiele mit datei:zeile für jedes Problem angeben
+- Maßnahmen anhand der Auswirkungs-/Aufwandsmatrix priorisieren
+- Sicherheitsprobleme haben IMMER höchste Priorität
+- Automatisierbare Korrekturen vorschlagen (Skripte, Pre-Commit-Hooks)
+- Der Bericht muss handlungsorientiert sein, nicht nur beschreibend
+- Empfehlungen an den geschäftlichen Kontext des Projekts anpassen

--- a/Dev/i18n/de/Python/checklists/new-feature.md
+++ b/Dev/i18n/de/Python/checklists/new-feature.md
@@ -1,20 +1,20 @@
 # Checkliste: Neues Feature
 
-## Phase 1: Analyse (OBLIGATORISCH)
+## Phase 1: Analyse (PFLICHT)
 
-### Bedarf verstehen
+### Den Bedarf verstehen
 
 - [ ] **Ziel** klar definiert
   - Welche Funktionalität genau?
   - Welches Problem wird gelöst?
   - Was sind die Akzeptanzkriterien?
 
-- [ ] **Geschäftskontext** verstanden
-  - Welche Geschäftsauswirkung?
-  - Welche Benutzer betroffen?
-  - Spezifische Geschäftsbeschränkungen?
+- [ ] **Geschäftlicher Kontext** verstanden
+  - Welche geschäftliche Auswirkung?
+  - Welche Benutzer sind betroffen?
+  - Gibt es spezifische geschäftliche Einschränkungen?
 
-- [ ] **Technische Einschränkungen** identifiziert
+- [ ] **Technische Anforderungen** identifiziert
   - Erforderliche Performance?
   - Skalierbarkeit?
   - Sicherheit?
@@ -40,41 +40,41 @@
 
 ### Auswirkungen identifizieren
 
-- [ ] **Impact-Matrix** erstellt
-  - Welche Module betroffen?
-  - Welche DB-Migrationen notwendig?
+- [ ] **Auswirkungsmatrix** erstellt
+  - Welche Module sind betroffen?
+  - Welche DB-Migrationen sind notwendig?
   - Welche API-Änderungen?
 
 - [ ] **Abhängigkeiten** identifiziert
-  - Module, die von zu änderndem Code abhängen
-  - Module, von denen neuer Code abhängt
+  - Module, die vom zu ändernden Code abhängen
+  - Module, von denen der neue Code abhängt
 
-### Lösung entwerfen
+### Die Lösung entwerfen
 
 - [ ] **Architektur** definiert
-  - Welcher Layer (Domain/Application/Infrastructure)?
-  - Welche Klassen/Funktionen zu erstellen?
+  - Welche Schicht (Domain/Application/Infrastructure)?
+  - Welche Klassen/Funktionen erstellen?
   - Welche Interfaces notwendig?
 
 - [ ] **Datenfluss** dokumentiert
-  - Wie fließen Daten?
+  - Wie fließen die Daten?
   - Welche Transformationen?
 
 - [ ] **Technische Entscheidungen** begründet
   - Warum dieser Ansatz?
-  - Welche Alternativen erwogen?
+  - Welche Alternativen wurden berücksichtigt?
 
 ### Implementierung planen
 
-- [ ] **Aufgaben** in atomare Schritte zerlegt
+- [ ] **Aufgaben** in atomare Schritte aufgeteilt
 - [ ] **Reihenfolge** der Implementierung definiert
-- [ ] **Schätzung** mit Puffer durchgeführt (20%)
+- [ ] **Schätzung** mit Puffer (20%) durchgeführt
 
 ### Risiken identifizieren
 
 - [ ] **Risiken** identifiziert und bewertet
 - [ ] **Mitigationen** geplant
-- [ ] **Fallbacks** definiert wenn möglich
+- [ ] **Fallbacks** wenn möglich definiert
 
 ### Tests definieren
 
@@ -82,13 +82,13 @@
   - Unit-Tests
   - Integrationstests
   - E2E-Tests
-- [ ] **Ziel-Coverage** definiert
+- [ ] **Zielabdeckung** definiert
 
 Siehe `rules/01-workflow-analysis.md` für Details.
 
 ## Phase 2: Implementierung
 
-### Domain-Layer (Falls zutreffend)
+### Domain-Schicht (falls zutreffend)
 
 - [ ] **Entities** erstellt
   - [ ] Dataclass oder Python-Klasse
@@ -102,47 +102,322 @@ Siehe `rules/01-workflow-analysis.md` für Details.
   - [ ] Strenge Validierung
   - [ ] Wertbasierte Gleichheit
 
-- [ ] **Domain-Services** erstellt (falls erforderlich)
-  - [ ] Multi-Entitäts-Geschäftslogik
+- [ ] **Domain-Services** erstellt (falls notwendig)
+  - [ ] Geschäftslogik mit mehreren Entities
   - [ ] Injizierte Abhängigkeiten
-  - [ ] Keine Infrastructure-Abhängigkeit
+  - [ ] Keine Infrastrukturabhängigkeit
 
 - [ ] **Repository-Interfaces** erstellt
   - [ ] Protocol in domain/repositories/
   - [ ] Dokumentierte Methoden
 
 - [ ] **Domain-Exceptions** erstellt
-  - [ ] Von DomainException erben
+  - [ ] Erben von DomainException
   - [ ] Klare Meldungen
 
-[... Rest der Phasen folgen dem gleichen Muster ...]
+### Application-Schicht
 
-## Quick-Checkliste
+- [ ] **DTOs** erstellt
+  - [ ] Pydantic BaseModel
+  - [ ] from_entity() und to_dict() falls notwendig
+  - [ ] Pydantic-Validierung
 
-### Mindestens erforderlich
+- [ ] **Commands** erstellt
+  - [ ] Dataclass oder Pydantic
+  - [ ] Alle Use-Case-Eingaben
+
+- [ ] **Use Cases** erstellt
+  - [ ] Eine Klasse pro Use Case
+  - [ ] Abhängigkeiten über __init__ injiziert
+  - [ ] execute()-Methode
+  - [ ] Eingabevalidierung
+  - [ ] Fehlerbehandlung
+  - [ ] Gibt DTO zurück
+
+### Infrastructure-Schicht
+
+- [ ] **Datenbankmodelle** erstellt (falls neue Entity)
+  - [ ] SQLAlchemy-Modell
+  - [ ] Geeignete Spalten
+  - [ ] Indizes falls notwendig
+  - [ ] Relationen falls notwendig
+
+- [ ] **Migrationen** erstellt
+  ```bash
+  make db-migrate msg="Migrationsbeschreibung"
+  ```
+  - [ ] Migration getestet (upgrade + downgrade)
+
+- [ ] **Repositories** implementiert
+  - [ ] Implementiert Domain-Interface
+  - [ ] Entity <-> Modell-Konvertierung
+  - [ ] Fehlerbehandlung
+  - [ ] Rollback bei Fehler
+
+- [ ] **API-Routen** erstellt
+  - [ ] FastAPI-Router
+  - [ ] Pydantic-Schemas
+  - [ ] Dependency Injection
+  - [ ] Geeignete Status-Codes
+  - [ ] Fehlerbehandlung
+
+- [ ] **Externe Services** integriert (falls notwendig)
+  - [ ] Implementiert Domain-Interface
+  - [ ] Retry-Logik
+  - [ ] Timeout-Behandlung
+  - [ ] Fehlerbehandlung
+
+### Konfiguration
+
+- [ ] **Dependency Injection** konfiguriert
+  - [ ] Container aktualisiert
+  - [ ] Factories erstellt
+  - [ ] FastAPI-Abhängigkeiten erstellt
+
+- [ ] **Umgebungsvariablen** hinzugefügt
+  - [ ] Zu `.env.example` hinzugefügt
+  - [ ] In README dokumentiert
+  - [ ] Validierung mit Pydantic Settings
+
+- [ ] **Konfiguration** aktualisiert
+  - [ ] Config-Klasse aktualisiert
+  - [ ] Standardwerte definiert
+
+## Phase 3: Tests
+
+### Unit-Tests
+
+- [ ] **Domain-Schicht** getestet
+  - [ ] Tests für jede Entity
+  - [ ] Tests für jedes Value Object
+  - [ ] Tests für jeden Service
+  - [ ] Abdeckung > 95%
+
+- [ ] **Application-Schicht** getestet
+  - [ ] Tests für jeden Use Case
+  - [ ] Mocks für Abhängigkeiten
+  - [ ] Normalfälle + Randfälle
+  - [ ] Abdeckung > 90%
+
+- [ ] **Alle Unit-Tests** bestehen
+  ```bash
+  make test-unit
+  ```
+
+### Integrationstests
+
+- [ ] **Repository** getestet
+  - [ ] CRUD-Operationen
+  - [ ] Suchmethoden
+  - [ ] Mit echter DB (testcontainers)
+
+- [ ] **API-Routen** getestet
+  - [ ] Normalfälle
+  - [ ] Fehler (400, 404, 409, 500)
+  - [ ] Mit FastAPI TestClient
+
+- [ ] **Alle Integrationstests** bestehen
+  ```bash
+  make test-integration
+  ```
+
+### E2E-Tests
+
+- [ ] **Vollständige Abläufe** getestet
+  - [ ] Happy Path
+  - [ ] Kritische Fehlerfälle
+
+- [ ] **Alle E2E-Tests** bestehen
+  ```bash
+  make test-e2e
+  ```
+
+### Abdeckung
+
+- [ ] **Gesamtabdeckung** > 80%
+  ```bash
+  make test-cov
+  ```
+- [ ] **Domain-Abdeckung** > 95%
+- [ ] **Application-Abdeckung** > 90%
+
+## Phase 4: Qualität
+
+### Code-Qualität
+
+- [ ] **Linting** erfolgreich
+  ```bash
+  make lint
+  ```
+
+- [ ] **Formatierung** korrekt
+  ```bash
+  make format-check
+  ```
+
+- [ ] **Typprüfung** erfolgreich
+  ```bash
+  make type-check
+  ```
+
+- [ ] **Sicherheitsprüfung** erfolgreich
+  ```bash
+  make security-check
+  ```
+
+### Persönliches Code-Review
+
+- [ ] **SOLID** eingehalten
+  - [ ] Single Responsibility
+  - [ ] Open/Closed
+  - [ ] Liskov Substitution
+  - [ ] Interface Segregation
+  - [ ] Dependency Inversion
+
+- [ ] **KISS, DRY, YAGNI** eingehalten
+  - [ ] Einfache Lösung
+  - [ ] Keine Duplikation
+  - [ ] Kein unnötiger Code
+
+- [ ] **Clean Architecture** eingehalten
+  - [ ] Abhängigkeiten nach innen
+  - [ ] Unabhängige Domain
+  - [ ] Abstraktionen (Protocols)
+
+- [ ] **Benennung** klar und konsistent
+- [ ] **Docstrings** vollständig
+- [ ] **Kommentare** nur für komplexe Logik
+- [ ] **Toter Code** entfernt
+
+## Phase 5: Dokumentation
+
+- [ ] **API-Dokumentation** aktuell
+  - [ ] Neue Endpunkte dokumentiert
+  - [ ] Beispiele bereitgestellt
+  - [ ] Klare Request/Response-Schemas
+
+- [ ] **README** falls notwendig aktualisiert
+  - [ ] Neue Features dokumentiert
+  - [ ] Setup-Anweisungen aktuell
+
+- [ ] **ADR** erstellt falls wichtige Architekturentscheidung
+  ```markdown
+  docs/adr/NNNN-beschreibung.md
+  ```
+
+- [ ] **Changelog** aktualisiert
+  ```markdown
+  ## [Unreleased]
+  ### Added
+  - Feature-Beschreibung
+  ```
+
+## Phase 6: Git & PR
+
+### Commits
+
+- [ ] **Commits** folgen den Conventional Commits
+  ```
+  feat(scope): add user notification system
+
+  - Implement email notifications
+  - Add SMS notification support
+  - Create notification repository
+
+  Closes #123
+  ```
+
+- [ ] **Atomare Commits**
+  - Keine riesigen Commits
+  - Ein Commit = eine logische Änderung
+
+### Pull Request
+
+- [ ] **Branch** korrekt benannt
+  ```
+  feature/user-notifications
+  ```
+
+- [ ] **PR-Beschreibung** vollständig
+  ```markdown
+  ## Zusammenfassung
+  - Was
+  - Warum
+  - Wie
+
+  ## Änderungen
+  - Änderung 1
+  - Änderung 2
+
+  ## Tests
+  - Wie getestet
+  - Screenshots falls UI
+
+  ## Checkliste
+  - [x] Tests bestehen
+  - [x] Docs aktualisiert
+  ```
+
+- [ ] **Tests** bestehen auf CI
+- [ ] **Keine Konflikte** mit main
+- [ ] **Self-Review** durchgeführt
+
+## Phase 7: Deployment
+
+### Vor dem Deployment
+
+- [ ] **DB-Migration** bereit
+  - [ ] Lokal getestet
+  - [ ] Im Staging getestet
+  - [ ] Rollback-Plan definiert
+
+- [ ] **Umgebungsvariablen** dokumentiert
+  - [ ] DevOps-Team informiert
+  - [ ] Produktionswerte bereitgestellt
+
+- [ ] **Feature-Flags** konfiguriert (falls zutreffend)
+  - [ ] Feature standardmäßig deaktiviert
+  - [ ] Rollout-Plan definiert
+
+### Nach dem Deployment
+
+- [ ] **Monitoring** eingerichtet
+  - [ ] Logs überprüft
+  - [ ] Metriken überprüft
+  - [ ] Alerts konfiguriert
+
+- [ ] **Smoke-Tests** durchgeführt
+  - [ ] Feature in Produktion getestet
+  - [ ] Keine sichtbaren Fehler
+
+- [ ] **Rollback-Plan** bereit falls Problem
+
+## Schnell-Checkliste
+
+### Unverzichtbares Minimum
 
 - [ ] Vollständige Analyse durchgeführt
-- [ ] Clean Architecture (Clean + SOLID)
-- [ ] Tests geschrieben und bestanden (> 80% Coverage)
-- [ ] `make quality` läuft durch
-- [ ] Dokumentation aktualisiert
+- [ ] Saubere Architektur (Clean + SOLID)
+- [ ] Tests geschrieben und bestehend (> 80% Abdeckung)
+- [ ] `make quality` erfolgreich
+- [ ] Dokumentation aktuell
 - [ ] Vollständige PR-Beschreibung
 
-### Vor Merge
+### Vor dem Merge
 
-- [ ] Genehmigte Review
-- [ ] CI läuft durch
+- [ ] Genehmigtes Review
+- [ ] CI erfolgreich
 - [ ] Keine Konflikte
-- [ ] Commits squashen falls erforderlich
+- [ ] Commits squashen falls notwendig
 
-### Warnsignale
+### Rote Flags
 
-Wenn eines davon zutrifft, **NICHT MERGEN**:
+Falls einer dieser Punkte zutrifft, **NICHT MERGEN**:
 
 - ❌ Analyse nicht durchgeführt
-- ❌ Fehlende Tests
-- ❌ Coverage < 80%
-- ❌ Linting/Type-Fehler
-- ❌ Fest codierte Geheimnisse
+- ❌ Tests fehlen
+- ❌ Abdeckung < 80%
+- ❌ Linting-/Typfehler
+- ❌ Hardcodierte Secrets
 - ❌ Undokumentierte Breaking Changes
-- ❌ Ungetestete DB-Migration
+- ❌ Nicht getestete DB-Migration

--- a/Dev/i18n/de/React/rules/02-architecture.md
+++ b/Dev/i18n/de/React/rules/02-architecture.md
@@ -1,75 +1,218 @@
-# React-Architektur
+# React-Architektur – Prinzipien und Organisation
 
-## Projekt-Struktur
+## Grundlegende Architekturprinzipien
 
-### Feature-basierte Organisation
+### 1. Trennung der Zuständigkeiten
+
+Jeder Teil des Codes sollte eine einzige, klar definierte Verantwortung haben:
+
+- **Komponenten**: Anzeige und Benutzerinteraktion
+- **Hooks**: Geschäftslogik und Zustandsverwaltung
+- **Services**: API-Kommunikation
+- **Utils**: Reine Hilfsfunktionen
+- **Types**: TypeScript-Definitionen
+
+### 2. Modularität
+
+Der Code sollte in unabhängige und wiederverwendbare Module gegliedert werden.
+
+### 3. Skalierbarkeit
+
+Die Architektur sollte das Projektwachstum ohne größeres Refactoring unterstützen.
+
+## Feature-basierte Ordnerstruktur
+
+### Allgemeine Organisation
 
 ```
 src/
-├── components/           # Wiederverwendbare Komponenten (Atomic Design)
-│   ├── atoms/           # Grundlegende Bausteine
-│   │   ├── Button/
-│   │   ├── Input/
-│   │   ├── Badge/
-│   │   └── Spinner/
-│   ├── molecules/       # Kombinationen von Atoms
-│   │   ├── FormField/
-│   │   ├── SearchBar/
-│   │   └── Card/
-│   └── organisms/       # Komplexe Komponenten
-│       ├── Header/
-│       ├── Sidebar/
-│       └── DataTable/
+├── app/                          # Anwendungskonfiguration
+│   ├── App.tsx                   # Root-Komponente
+│   ├── AppProviders.tsx          # Globale Provider
+│   └── router.tsx                # Routing-Konfiguration
 │
-├── features/            # Business-Features
+├── components/                   # Gemeinsame Komponenten (Atomic Design)
+│   ├── atoms/                    # Atomare Komponenten
+│   │   ├── Button/
+│   │   │   ├── Button.tsx
+│   │   │   ├── Button.test.tsx
+│   │   │   ├── Button.stories.tsx
+│   │   │   └── index.ts
+│   │   ├── Input/
+│   │   ├── Label/
+│   │   ├── Icon/
+│   │   └── Spinner/
+│   │
+│   ├── molecules/                # Molekulare Komponenten
+│   │   ├── FormField/
+│   │   │   ├── FormField.tsx
+│   │   │   ├── FormField.test.tsx
+│   │   │   └── index.ts
+│   │   ├── SearchBar/
+│   │   ├── Card/
+│   │   └── Modal/
+│   │
+│   ├── organisms/                # Organismus-Komponenten
+│   │   ├── Header/
+│   │   │   ├── Header.tsx
+│   │   │   ├── Header.test.tsx
+│   │   │   ├── components/      # Spezifische Unterkomponenten
+│   │   │   │   ├── HeaderNav.tsx
+│   │   │   │   └── UserMenu.tsx
+│   │   │   └── index.ts
+│   │   ├── Sidebar/
+│   │   ├── DataTable/
+│   │   └── Form/
+│   │
+│   └── templates/                # Seiten-Templates
+│       ├── DashboardTemplate/
+│       ├── AuthTemplate/
+│       └── SettingsTemplate/
+│
+├── features/                     # Geschäftliche Features
 │   ├── auth/
-│   │   ├── components/  # Feature-spezifische Komponenten
-│   │   ├── hooks/       # Feature-spezifische Hooks
-│   │   ├── services/    # API-Calls
-│   │   ├── types/       # TypeScript-Types
-│   │   └── utils/       # Utilities
+│   │   ├── components/          # Authentifizierungsspezifische Komponenten
+│   │   │   ├── LoginForm/
+│   │   │   │   ├── LoginForm.tsx
+│   │   │   │   ├── LoginForm.test.tsx
+│   │   │   │   └── index.ts
+│   │   │   ├── RegisterForm/
+│   │   │   └── PasswordReset/
+│   │   │
+│   │   ├── hooks/               # Custom Hooks für Auth
+│   │   │   ├── useAuth.ts
+│   │   │   ├── useAuth.test.ts
+│   │   │   ├── useLogin.ts
+│   │   │   └── useRegister.ts
+│   │   │
+│   │   ├── services/            # API-Services für Auth
+│   │   │   ├── auth.service.ts
+│   │   │   ├── auth.service.test.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── types/               # TypeScript-Typen
+│   │   │   ├── auth.types.ts
+│   │   │   ├── user.types.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── utils/               # Spezifische Hilfsfunktionen
+│   │   │   ├── tokenStorage.ts
+│   │   │   ├── validators.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── store/               # Lokale Zustandsverwaltung
+│   │   │   ├── authStore.ts
+│   │   │   └── index.ts
+│   │   │
+│   │   ├── constants/           # Konstanten
+│   │   │   └── auth.constants.ts
+│   │   │
+│   │   └── index.ts             # Feature-Einstiegspunkt
+│   │
 │   ├── users/
+│   │   ├── components/
+│   │   │   ├── UserList/
+│   │   │   ├── UserProfile/
+│   │   │   └── UserForm/
+│   │   ├── hooks/
+│   │   │   ├── useUsers.ts
+│   │   │   ├── useUserMutations.ts
+│   │   │   └── useUserFilters.ts
+│   │   ├── services/
+│   │   ├── types/
+│   │   ├── utils/
+│   │   └── index.ts
+│   │
+│   ├── products/
+│   ├── orders/
 │   └── dashboard/
 │
-├── hooks/               # Geteilte Custom Hooks
-│   ├── useAuth.ts
+├── hooks/                        # Globale wiederverwendbare Hooks
+│   ├── useDebounce.ts
 │   ├── useLocalStorage.ts
-│   └── useDebounce.ts
+│   ├── useMediaQuery.ts
+│   ├── useOnClickOutside.ts
+│   ├── usePagination.ts
+│   └── index.ts
 │
-├── services/            # Geteilte API-Services
-│   ├── api.service.ts
-│   ├── auth.service.ts
-│   └── storage.service.ts
+├── services/                     # Globale Services
+│   ├── api/
+│   │   ├── axios.config.ts      # Axios-Konfiguration
+│   │   ├── apiClient.ts         # API-Client
+│   │   └── interceptors.ts      # Interceptors
+│   ├── storage/
+│   │   ├── localStorage.service.ts
+│   │   └── sessionStorage.service.ts
+│   ├── analytics/
+│   │   └── analytics.service.ts
+│   └── index.ts
 │
-├── utils/               # Geteilte Utilities
-│   ├── formatters.ts
-│   ├── validators.ts
-│   └── helpers.ts
+├── store/                        # Globale Zustandsverwaltung
+│   ├── slices/                  # Zustand-Slices
+│   │   ├── uiStore.ts
+│   │   ├── themeStore.ts
+│   │   └── notificationStore.ts
+│   ├── index.ts
+│   └── types.ts
 │
-├── types/               # Geteilte TypeScript-Types
+├── types/                        # Globale Typen
+│   ├── global.types.ts
 │   ├── api.types.ts
-│   ├── user.types.ts
-│   └── common.types.ts
+│   ├── common.types.ts
+│   └── index.ts
 │
-├── config/              # Konfigurationsdateien
-│   ├── constants.ts
-│   ├── routes.ts
-│   └── api.config.ts
+├── utils/                        # Globale Hilfsfunktionen
+│   ├── formatters/
+│   │   ├── date.ts
+│   │   ├── currency.ts
+│   │   └── number.ts
+│   ├── validators/
+│   │   ├── email.ts
+│   │   └── phone.ts
+│   ├── helpers/
+│   │   ├── array.ts
+│   │   ├── object.ts
+│   │   └── string.ts
+│   └── index.ts
 │
-├── styles/              # Globale Styles
+├── styles/                       # Globale Stile
 │   ├── globals.css
-│   └── tailwind.css
+│   ├── variables.css
+│   ├── theme.ts
+│   └── tailwind.config.ts
 │
-├── App.tsx              # Root-Komponente
-├── main.tsx             # Entry-Point
-└── routes.tsx           # Routing-Konfiguration
+├── config/                       # Konfiguration
+│   ├── env.ts                   # Umgebungsvariablen
+│   ├── constants.ts             # Globale Konstanten
+│   ├── routes.ts                # Routen-Definitionen
+│   └── features.ts              # Feature-Flags
+│
+├── assets/                       # Statische Assets
+│   ├── images/
+│   ├── icons/
+│   └── fonts/
+│
+├── lib/                          # Konfigurierte Drittanbieter-Bibliotheken
+│   ├── react-query/
+│   │   └── queryClient.ts
+│   ├── router/
+│   │   └── router.config.ts
+│   └── i18n/
+│       └── i18n.config.ts
+│
+└── pages/                        # Seiten (bei dateibasiertem Routing)
+    ├── HomePage.tsx
+    ├── DashboardPage.tsx
+    └── NotFoundPage.tsx
 ```
 
-## Atomic Design-Prinzipien
+## Atomic-Design-Pattern
 
-### Atoms (Atome)
+### Komponentenhierarchie
 
-Grundlegende UI-Bausteine, nicht weiter zerlegbar.
+#### 1. Atoms (Atome)
+
+**Grundlegendste Komponenten, nicht weiter zerlegbar.**
 
 ```typescript
 // components/atoms/Button/Button.tsx
@@ -81,410 +224,428 @@ const buttonVariants = cva(
   {
     variants: {
       variant: {
-        default: 'bg-primary text-white hover:bg-primary/90',
-        secondary: 'bg-secondary text-white hover:bg-secondary/90',
-        outline: 'border border-input hover:bg-accent'
+        primary: 'bg-blue-600 text-white hover:bg-blue-700',
+        secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300',
+        outline: 'border border-gray-300 bg-transparent hover:bg-gray-100',
+        ghost: 'hover:bg-gray-100',
+        danger: 'bg-red-600 text-white hover:bg-red-700'
       },
       size: {
         sm: 'h-9 px-3 text-sm',
-        md: 'h-10 px-4',
+        md: 'h-10 px-4 text-base',
         lg: 'h-11 px-8 text-lg'
       }
     },
     defaultVariants: {
-      variant: 'default',
+      variant: 'primary',
       size: 'md'
     }
   }
 );
 
-interface ButtonProps
+export interface ButtonProps
   extends ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {}
+    VariantProps<typeof buttonVariants> {
+  isLoading?: boolean;
+}
 
 export const Button: FC<ButtonProps> = ({
   variant,
   size,
+  isLoading,
+  disabled,
+  children,
   className,
   ...props
 }) => {
   return (
     <button
       className={buttonVariants({ variant, size, className })}
+      disabled={disabled || isLoading}
       {...props}
-    />
+    >
+      {isLoading ? <Spinner size="sm" /> : children}
+    </button>
   );
 };
 ```
 
-### Molecules (Moleküle)
+```typescript
+// components/atoms/Input/Input.tsx
+import { FC, InputHTMLAttributes, forwardRef } from 'react';
+import { cn } from '@/utils/classnames';
 
-Kombinationen von mehreren Atoms.
+export interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  error?: boolean;
+  fullWidth?: boolean;
+}
+
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ error, fullWidth, className, ...props }, ref) => {
+    return (
+      <input
+        ref={ref}
+        className={cn(
+          'px-3 py-2 border rounded-md outline-none transition-colors',
+          'focus:ring-2 focus:ring-blue-500',
+          error && 'border-red-500 focus:ring-red-500',
+          fullWidth && 'w-full',
+          className
+        )}
+        {...props}
+      />
+    );
+  }
+);
+
+Input.displayName = 'Input';
+```
+
+#### 2. Molecules (Moleküle)
+
+**Kombination mehrerer Atome.**
 
 ```typescript
 // components/molecules/FormField/FormField.tsx
-import { FC, InputHTMLAttributes } from 'react';
-import { Input } from '@/components/atoms/Input';
+import { FC, ReactNode } from 'react';
+import { Input, InputProps } from '@/components/atoms/Input';
 import { Label } from '@/components/atoms/Label';
 
-interface FormFieldProps extends InputHTMLAttributes<HTMLInputElement> {
+export interface FormFieldProps extends InputProps {
   label: string;
   error?: string;
   helperText?: string;
+  required?: boolean;
 }
 
 export const FormField: FC<FormFieldProps> = ({
   label,
   error,
   helperText,
+  required,
   id,
   ...inputProps
 }) => {
+  const inputId = id || `field-${label.toLowerCase().replace(/\s/g, '-')}`;
+
   return (
-    <div className="space-y-2">
-      <Label htmlFor={id}>{label}</Label>
+    <div className="space-y-1">
+      <Label htmlFor={inputId} required={required}>
+        {label}
+      </Label>
       <Input
-        id={id}
+        id={inputId}
+        error={!!error}
         aria-invalid={!!error}
-        aria-describedby={error ? `${id}-error` : undefined}
+        aria-describedby={error ? `${inputId}-error` : undefined}
         {...inputProps}
       />
       {error && (
-        <p id={`${id}-error`} className="text-sm text-destructive">
+        <p id={`${inputId}-error`} className="text-sm text-red-600">
           {error}
         </p>
       )}
       {helperText && !error && (
-        <p className="text-sm text-muted-foreground">{helperText}</p>
+        <p className="text-sm text-gray-500">{helperText}</p>
       )}
     </div>
   );
 };
 ```
 
-### Organisms (Organismen)
+## Container/Presenter-Pattern
 
-Komplexe Komponenten aus Molecules und Atoms.
+### Trennung von Logik und Präsentation
 
-```typescript
-// components/organisms/LoginForm/LoginForm.tsx
-import { FC } from 'react';
-import { useForm } from 'react-hook-form';
-import { zodResolver } from '@hookform/resolvers/zod';
-import { z } from 'zod';
-import { FormField } from '@/components/molecules/FormField';
-import { Button } from '@/components/atoms/Button';
+#### Container (Smart Component)
 
-const loginSchema = z.object({
-  email: z.string().email('Ungültige E-Mail'),
-  password: z.string().min(8, 'Passwort muss mindestens 8 Zeichen haben')
-});
-
-type LoginFormData = z.infer<typeof loginSchema>;
-
-interface LoginFormProps {
-  onSubmit: (data: LoginFormData) => Promise<void>;
-  isLoading?: boolean;
-}
-
-export const LoginForm: FC<LoginFormProps> = ({ onSubmit, isLoading }) => {
-  const {
-    register,
-    handleSubmit,
-    formState: { errors }
-  } = useForm<LoginFormData>({
-    resolver: zodResolver(loginSchema)
-  });
-
-  return (
-    <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">
-      <FormField
-        label="E-Mail"
-        type="email"
-        error={errors.email?.message}
-        {...register('email')}
-      />
-
-      <FormField
-        label="Passwort"
-        type="password"
-        error={errors.password?.message}
-        {...register('password')}
-      />
-
-      <Button type="submit" className="w-full" disabled={isLoading}>
-        {isLoading ? 'Anmeldung läuft...' : 'Anmelden'}
-      </Button>
-    </form>
-  );
-};
-```
-
-## Feature-basierte Architektur
-
-### Feature-Organisation
-
-Jedes Feature ist selbständig mit eigenen Komponenten, Hooks und Services.
-
-```typescript
-// features/users/index.ts
-export { UserList } from './components/UserList';
-export { UserForm } from './components/UserForm';
-export { useUsers, useCreateUser } from './hooks/useUsers';
-export type { User, CreateUserInput } from './types';
-```
-
-### Feature-Komponente mit Container/Presenter
+**Verwaltet Logik, Nebeneffekte und Zustand.**
 
 ```typescript
 // features/users/components/UserList/UserListContainer.tsx
 import { FC } from 'react';
-import { useUsers } from '../../hooks/useUsers';
+import { useUsers } from '@/features/users/hooks/useUsers';
 import { UserListPresenter } from './UserListPresenter';
-import { Spinner } from '@/components/atoms/Spinner';
-import { ErrorMessage } from '@/components/atoms/ErrorMessage';
 
 export const UserListContainer: FC = () => {
-  const { data: users, isLoading, error } = useUsers();
+  const {
+    users,
+    isLoading,
+    error,
+    pagination,
+    handlePageChange,
+    handleSearch,
+    handleSort
+  } = useUsers();
 
-  if (isLoading) return <Spinner />;
-  if (error) return <ErrorMessage error={error} />;
-  if (!users) return null;
+  if (error) {
+    return <ErrorMessage error={error} />;
+  }
 
-  return <UserListPresenter users={users} />;
+  return (
+    <UserListPresenter
+      users={users}
+      isLoading={isLoading}
+      pagination={pagination}
+      onPageChange={handlePageChange}
+      onSearch={handleSearch}
+      onSort={handleSort}
+    />
+  );
 };
+```
 
+#### Presenter (Dumb Component)
+
+**Nur Anzeige, empfängt alles über Props.**
+
+```typescript
 // features/users/components/UserList/UserListPresenter.tsx
 import { FC } from 'react';
-import type { User } from '../../types';
-import { Card } from '@/components/molecules/Card';
+import { User } from '@/features/users/types';
+import { DataTable } from '@/components/organisms/DataTable';
+import { SearchBar } from '@/components/molecules/SearchBar';
+import { Pagination } from '@/components/molecules/Pagination';
 
-interface UserListPresenterProps {
+export interface UserListPresenterProps {
   users: User[];
+  isLoading: boolean;
+  pagination: PaginationState;
+  onPageChange: (page: number) => void;
+  onSearch: (query: string) => void;
+  onSort: (field: string) => void;
 }
 
-export const UserListPresenter: FC<UserListPresenterProps> = ({ users }) => {
+export const UserListPresenter: FC<UserListPresenterProps> = ({
+  users,
+  isLoading,
+  pagination,
+  onPageChange,
+  onSearch,
+  onSort
+}) => {
+  const columns = useMemo(() => [
+    {
+      accessorKey: 'name',
+      header: 'Name'
+    },
+    {
+      accessorKey: 'email',
+      header: 'E-Mail'
+    },
+    {
+      accessorKey: 'role',
+      header: 'Rolle'
+    }
+  ], []);
+
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {users.map((user) => (
-        <Card key={user.id}>
-          <h3>{user.name}</h3>
-          <p>{user.email}</p>
-        </Card>
-      ))}
+    <div className="space-y-4">
+      <SearchBar onSearch={onSearch} placeholder="Benutzer suchen..." />
+
+      {isLoading ? (
+        <Skeleton />
+      ) : (
+        <DataTable data={users} columns={columns} />
+      )}
+
+      <Pagination
+        currentPage={pagination.currentPage}
+        totalPages={pagination.totalPages}
+        onPageChange={onPageChange}
+      />
     </div>
   );
 };
 ```
 
-## State Management
+## Organisation von Custom Hooks
 
-### Lokaler State (useState)
-
-Für Komponenten-spezifischen State.
+### Hook-Struktur
 
 ```typescript
-const [isOpen, setIsOpen] = useState(false);
-const [count, setCount] = useState(0);
-```
+// hooks/useExample/useExample.ts
+import { useState, useEffect, useCallback } from 'react';
 
-### Server State (TanStack Query)
-
-Für API-Daten und Caching.
-
-```typescript
-// hooks/useUsers.ts
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
-import { userService } from '@/services/user.service';
-
-export const useUsers = () => {
-  return useQuery({
-    queryKey: ['users'],
-    queryFn: () => userService.getAll()
-  });
-};
-
-export const useCreateUser = () => {
-  const queryClient = useQueryClient();
-
-  return useMutation({
-    mutationFn: userService.create,
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['users'] });
-    }
-  });
-};
-```
-
-### Globaler State (Zustand)
-
-Für App-weiten State (Theme, Auth, etc.).
-
-```typescript
-// stores/useAuthStore.ts
-import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
-
-interface AuthState {
-  user: User | null;
-  token: string | null;
-  login: (user: User, token: string) => void;
-  logout: () => void;
+export interface UseExampleOptions {
+  initialValue?: string;
+  onSuccess?: (data: string) => void;
 }
 
-export const useAuthStore = create<AuthState>()(
-  persist(
-    (set) => ({
-      user: null,
-      token: null,
-      login: (user, token) => set({ user, token }),
-      logout: () => set({ user: null, token: null })
-    }),
-    {
-      name: 'auth-storage'
-    }
-  )
-);
-```
+export interface UseExampleReturn {
+  value: string;
+  isLoading: boolean;
+  error: Error | null;
+  update: (newValue: string) => void;
+  reset: () => void;
+}
 
-## Routing-Architektur
+/**
+ * Custom Hook zur Verwaltung von [Beschreibung]
+ *
+ * @param options - Konfigurationsoptionen
+ * @returns Zustand und Methoden zur Verwaltung von [Funktionalität]
+ *
+ * @example
+ * ```tsx
+ * const { value, update } = useExample({ initialValue: 'test' });
+ * ```
+ */
+export const useExample = (
+  options: UseExampleOptions = {}
+): UseExampleReturn => {
+  const { initialValue = '', onSuccess } = options;
 
-### Route-Konfiguration
+  const [value, setValue] = useState(initialValue);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
 
-```typescript
-// routes.tsx
-import { lazy } from 'react';
-import { createBrowserRouter } from 'react-router-dom';
-import { ProtectedRoute } from './components/ProtectedRoute';
-import { Layout } from './components/Layout';
+  const update = useCallback(
+    async (newValue: string) => {
+      setIsLoading(true);
+      setError(null);
 
-// Lazy Loading für Code-Splitting
-const HomePage = lazy(() => import('./pages/HomePage'));
-const DashboardPage = lazy(() => import('./pages/DashboardPage'));
-const UsersPage = lazy(() => import('./features/users/pages/UsersPage'));
-
-export const router = createBrowserRouter([
-  {
-    path: '/',
-    element: <Layout />,
-    children: [
-      {
-        index: true,
-        element: <HomePage />
-      },
-      {
-        path: 'dashboard',
-        element: (
-          <ProtectedRoute>
-            <DashboardPage />
-          </ProtectedRoute>
-        )
-      },
-      {
-        path: 'users',
-        element: (
-          <ProtectedRoute>
-            <UsersPage />
-          </ProtectedRoute>
-        )
+      try {
+        // Geschäftslogik
+        setValue(newValue);
+        onSuccess?.(newValue);
+      } catch (err) {
+        setError(err as Error);
+      } finally {
+        setIsLoading(false);
       }
-    ]
-  }
-]);
+    },
+    [onSuccess]
+  );
+
+  const reset = useCallback(() => {
+    setValue(initialValue);
+    setError(null);
+  }, [initialValue]);
+
+  return {
+    value,
+    isLoading,
+    error,
+    update,
+    reset
+  };
+};
 ```
 
-## Dependency Injection Pattern
+## Bewährte Architekturpraktiken
 
-### Service Layer
+### 1. Index-Barrel-Dateien
+
+**Imports mit Index-Dateien vereinfachen.**
 
 ```typescript
-// services/api.service.ts
-import axios, { AxiosInstance } from 'axios';
+// features/users/components/index.ts
+export { UserList } from './UserList';
+export { UserProfile } from './UserProfile';
+export { UserForm } from './UserForm';
 
-export class ApiService {
-  private client: AxiosInstance;
+// features/users/hooks/index.ts
+export { useUsers, useUser } from './useUsers';
+export { useCreateUser, useUpdateUser, useDeleteUser } from './useUserMutations';
+export { useUserFilters } from './useUserFilters';
 
-  constructor(baseURL: string) {
-    this.client = axios.create({
-      baseURL,
-      timeout: 10000
-    });
-  }
-
-  async get<T>(url: string): Promise<T> {
-    const response = await this.client.get<T>(url);
-    return response.data;
-  }
-
-  async post<T>(url: string, data: unknown): Promise<T> {
-    const response = await this.client.post<T>(url, data);
-    return response.data;
-  }
-}
-
-export const apiService = new ApiService(
-  import.meta.env.VITE_API_BASE_URL
-);
+// features/users/index.ts
+export * from './components';
+export * from './hooks';
+export * from './types';
 ```
 
-## Best Practices
-
-### 1. Komponenten-Aufteilung
-
+**Verwendung**:
 ```typescript
-// ✅ Gut - Kleine, fokussierte Komponenten
-export const UserCard: FC<{ user: User }> = ({ user }) => {
-  return (
-    <Card>
-      <UserAvatar user={user} />
-      <UserInfo user={user} />
-      <UserActions user={user} />
-    </Card>
-  );
-};
+// Statt mehrerer Imports
+import { UserList } from '@/features/users/components/UserList';
+import { UserProfile } from '@/features/users/components/UserProfile';
 
-// ❌ Schlecht - Monolithische Komponente
-export const UserCard: FC<{ user: User }> = ({ user }) => {
-  return (
-    <Card>
-      {/* 200 Zeilen Code... */}
-    </Card>
-  );
-};
+// Ein einzelner Import
+import { UserList, UserProfile } from '@/features/users/components';
 ```
 
 ### 2. Absolute Imports
 
-```typescript
-// ✅ Gut - Absolute Imports
-import { Button } from '@/components/atoms/Button';
-import { useAuth } from '@/hooks/useAuth';
+**tsconfig.json-Konfiguration**:
 
-// ❌ Schlecht - Relative Imports
-import { Button } from '../../../components/atoms/Button';
-import { useAuth } from '../../hooks/useAuth';
+```json
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@/components/*": ["./src/components/*"],
+      "@/features/*": ["./src/features/*"],
+      "@/hooks/*": ["./src/hooks/*"],
+      "@/utils/*": ["./src/utils/*"],
+      "@/types/*": ["./src/types/*"]
+    }
+  }
+}
 ```
 
-### 3. Barrel Exports
+**Verwendung**:
+```typescript
+// ❌ Schlecht – relative Imports
+import { Button } from '../../../components/atoms/Button';
+
+// ✅ Gut – absolute Imports
+import { Button } from '@/components/atoms/Button';
+```
+
+### 3. Lazy Loading
+
+**Code-Splitting nach Route**:
 
 ```typescript
-// components/atoms/index.ts
-export { Button } from './Button';
-export { Input } from './Input';
-export { Badge } from './Badge';
+// app/router.tsx
+import { lazy, Suspense } from 'react';
+import { createBrowserRouter } from 'react-router-dom';
+import { Spinner } from '@/components/atoms/Spinner';
 
-// Nutzung
-import { Button, Input, Badge } from '@/components/atoms';
+// Seiten lazy laden
+const HomePage = lazy(() => import('@/pages/HomePage'));
+const DashboardPage = lazy(() => import('@/pages/DashboardPage'));
+const UsersPage = lazy(() => import('@/features/users/pages/UsersPage'));
+
+export const router = createBrowserRouter([
+  {
+    path: '/',
+    element: (
+      <Suspense fallback={<Spinner />}>
+        <HomePage />
+      </Suspense>
+    )
+  },
+  {
+    path: '/dashboard',
+    element: (
+      <Suspense fallback={<Spinner />}>
+        <DashboardPage />
+      </Suspense>
+    )
+  },
+  {
+    path: '/users',
+    element: (
+      <Suspense fallback={<Spinner />}>
+        <UsersPage />
+      </Suspense>
+    )
+  }
+]);
 ```
 
 ## Fazit
 
-Eine gute Architektur ermöglicht:
+Eine gut durchdachte Architektur ist die Grundlage einer wartbaren und skalierbaren React-Anwendung. Wichtigste Prinzipien:
 
-1. ✅ **Wartbarkeit**: Leicht zu verstehen und zu ändern
-2. ✅ **Skalierbarkeit**: Wächst mit dem Projekt
-3. ✅ **Wiederverwendbarkeit**: DRY-Prinzip
-4. ✅ **Testbarkeit**: Einfach zu testen
-5. ✅ **Team-Kollaboration**: Klare Struktur für alle
+1. ✅ **Feature-basiert**: Organisation nach geschäftlichen Funktionalitäten
+2. ✅ **Atomic Design**: Klare Komponentenhierarchie
+3. ✅ **Trennung der Zuständigkeiten**: Container/Presenter, Hooks, Services
+4. ✅ **Modularität**: Wiederverwendbare Komponenten und Hooks
+5. ✅ **Skalierbarkeit**: Struktur, die mit dem Projekt wächst
 
-**Goldene Regel**: Architektur sollte dem Team dienen, nicht umgekehrt.
+**Goldene Regel**: Jede Datei, jeder Ordner und jede Komponente sollte eine einzige, klare Verantwortung haben.

--- a/Dev/i18n/de/React/rules/03-coding-standards.md
+++ b/Dev/i18n/de/React/rules/03-coding-standards.md
@@ -1,500 +1,716 @@
-# Coding-Standards für React
+# React TypeScript Coding Standards
 
-## Namenskonventionen
+## TypeScript Strict Mode
 
-### Komponenten
-
-```typescript
-// ✅ GUT - PascalCase für Komponenten
-export const UserProfile: FC = () => { };
-export const LoginForm: FC = () => { };
-
-// ❌ SCHLECHT
-export const userProfile: FC = () => { };
-export const login_form: FC = () => { };
-```
-
-### Hooks
-
-```typescript
-// ✅ GUT - camelCase mit "use"-Präfix
-export const useAuth = () => { };
-export const useLocalStorage = () => { };
-
-// ❌ SCHLECHT
-export const Auth = () => { };
-export const localStorage = () => { };
-```
-
-### Constants
-
-```typescript
-// ✅ GUT - SCREAMING_SNAKE_CASE
-export const API_BASE_URL = 'https://api.example.com';
-export const MAX_RETRY_ATTEMPTS = 3;
-
-// ❌ SCHLECHT
-export const apiBaseUrl = 'https://api.example.com';
-export const maxRetryAttempts = 3;
-```
-
-### Files und Ordner
-
-```typescript
-// Komponenten: PascalCase
-Button.tsx
-UserProfile.tsx
-
-// Hooks: camelCase
-useAuth.ts
-useLocalStorage.ts
-
-// Utils: camelCase
-formatDate.ts
-validators.ts
-
-// Konstanten: camelCase oder kebab-case
-constants.ts
-api-config.ts
-```
-
-## TypeScript Best Practices
-
-### Strikte Typisierung
-
-```typescript
-// ✅ GUT - Explizite Typen
-interface User {
-  id: string;
-  name: string;
-  email: string;
-  role: 'admin' | 'user';
-}
-
-const fetchUser = async (id: string): Promise<User> => {
-  const response = await fetch(\`/api/users/\${id}\`);
-  return response.json();
-};
-
-// ❌ SCHLECHT - any oder fehlende Typen
-const fetchUser = async (id) => {
-  const response = await fetch(\`/api/users/\${id}\`);
-  return response.json();
-};
-```
-
-### Type vs Interface
-
-```typescript
-// ✅ Interface für Objekt-Shapes (erweiterbar)
-interface User {
-  id: string;
-  name: string;
-}
-
-interface Employee extends User {
-  department: string;
-}
-
-// ✅ Type für Unions, Intersections, Primitives
-type Status = 'pending' | 'approved' | 'rejected';
-type ID = string | number;
-type UserWithRole = User & { role: string };
-
-// ❌ SCHLECHT - Inkonsistente Nutzung
-type User = {  // Sollte interface sein
-  id: string;
-};
-```
-
-### Generics
-
-```typescript
-// ✅ GUT - Wiederverwendbare generische Funktionen
-function useAsync<T>(
-  asyncFn: () => Promise<T>
-): {
-  data: T | null;
-  error: Error | null;
-  isLoading: boolean;
-} {
-  // Implementation
-}
-
-// Nutzung
-const { data, error, isLoading } = useAsync<User[]>(fetchUsers);
-```
-
-## Komponenten-Standards
-
-### Props-Definitionen
-
-```typescript
-// ✅ GUT - Interface mit Dokumentation
-/**
- * User-Karten-Komponente zur Anzeige von Benutzerinformationen
- */
-interface UserCardProps {
-  /**
-   * Anzuzeigender Benutzer
-   */
-  user: User;
-
-  /**
-   * Callback bei Klick auf Bearbeiten
-   */
-  onEdit?: (user: User) => void;
-
-  /**
-   * Zusätzliche CSS-Klassen
-   */
-  className?: string;
-}
-
-export const UserCard: FC<UserCardProps> = ({ user, onEdit, className }) => {
-  // Implementation
-};
-```
-
-### Default Props
-
-```typescript
-// ✅ GUT - Default-Werte in Destrukturierung
-export const Button: FC<ButtonProps> = ({
-  variant = 'default',
-  size = 'md',
-  disabled = false,
-  children
-}) => {
-  // Implementation
-};
-
-// ❌ VERMEIDEN - defaultProps (veraltet)
-Button.defaultProps = {
-  variant: 'default',
-  size: 'md'
-};
-```
-
-### Event Handler
-
-```typescript
-// ✅ GUT - Konsistente Benennung
-const handleClick = () => { };
-const handleSubmit = () => { };
-const handleChange = () => { };
-
-// Props
-interface Props {
-  onClick?: () => void;
-  onSubmit?: (data: FormData) => void;
-  onChange?: (value: string) => void;
-}
-```
-
-## Hooks-Standards
-
-### Hook-Reihenfolge
-
-```typescript
-export const MyComponent: FC = () => {
-  // 1. State Hooks
-  const [count, setCount] = useState(0);
-  const [isOpen, setIsOpen] = useState(false);
-
-  // 2. Context Hooks
-  const { user } = useAuth();
-  const theme = useTheme();
-
-  // 3. Custom Hooks
-  const { data, isLoading } = useUsers();
-
-  // 4. Refs
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  // 5. useMemo / useCallback
-  const expensiveValue = useMemo(() => computeExpensiveValue(count), [count]);
-  const handleClick = useCallback(() => {}, []);
-
-  // 6. useEffect
-  useEffect(() => {
-    // Side effects
-  }, []);
-
-  // Render
-  return <div>{count}</div>;
-};
-```
-
-### Custom Hooks
-
-```typescript
-// ✅ GUT - Klare API, mit TypeScript
-export const useLocalStorage = <T>(
-  key: string,
-  initialValue: T
-): [T, (value: T) => void] => {
-  const [storedValue, setStoredValue] = useState<T>(() => {
-    try {
-      const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
-    } catch {
-      return initialValue;
-    }
-  });
-
-  const setValue = (value: T) => {
-    setStoredValue(value);
-    window.localStorage.setItem(key, JSON.stringify(value));
-  };
-
-  return [storedValue, setValue];
-};
-
-// Nutzung
-const [user, setUser] = useLocalStorage<User>('user', null);
-```
-
-## Code-Organisation
-
-### Imports-Reihenfolge
-
-```typescript
-// 1. React imports
-import { FC, useState, useEffect } from 'react';
-
-// 2. External libraries
-import { useQuery } from '@tanstack/react-query';
-import { z } from 'zod';
-
-// 3. Interne absolute imports
-import { Button } from '@/components/atoms/Button';
-import { useAuth } from '@/hooks/useAuth';
-
-// 4. Relative imports
-import { helper } from './utils';
-
-// 5. Types
-import type { User } from '@/types/user.types';
-
-// 6. Styles (falls nötig)
-import styles from './Component.module.css';
-```
-
-### Exports
-
-```typescript
-// ✅ GUT - Named exports (bevorzugt)
-export const Button: FC = () => { };
-export const Input: FC = () => { };
-
-// ✅ Barrel exports
-// components/atoms/index.ts
-export { Button } from './Button';
-export { Input } from './Input';
-
-// ❌ VERMEIDEN - Default exports (außer für Pages)
-export default Button;
-```
-
-## Code-Formatierung
-
-### Prettier-Konfiguration
+### tsconfig.json-Konfiguration
 
 ```json
 {
-  "semi": true,
-  "singleQuote": true,
-  "tabWidth": 2,
-  "useTabs": false,
-  "printWidth": 90,
-  "trailingComma": "none",
-  "arrowParens": "avoid"
+  "compilerOptions": {
+    // Strikte Typprüfungsoptionen
+    "strict": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true,
+    "strictFunctionTypes": true,
+    "strictBindCallApply": true,
+    "strictPropertyInitialization": true,
+    "noImplicitThis": true,
+    "alwaysStrict": true,
+
+    // Zusätzliche Prüfungen
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+
+    // Modulauflösung
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+
+    // Ausgabe
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "removeComments": false,
+
+    // React
+    "jsx": "react-jsx",
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "target": "ES2020",
+    "module": "ESNext",
+
+    // Pfade
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"]
+    }
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", "dist", "build"]
 }
 ```
 
-### ESLint-Regeln
+### Strikte TypeScript-Regeln
+
+#### 1. Explizite Typen
+
+```typescript
+// ❌ Schlecht – Impliziter 'any'-Typ
+const handleClick = (event) => {
+  console.log(event.target);
+};
+
+// ✅ Gut – Expliziter Typ
+const handleClick = (event: MouseEvent<HTMLButtonElement>) => {
+  console.log(event.currentTarget);
+};
+
+// ❌ Schlecht – Impliziter Rückgabetyp
+function calculateTotal(items) {
+  return items.reduce((sum, item) => sum + item.price, 0);
+}
+
+// ✅ Gut – Explizite Typen
+function calculateTotal(items: Product[]): number {
+  return items.reduce((sum, item) => sum + item.price, 0);
+}
+```
+
+#### 2. Null-Sicherheit
+
+```typescript
+// ❌ Schlecht – Keine Null-Prüfung
+function getUserName(user: User) {
+  return user.profile.name; // Fehler wenn profile null ist
+}
+
+// ✅ Gut – Optionales Verketten
+function getUserName(user: User): string {
+  return user.profile?.name ?? 'Anonym';
+}
+
+// ✅ Gut – Guard-Klausel
+function getUserName(user: User): string {
+  if (!user.profile) {
+    return 'Anonym';
+  }
+  return user.profile.name;
+}
+```
+
+#### 3. Union-Typen und Type Guards
+
+```typescript
+// Union-Typen definieren
+type Status = 'idle' | 'loading' | 'success' | 'error';
+
+interface IdleState {
+  status: 'idle';
+}
+
+interface LoadingState {
+  status: 'loading';
+}
+
+interface SuccessState {
+  status: 'success';
+  data: User;
+}
+
+interface ErrorState {
+  status: 'error';
+  error: Error;
+}
+
+type AsyncState = IdleState | LoadingState | SuccessState | ErrorState;
+
+// Type Guards
+function isSuccessState(state: AsyncState): state is SuccessState {
+  return state.status === 'success';
+}
+
+function isErrorState(state: AsyncState): state is ErrorState {
+  return state.status === 'error';
+}
+
+// Verwendung
+const renderState = (state: AsyncState) => {
+  if (isSuccessState(state)) {
+    return <div>{state.data.name}</div>; // TypeScript weiß, dass data existiert
+  }
+
+  if (isErrorState(state)) {
+    return <div>{state.error.message}</div>; // TypeScript weiß, dass error existiert
+  }
+
+  return <Spinner />;
+};
+```
+
+## ESLint-Konfiguration
+
+### Installation
+
+```bash
+npm install -D eslint @typescript-eslint/parser @typescript-eslint/eslint-plugin
+npm install -D eslint-plugin-react eslint-plugin-react-hooks
+npm install -D eslint-plugin-jsx-a11y eslint-plugin-import
+npm install -D eslint-config-prettier
+```
+
+### .eslintrc.cjs-Konfiguration
 
 ```javascript
 module.exports = {
+  root: true,
+  env: {
+    browser: true,
+    es2020: true,
+    node: true
+  },
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
+    'plugin:@typescript-eslint/recommended-requiring-type-checking',
     'plugin:react/recommended',
-    'plugin:react-hooks/recommended'
+    'plugin:react/jsx-runtime',
+    'plugin:react-hooks/recommended',
+    'plugin:jsx-a11y/recommended',
+    'plugin:import/recommended',
+    'plugin:import/typescript',
+    'prettier'
   ],
+  parser: '@typescript-eslint/parser',
+  parserOptions: {
+    ecmaVersion: 'latest',
+    sourceType: 'module',
+    project: ['./tsconfig.json'],
+    ecmaFeatures: {
+      jsx: true
+    }
+  },
+  plugins: ['react', 'react-hooks', '@typescript-eslint', 'jsx-a11y', 'import'],
+  settings: {
+    react: {
+      version: 'detect'
+    },
+    'import/resolver': {
+      typescript: {
+        alwaysTryTypes: true,
+        project: './tsconfig.json'
+      }
+    }
+  },
   rules: {
+    // TypeScript
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_'
+      }
+    ],
     '@typescript-eslint/no-explicit-any': 'error',
-    '@typescript-eslint/explicit-function-return-type': 'warn',
+    '@typescript-eslint/explicit-function-return-type': [
+      'warn',
+      {
+        allowExpressions: true,
+        allowTypedFunctionExpressions: true
+      }
+    ],
+    '@typescript-eslint/no-non-null-assertion': 'error',
+    '@typescript-eslint/prefer-nullish-coalescing': 'error',
+    '@typescript-eslint/prefer-optional-chain': 'error',
+    '@typescript-eslint/consistent-type-imports': [
+      'error',
+      {
+        prefer: 'type-imports'
+      }
+    ],
+
+    // React
     'react/prop-types': 'off',
+    'react/react-in-jsx-scope': 'off',
+    'react/jsx-no-target-blank': 'error',
+    'react/jsx-curly-brace-presence': [
+      'error',
+      {
+        props: 'never',
+        children: 'never'
+      }
+    ],
+    'react/self-closing-comp': 'error',
+    'react/jsx-boolean-value': ['error', 'never'],
+    'react/jsx-fragments': ['error', 'syntax'],
+
+    // React Hooks
     'react-hooks/rules-of-hooks': 'error',
-    'react-hooks/exhaustive-deps': 'warn'
+    'react-hooks/exhaustive-deps': 'warn',
+
+    // Import
+    'import/order': [
+      'error',
+      {
+        groups: [
+          'builtin',
+          'external',
+          'internal',
+          'parent',
+          'sibling',
+          'index',
+          'type'
+        ],
+        'newlines-between': 'always',
+        alphabetize: {
+          order: 'asc',
+          caseInsensitive: true
+        }
+      }
+    ],
+    'import/no-duplicates': 'error',
+    'import/no-unresolved': 'error',
+
+    // Allgemein
+    'no-console': ['warn', { allow: ['warn', 'error'] }],
+    'prefer-const': 'error',
+    'no-var': 'error'
   }
 };
 ```
 
-## Kommentare und Dokumentation
+## Prettier-Konfiguration
 
-### JSDoc für Public APIs
+### Installation
 
-```typescript
-/**
- * Berechnet das Alter basierend auf dem Geburtsdatum
- *
- * @param birthDate - Geburtsdatum des Benutzers
- * @returns Alter in Jahren
- *
- * @example
- * \`\`\`ts
- * const age = calculateAge(new Date('1990-01-01'));
- * console.log(age); // 34
- * \`\`\`
- */
-export const calculateAge = (birthDate: Date): number => {
-  const today = new Date();
-  let age = today.getFullYear() - birthDate.getFullYear();
-  const monthDiff = today.getMonth() - birthDate.getMonth();
-
-  if (monthDiff < 0 || (monthDiff === 0 && today.getDate() < birthDate.getDate())) {
-    age--;
-  }
-
-  return age;
-};
+```bash
+npm install -D prettier
 ```
 
-### Inline-Kommentare
+### .prettierrc-Konfiguration
 
-```typescript
-// ✅ GUT - Erklärt das "Warum"
-// Verwende requestAnimationFrame um Layout-Thrashing zu vermeiden
-const optimizedScroll = () => {
-  requestAnimationFrame(() => {
-    updateScrollPosition();
-  });
-};
-
-// ❌ SCHLECHT - Erklärt das "Was" (offensichtlich)
-// Inkrementiere den Zähler um 1
-count++;
+```json
+{
+  "printWidth": 90,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "quoteProps": "as-needed",
+  "jsxSingleQuote": false,
+  "trailingComma": "none",
+  "bracketSpacing": true,
+  "bracketSameLine": false,
+  "arrowParens": "avoid",
+  "endOfLine": "lf",
+  "plugins": ["prettier-plugin-tailwindcss"]
+}
 ```
 
-## Best Practices
+### .prettierignore
 
-### 1. Komponenten klein halten
-
-```typescript
-// ✅ GUT - Einzelne Verantwortlichkeit
-export const UserAvatar: FC<{ user: User }> = ({ user }) => (
-  <img src={user.avatar} alt={user.name} />
-);
-
-export const UserInfo: FC<{ user: User }> = ({ user }) => (
-  <div>
-    <h3>{user.name}</h3>
-    <p>{user.email}</p>
-  </div>
-);
-
-// ❌ SCHLECHT - Zu viel in einer Komponente
-export const UserCard: FC<{ user: User }> = ({ user }) => (
-  <div>
-    <img src={user.avatar} alt={user.name} />
-    <h3>{user.name}</h3>
-    <p>{user.email}</p>
-    {/* Noch 100 weitere Zeilen... */}
-  </div>
-);
+```
+node_modules
+dist
+build
+.next
+coverage
+*.min.js
+*.min.css
+package-lock.json
+yarn.lock
+pnpm-lock.yaml
 ```
 
-### 2. Early Returns
+## Namenskonventionen
+
+### 1. Dateien
+
+```
+✅ React-Komponenten: PascalCase
+- UserProfile.tsx
+- LoginForm.tsx
+- DataTable.tsx
+
+✅ Hooks: camelCase mit 'use'-Präfix
+- useAuth.ts
+- useLocalStorage.ts
+- useDebounce.ts
+
+✅ Hilfsfunktionen: camelCase
+- formatDate.ts
+- validateEmail.ts
+- calculateTotal.ts
+
+✅ Konstanten: UPPER_SNAKE_CASE
+- API_ENDPOINTS.ts
+- VALIDATION_RULES.ts
+- ERROR_MESSAGES.ts
+
+✅ Typen: PascalCase mit '.types'-Suffix
+- User.types.ts
+- Product.types.ts
+- api.types.ts
+
+✅ Services: camelCase mit '.service'-Suffix
+- auth.service.ts
+- user.service.ts
+- api.service.ts
+
+✅ Tests: gleicher Name + '.test' oder '.spec'
+- UserProfile.test.tsx
+- useAuth.test.ts
+- formatDate.spec.ts
+```
+
+### 2. Variablen und Funktionen
 
 ```typescript
-// ✅ GUT - Guard Clauses
-export const UserProfile: FC<{ userId: string }> = ({ userId }) => {
-  const { data: user, isLoading, error } = useUser(userId);
+// ✅ Variablen: camelCase
+const userName = 'John';
+const isAuthenticated = true;
+const userProfile = { name: 'John' };
 
-  if (isLoading) return <Spinner />;
-  if (error) return <ErrorMessage error={error} />;
-  if (!user) return <NotFound />;
+// ✅ Konstanten: UPPER_SNAKE_CASE
+const API_BASE_URL = 'https://api.example.com';
+const MAX_RETRY_ATTEMPTS = 3;
+const DEFAULT_PAGE_SIZE = 10;
 
-  return <div>{user.name}</div>;
+// ✅ Funktionen: camelCase, Aktionsverb
+function getUserById(id: string): User {}
+function calculateTotal(items: Product[]): number {}
+function validateEmail(email: string): boolean {}
+
+// ✅ Handler: 'handle'-Präfix
+const handleClick = () => {};
+const handleSubmit = (e: FormEvent) => {};
+const handleChange = (value: string) => {};
+
+// ✅ Boolesche Werte: 'is'-, 'has'-, 'should'-, 'can'-Präfix
+const isLoading = false;
+const hasError = false;
+const shouldRender = true;
+const canEdit = false;
+```
+
+### 3. Komponenten
+
+```typescript
+// ✅ Komponenten: PascalCase
+export const UserProfile: FC<UserProfileProps> = (props) => {};
+
+// ✅ Props-Interface: Komponentenname + 'Props'
+interface UserProfileProps {
+  userId: string;
+  onUpdate?: (user: User) => void;
+}
+
+// ✅ Hooks: camelCase mit 'use'-Präfix
+export const useUserProfile = (userId: string) => {};
+
+// ✅ Typen: PascalCase
+type User = {
+  id: string;
+  name: string;
 };
 
-// ❌ SCHLECHT - Verschachtelte Conditionals
-export const UserProfile: FC<{ userId: string }> = ({ userId }) => {
-  const { data: user, isLoading, error } = useUser(userId);
+// ✅ Interfaces: PascalCase (optionales 'I'-Präfix)
+interface IUser {
+  id: string;
+  name: string;
+}
 
+// ✅ Enums: PascalCase
+enum UserRole {
+  ADMIN = 'admin',
+  USER = 'user',
+  GUEST = 'guest'
+}
+```
+
+## Komponentenmuster
+
+### 1. Funktionale Komponente mit TypeScript
+
+```typescript
+import { FC } from 'react';
+
+// Props-Interface
+interface ButtonProps {
+  variant?: 'primary' | 'secondary';
+  size?: 'sm' | 'md' | 'lg';
+  disabled?: boolean;
+  onClick?: () => void;
+  children: React.ReactNode;
+}
+
+// Funktionale Komponente mit FC
+export const Button: FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  onClick,
+  children
+}) => {
   return (
-    <div>
-      {isLoading ? (
-        <Spinner />
-      ) : error ? (
-        <ErrorMessage error={error} />
-      ) : user ? (
-        <div>{user.name}</div>
-      ) : (
-        <NotFound />
-      )}
-    </div>
-  );
-};
-```
-
-### 3. Destructuring
-
-```typescript
-// ✅ GUT - Props destrukturieren
-export const Button: FC<ButtonProps> = ({ variant, size, children }) => {
-  return <button className={\`btn-\${variant} btn-\${size}\`}>{children}</button>;
-};
-
-// ❌ SCHLECHT
-export const Button: FC<ButtonProps> = (props) => {
-  return (
-    <button className={\`btn-\${props.variant} btn-\${props.size}\`}>
-      {props.children}
+    <button
+      className={`btn btn-${variant} btn-${size}`}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {children}
     </button>
   );
 };
+
+// Export mit displayName zum Debuggen
+Button.displayName = 'Button';
 ```
 
-## Checkliste
+### 2. React.memo für Performance
 
-```markdown
-## Code-Qualität
-- [ ] Keine ESLint-Fehler oder -Warnungen
-- [ ] Alle Dateien mit Prettier formatiert
-- [ ] TypeScript strict mode aktiviert
-- [ ] Keine `any`-Types
+```typescript
+import { FC, memo } from 'react';
 
-## Namenskonventionen
-- [ ] Komponenten in PascalCase
-- [ ] Hooks mit "use"-Präfix in camelCase
-- [ ] Konstanten in SCREAMING_SNAKE_CASE
-- [ ] Dateien konsistent benannt
+interface UserCardProps {
+  user: User;
+  onSelect: (userId: string) => void;
+}
 
-## Dokumentation
-- [ ] JSDoc für öffentliche APIs
-- [ ] Props dokumentiert
-- [ ] Komplexe Logik kommentiert
-- [ ] README aktuell
+// Memoisierte Komponente
+export const UserCard: FC<UserCardProps> = memo(({ user, onSelect }) => {
+  return (
+    <div onClick={() => onSelect(user.id)}>
+      <h3>{user.name}</h3>
+      <p>{user.email}</p>
+    </div>
+  );
+});
 
-## Best Practices
-- [ ] Komponenten klein und fokussiert
-- [ ] Early returns verwendet
-- [ ] Props destrukturiert
-- [ ] Imports organisiert
+UserCard.displayName = 'UserCard';
+
+// Mit benutzerdefiniertem Vergleich
+export const UserCardCustom: FC<UserCardProps> = memo(
+  ({ user, onSelect }) => {
+    return (
+      <div onClick={() => onSelect(user.id)}>
+        <h3>{user.name}</h3>
+      </div>
+    );
+  },
+  (prevProps, nextProps) => {
+    // true zurückgeben, wenn Props gleich sind (kein Re-Render)
+    return prevProps.user.id === nextProps.user.id;
+  }
+);
+```
+
+### 3. forwardRef für Refs
+
+```typescript
+import { forwardRef, InputHTMLAttributes } from 'react';
+
+interface InputProps extends InputHTMLAttributes<HTMLInputElement> {
+  label?: string;
+  error?: string;
+}
+
+// Komponente mit forwardRef
+export const Input = forwardRef<HTMLInputElement, InputProps>(
+  ({ label, error, ...props }, ref) => {
+    return (
+      <div>
+        {label && <label>{label}</label>}
+        <input ref={ref} {...props} />
+        {error && <span>{error}</span>}
+      </div>
+    );
+  }
+);
+
+Input.displayName = 'Input';
+
+// Verwendung
+const MyForm = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const focusInput = () => {
+    inputRef.current?.focus();
+  };
+
+  return <Input ref={inputRef} label="Name" />;
+};
+```
+
+## Dateistruktur von Komponenten
+
+### Einfache Komponente
+
+```
+Button/
+├── Button.tsx          # Hauptkomponente
+├── Button.test.tsx     # Tests
+├── Button.stories.tsx  # Storybook
+└── index.ts            # Exporte
+```
+
+```typescript
+// Button.tsx
+import { FC, ButtonHTMLAttributes } from 'react';
+import { cn } from '@/utils/classnames';
+
+export interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+}
+
+export const Button: FC<ButtonProps> = ({ variant = 'primary', ...props }) => {
+  return <button className={cn('btn', `btn-${variant}`)} {...props} />;
+};
+```
+
+```typescript
+// index.ts
+export { Button } from './Button';
+export type { ButtonProps } from './Button';
+```
+
+## JSDoc/TSDoc-Dokumentation
+
+### Komponenten dokumentieren
+
+```typescript
+/**
+ * Benutzerdefinierter Button mit verschiedenen visuellen Varianten.
+ *
+ * @remarks
+ * Diese Komponente erweitert die nativen HTMLButtonElement-Props,
+ * sodass alle Standard-HTML-Attribute verwendet werden können.
+ *
+ * @example
+ * ```tsx
+ * // Primärer Button
+ * <Button variant="primary" onClick={handleClick}>
+ *   Klick mich
+ * </Button>
+ *
+ * // Deaktivierter Button
+ * <Button variant="secondary" disabled>
+ *   Deaktiviert
+ * </Button>
+ * ```
+ */
+export const Button: FC<ButtonProps> = ({ variant, children, ...rest }) => {
+  return <button className={`btn-${variant}`} {...rest}>{children}</button>;
+};
+```
+
+## Allgemeine bewährte Praktiken
+
+### 1. Eine Komponente = Eine Datei
+
+```typescript
+// ❌ Schlecht – Mehrere Komponenten in einer Datei
+export const Button = () => {};
+export const Input = () => {};
+export const Form = () => {};
+
+// ✅ Gut – Eine Komponente pro Datei
+// Button.tsx
+export const Button = () => {};
+
+// Input.tsx
+export const Input = () => {};
+```
+
+### 2. Any vermeiden
+
+```typescript
+// ❌ Schlecht
+const handleData = (data: any) => {
+  console.log(data.name);
+};
+
+// ✅ Gut
+interface Data {
+  name: string;
+}
+
+const handleData = (data: Data) => {
+  console.log(data.name);
+};
+
+// ✅ Gut – Falls wirklich nötig, dokumentieren
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const handleUnknown = (data: any) => {
+  // Grund für die Verwendung von any...
+};
+```
+
+### 3. Benannte Exporte vs. Default
+
+```typescript
+// ✅ Benannte Exporte bevorzugen
+export const Button = () => {};
+export const Input = () => {};
+
+// ❌ Default-Exporte vermeiden (außer bei Seiten/Routen)
+export default Button;
+```
+
+### 4. Gruppierte und geordnete Imports
+
+```typescript
+// 1. React und externe Bibliotheken
+import { FC, useState, useEffect } from 'react';
+import { useQuery } from '@tanstack/react-query';
+
+// 2. Absolute interne Imports
+import { Button } from '@/components/atoms/Button';
+import { useAuth } from '@/hooks/useAuth';
+
+// 3. Relative Imports
+import { UserCard } from './UserCard';
+
+// 4. Typen
+import type { User } from '@/types/user.types';
+
+// 5. Stile und Assets
+import './styles.css';
+```
+
+## NPM-Skripte
+
+```json
+{
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "lint": "eslint . --ext ts,tsx --report-unused-disable-directives --max-warnings 0",
+    "lint:fix": "eslint . --ext ts,tsx --fix",
+    "format": "prettier --write \"src/**/*.{ts,tsx,json,css,md}\"",
+    "format:check": "prettier --check \"src/**/*.{ts,tsx,json,css,md}\"",
+    "type-check": "tsc --noEmit",
+    "test": "vitest",
+    "test:ui": "vitest --ui",
+    "test:coverage": "vitest --coverage"
+  }
+}
 ```
 
 ## Fazit
 
-Konsistente Coding-Standards ermöglichen:
+Coding Standards gewährleisten:
 
-1. ✅ **Lesbarkeit**: Code ist leicht zu verstehen
-2. ✅ **Wartbarkeit**: Änderungen sind einfach
-3. ✅ **Teamwork**: Einheitlicher Code-Stil
-4. ✅ **Qualität**: Weniger Bugs
-5. ✅ **Onboarding**: Neue Entwickler schneller produktiv
+1. ✅ Code-Konsistenz im gesamten Team
+2. ✅ Bessere Wartbarkeit
+3. ✅ Weniger Fehler
+4. ✅ Einfachere Code-Reviews
+5. ✅ Schnelleres Onboarding für neue Entwickler
 
-**Goldene Regel**: Code wird öfter gelesen als geschrieben.
+**Goldene Regel**: Code sollte so geschrieben werden, dass er von Menschen gelesen werden kann – nicht nur von Maschinen ausgeführt.

--- a/Dev/i18n/de/Symfony/commands/check-compliance.md
+++ b/Dev/i18n/de/Symfony/commands/check-compliance.md
@@ -1,5 +1,5 @@
 ---
-description: Vollständiges Symfony-Konformitäts-Audit
+description: Vollständiges Symfony-Konformitäts-Audit durchführen
 argument-hint: [arguments]
 ---
 
@@ -7,7 +7,7 @@ argument-hint: [arguments]
 
 ## Argumente
 
-$ARGUMENTS : Pfad zum zu auditierenden Symfony-Projekt (optional, Standard: aktuelles Verzeichnis)
+$ARGUMENTS (optional: Pfad zum zu analysierenden Projekt)
 
 ## Plan-Modus
 
@@ -15,167 +15,239 @@ $ARGUMENTS : Pfad zum zu auditierenden Symfony-Projekt (optional, Standard: aktu
 
 ## MISSION
 
-Du bist ein erfahrener Symfony-Auditor, der ein vollständiges Konformitäts-Audit eines Symfony-Projekts durchführt.
+Ein vollständiges Konformitäts-Audit des Symfony-Projekts durchführen, indem die 4 wesentlichen Prüfungen orchestriert werden: Architektur, Code-Qualität, Tests und Sicherheit. Einen konsolidierten Bericht mit einem Gesamtergebnis von 100 Punkten erstellen.
 
-### Schritt 1: Projekt überprüfen
+### Schritt 1: Audit-Vorbereitung
 
-1. Zu auditierendes Projektverzeichnis identifizieren
-2. Prüfen, ob es sich um ein Symfony-Projekt handelt (composer.json mit symfony/*)
-3. Verwendete Symfony-Version prüfen
+Audit-Umgebung vorbereiten:
+- [ ] Zu auditierendes Projektverzeichnis identifizieren
+- [ ] Vorhandensein von Konfigurationsdateien prüfen (composer.json mit symfony/*, .env)
+- [ ] Hauptverzeichnisse auflisten (src/, tests/, config/ usw.)
+- [ ] Projektstruktur und Symfony-Version identifizieren
+
+**Hinweis**: Wenn $ARGUMENTS angegeben ist, diesen als Projektpfad verwenden, andernfalls das aktuelle Verzeichnis verwenden.
 
 ### Schritt 2: Architektur-Audit (25 Punkte)
 
-Architektur-Audit durchführen und prüfen:
+Vollständige Architekturprüfung durchführen:
 
-**Regelreferenz**: `.claude/rules/symfony-architecture.md`
+**Befehl**: Slash-Befehl `/symfony:check-architecture` verwenden oder die Schritte in `check-architecture.md` manuell befolgen
 
-- [ ] Ordnerstruktur entspricht Clean Architecture
-- [ ] Trennung Domain / Application / Infrastructure
-- [ ] Einhaltung von DDD-Prinzipien (Entities, Value Objects, Aggregates)
-- [ ] Hexagonale Architektur (Ports & Adapters)
-- [ ] Verwendung von Deptrac zur Abhängigkeitsprüfung
-- [ ] Keine Kopplung zwischen Schichten
-- [ ] Korrekt definierte Interfaces für Ports
-- [ ] Gut definierte Use Cases / Application Services
-- [ ] Repositories mit Interfaces in der Domain
-- [ ] DTOs für Datentransfer
+**Bewertete Kriterien**:
+- Clean-Architecture-Struktur (6 Pkt.)
+- Trennung Domain/Application/Infrastructure (6 Pkt.)
+- Hexagonale Architektur / Ports & Adapters (4 Pkt.)
+- DDD-Modellierung (Entities, Value Objects, Aggregates) (4 Pkt.)
+- Use Cases und Application Services (3 Pkt.)
+- Abhängigkeitsregeln und Deptrac (2 Pkt.)
 
-**Architektur-Score**: ___/25 Punkte
+**Referenz**: `check-architecture.md`
 
 ### Schritt 3: Code-Qualitäts-Audit (25 Punkte)
 
-Code-Qualitäts-Audit durchführen und prüfen:
+Code-Qualitätsprüfung durchführen:
 
-**Regelreferenz**: `.claude/rules/symfony-code-quality.md`
+**Befehl**: Slash-Befehl `/symfony:check-code-quality` verwenden oder die Schritte in `check-code-quality.md` manuell befolgen
 
-- [ ] Einhaltung von PSR-12
-- [ ] PHPStan Level 9 ohne Fehler
-- [ ] Strikte Type Hints auf allen Parametern und Rückgaben
-- [ ] `declare(strict_types=1)` in allen Dateien
-- [ ] Kein toter Code (von PHPStan erkannt)
-- [ ] Keine ungenutzten Abhängigkeiten
-- [ ] Zyklomatische Komplexität < 10 pro Methode
-- [ ] Methodenlänge < 20 Zeilen
-- [ ] Klassen mit Single Responsibility
-- [ ] Vollständige und aktuelle PHPDoc-Dokumentation
+**Bewertete Kriterien**:
+- PSR-12-Konformität (5 Pkt.)
+- PHPStan Level 9 (5 Pkt.)
+- Strikte Type Hints und declare(strict_types=1) (4 Pkt.)
+- KISS/DRY/YAGNI-Prinzipien (4 Pkt.)
+- Dokumentation und PHPDoc (4 Pkt.)
+- Fehlerbehandlung (3 Pkt.)
 
-**Code-Qualitäts-Score**: ___/25 Punkte
+**Referenz**: `check-code-quality.md`
 
 ### Schritt 4: Test-Audit (25 Punkte)
 
-Test-Audit durchführen und prüfen:
+Test-Prüfung durchführen:
 
-**Regelreferenz**: `.claude/rules/symfony-testing.md`
+**Befehl**: Slash-Befehl `/symfony:check-testing` verwenden oder die Schritte in `check-testing.md` manuell befolgen
 
-- [ ] Code-Abdeckung ≥ 80%
-- [ ] Unit-Tests für Domain
-- [ ] Integrationstests für Infrastructure
-- [ ] Funktionale Tests mit Behat oder Symfony WebTestCase
-- [ ] Mutation-Tests mit Infection (MSI ≥ 70%)
-- [ ] Fixtures für Tests
-- [ ] Isolierte Tests (keine gegenseitigen Abhängigkeiten)
-- [ ] Separate Test-Datenbank
-- [ ] Angemessene Mocks und Stubs
-- [ ] CI/CD mit automatischer Testausführung
+**Bewertete Kriterien**:
+- Code-Abdeckung (7 Pkt.)
+- Unit-Tests für Domain (6 Pkt.)
+- Integrationstests für Infrastructure (4 Pkt.)
+- Funktionale Tests (WebTestCase/Behat) (3 Pkt.)
+- Mutations-Testing mit Infection (3 Pkt.)
+- Test-Isolation und Fixtures (2 Pkt.)
 
-**Test-Score**: ___/25 Punkte
+**Referenz**: `check-testing.md`
 
 ### Schritt 5: Sicherheits-Audit (25 Punkte)
 
-Sicherheits-Audit durchführen und prüfen:
+Sicherheitsprüfung durchführen:
 
-**Regelreferenz**: `.claude/rules/symfony-security.md`
+**Befehl**: Slash-Befehl `/symfony:check-security` verwenden oder die Schritte in `check-security.md` manuell befolgen
 
-- [ ] Symfony Security Bundle korrekt konfiguriert
-- [ ] OWASP Top 10: Schutz gegen SQL-Injection
-- [ ] OWASP Top 10: XSS-Schutz
-- [ ] OWASP Top 10: CSRF-Schutz
-- [ ] OWASP Top 10: Sichere Authentifizierung
-- [ ] OWASP Top 10: Zugriffskontrolle (Voters, ACL)
-- [ ] DSGVO: Benutzereinwilligung
-- [ ] DSGVO: Implementiertes Recht auf Vergessenwerden
-- [ ] DSGVO: Export persönlicher Daten
-- [ ] Externalisierte Secrets (nicht im Code)
+**Bewertete Kriterien**:
+- Konfiguration des Symfony Security Bundle (6 Pkt.)
+- OWASP-Top-10-Schutzmaßnahmen (5 Pkt.)
+- Verwaltung von Secrets und Anmeldeinformationen (4 Pkt.)
+- Eingabevalidierung und CSRF (4 Pkt.)
+- Authentifizierung und Autorisierung (Voters) (3 Pkt.)
+- Abhängigkeitsschwachstellen (2 Pkt.)
+- DSGVO-Konformität (1 Pkt.)
 
-**Sicherheits-Score**: ___/25 Punkte
+**Referenz**: `check-security.md`
 
-### Schritt 6: Gesamt-Score berechnen
+### Schritt 6: Konsolidierung und Gesamtbewertung
 
-**GESAMT-SCORE**: ___/100 Punkte
+Gesamtergebnis berechnen und konsolidierten Bericht erstellen:
+- [ ] Die 4 Bewertungen addieren (max. 100 Punkte)
+- [ ] Kritische Kategorien identifizieren (< 50 %)
+- [ ] Alle kritischen kategorienübergreifenden Probleme auflisten
+- [ ] Maßnahmen nach Auswirkung/Aufwand priorisieren
+- [ ] Abschließenden konsolidierten Bericht erstellen
 
-Interpretation:
-- ✅ 90-100: Exzellent - Vorbildliche Konformität
-- ✅ 75-89: Gut - Einige kleinere Verbesserungen
-- ⚠️ 60-74: Mittel - Verbesserungen erforderlich
-- ⚠️ 40-59: Unzureichend - Umfangreiches Refactoring erforderlich
-- ❌ 0-39: Kritisch - Vollständige Überarbeitung notwendig
+**Bewertungsskala**:
+- 90–100: Ausgezeichnet – Referenzprojekt
+- 75–89: Sehr gut – Einige kleinere Verbesserungen
+- 60–74: Akzeptabel – Verbesserungen erforderlich
+- 40–59: Unzureichend – Umfangreiches Refactoring erforderlich
+- 0–39: Kritisch – Vollständige Überarbeitung notwendig
 
-### Schritt 7: Detaillierter Bericht
+### Schritt 7: Empfehlungen und Aktionsplan
 
-Strukturierten Bericht erstellen mit:
+Abschließende Empfehlungen erstellen:
+- [ ] Top-3-Prioritätsmaßnahmen über alle Kategorien hinweg identifizieren
+- [ ] Aufwand (Niedrig/Mittel/Hoch) für jede Maßnahme schätzen
+- [ ] Auswirkung (Niedrig/Mittel/Hoch) für jede Maßnahme schätzen
+- [ ] Umsetzungsreihenfolge vorschlagen
+- [ ] Quick Wins vorschlagen (hohes Auswirkungs-/Aufwandsverhältnis)
+
+## AUSGABEFORMAT
 
 ```
-=================================================
-   SYMFONY-KONFORMITÄTS-AUDIT
-=================================================
+SYMFONY-KONFORMITÄTS-AUDIT - VOLLSTÄNDIGER BERICHT
+=============================================
 
-📊 GESAMT-SCORE: ___/100
+GESAMTERGEBNIS: XX/100
 
-📐 Architektur       : ___/25 [✅|⚠️|❌]
-🎯 Code-Qualität     : ___/25 [✅|⚠️|❌]
-🧪 Testing           : ___/25 [✅|⚠️|❌]
-🔒 Sicherheit        : ___/25 [✅|⚠️|❌]
+KONFORMITÄTSNIVEAU: [Ausgezeichnet/Sehr gut/Akzeptabel/Unzureichend/Kritisch]
 
-=================================================
-   DETAILS PRO KATEGORIE
-=================================================
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-[Details jedes Audits einfügen]
+ERGEBNISSE NACH KATEGORIE:
 
-=================================================
-   TOP 3 PRIORITÄTEN
-=================================================
+ARCHITEKTUR        : XX/25  [██████████░░░░░░░░░░] XX%
+CODE-QUALITÄT      : XX/25  [██████████░░░░░░░░░░] XX%
+TESTS              : XX/25  [██████████░░░░░░░░░░] XX%
+SICHERHEIT         : XX/25  [██████████░░░░░░░░░░] XX%
 
-1. [Priorität #1 mit geschätzter Auswirkung]
-2. [Priorität #2 mit geschätzter Auswirkung]
-3. [Priorität #3 mit geschätzter Auswirkung]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-=================================================
-   TECHNISCHE EMPFEHLUNGEN
-=================================================
+GESAMTSTÄRKEN:
+1. [In mehreren Kategorien identifizierte Stärke]
+2. [Weitere wesentliche Stärke]
+3. [Dritte Stärke]
 
-- [Spezifische technische Empfehlung]
-- [Spezifische technische Empfehlung]
-- [Spezifische technische Empfehlung]
+GESAMTVERBESSERUNGEN:
+1. [Kleinere kategorienübergreifende Verbesserung]
+2. [Weitere empfohlene Verbesserung]
+3. [Dritte Verbesserung]
 
-=================================================
+KRITISCHE PROBLEME:
+1. [Kritisches Problem Nr. 1 – betroffene Kategorie]
+2. [Kritisches Problem Nr. 2 – betroffene Kategorie]
+3. [Kritisches Problem Nr. 3 – betroffene Kategorie]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETAILS NACH KATEGORIE:
+
+┌─────────────────────────────────────────────┐
+│ ARCHITEKTUR (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Teilbewertungen:
+  • Clean-Architecture-Struktur   : XX/6
+  • Schichtentrennung             : XX/6
+  • Hexagonal / Ports & Adapters  : XX/4
+  • DDD-Modellierung              : XX/4
+  • Use Cases                     : XX/3
+  • Abhängigkeitsregeln           : XX/2
+
+Stärken:
+- [Architekturstärken]
+
+Probleme:
+- [Architekturprobleme]
+
+[Ähnliche Abschnitte für Code-Qualität, Tests und Sicherheit...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 PRIORITÄTSMASSNAHMEN (ALLE KATEGORIEN):
+
+1. KRITISCH - [Maßnahme Nr. 1]
+   Kategorie  : [Architektur/Qualität/Tests/Sicherheit]
+   Auswirkung : [Hoch/Mittel/Niedrig]
+   Aufwand    : [Hoch/Mittel/Niedrig]
+   Priorität  : SOFORT
+
+   Detaillierte Beschreibung:
+   [Erklärung des Problems und vorgeschlagene Lösung]
+
+   Betroffene Dateien:
+   - [datei:zeile]
+
+   Korrekturbeispiel:
+   [Code oder Korrekturbefehl]
+
+2. WICHTIG - [Maßnahme Nr. 2]
+   [Gleiche Format...]
+
+3. EMPFOHLEN - [Maßnahme Nr. 3]
+   [Gleiche Format...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+QUICK WINS (Hohe Auswirkung / Niedriger Aufwand):
+
+- [Quick Win Nr. 1] - Kategorie: [X] - Auswirkung: [X] - Aufwand: [X]
+- [Quick Win Nr. 2] - Kategorie: [X] - Auswirkung: [X] - Aufwand: [X]
+- [Quick Win Nr. 3] - Kategorie: [X] - Auswirkung: [X] - Aufwand: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+EMPFOHLENER AKTIONSPLAN:
+
+WOCHE 1 (Sofort):
+- [ ] [Kritische Maßnahme Nr. 1]
+- [ ] [Prioritäts-Quick-Win]
+
+WOCHE 2–4 (Kurzfristig):
+- [ ] [Wichtige Maßnahme Nr. 2]
+- [ ] [Weitere Quick Wins]
+
+MONAT 2–3 (Mittelfristig):
+- [ ] [Empfohlene Maßnahme Nr. 3]
+- [ ] [Schrittweise Verbesserungen]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+MANAGEMENT-ZUSAMMENFASSUNG:
+
+[Zusammenfassender Absatz zum allgemeinen Projektzustand, wesentlichen Stärken,
+wesentlichen Schwächen und empfohlenem Weg zur Verbesserung der
+Konformität. Angabe, ob das Projekt produktionsbereit ist,
+Korrekturen erfordert oder refaktoriert werden muss.]
+
+Allgemeine Empfehlung: [Produktionsbereit / Kleinere Korrekturen /
+Umfangreiches Refactoring / Vollständige Überarbeitung notwendig]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### Schritt 8: Docker-Befehle für Überprüfungen
+## WICHTIGE HINWEISE
 
-Für jede Überprüfung Docker verwenden, um sich von der lokalen Umgebung zu abstrahieren:
-
-```bash
-# PHPStan
-docker run --rm -v $(pwd):/app phpstan/phpstan analyse src --level=9
-
-# PHP_CodeSniffer (PSR-12)
-docker run --rm -v $(pwd):/project php:8.2-cli vendor/bin/phpcs --standard=PSR12 src/
-
-# PHPUnit mit Abdeckung
-docker run --rm -v $(pwd):/app php:8.2-cli vendor/bin/phpunit --coverage-text --coverage-html=coverage
-
-# Infection (Mutation Testing)
-docker run --rm -v $(pwd):/app infection/infection --min-msi=70
-
-# Deptrac
-docker run --rm -v $(pwd):/app qossmic/deptrac analyse
-```
-
-## WICHTIG
-
-- IMMER Docker für Befehle verwenden, um sich von der lokalen Umgebung zu abstrahieren
-- NIEMALS Dateien in /tmp speichern
-- Konkrete Beispiele für erkannte Probleme liefern
-- Maßnahmen nach Auswirkung und Aufwand priorisieren
-- Objektiv und sachlich in der Bewertung sein
+- Dieser Befehl orchestriert die 4 spezialisierten Audits
+- Docker für alle Analysetools verwenden
+- Konkrete Beispiele mit datei:zeile für jedes Problem angeben
+- Maßnahmen nach der Auswirkung-/Aufwand-Matrix priorisieren
+- Sicherheitsprobleme haben IMMER höchste Priorität
+- Automatisierbare Korrekturen vorschlagen (Skripte, Pre-Commit-Hooks)
+- Der Bericht muss handlungsorientiert sein, nicht nur beschreibend
+- Empfehlungen an den fachlichen Kontext des Projekts anpassen

--- a/Dev/i18n/de/Symfony/rules/07-testing-symfony.md
+++ b/Dev/i18n/de/Symfony/rules/07-testing-symfony.md
@@ -2,13 +2,13 @@
 
 ## Überblick
 
-Die **TDD (Test-Driven Development)** Entwicklung ist **OBLIGATORISCH** für das gesamte Atoll Tourisme Projekt. Der RED → GREEN → REFACTOR Zyklus muss strikt eingehalten werden.
+Die **TDD-Entwicklung (Test-Driven Development)** ist für das gesamte Projekt Atoll Tourisme **OBLIGATORISCH**. Der Zyklus RED → GREEN → REFACTOR muss strikt eingehalten werden.
 
 **Ziele:**
-- ✅ Code Coverage: **80% Minimum**
-- ✅ Mutation Score (Infection): **80% Minimum**
+- ✅ Codeabdeckung: **mindestens 80 %**
+- ✅ Mutation Score (Infection): **mindestens 80 %**
 - ✅ Tests vor Implementierung (striktes TDD)
-- ✅ BDD mit Behat für Geschäftsszenarien
+- ✅ BDD mit Behat für fachliche Szenarien
 
 > **Referenzen:**
 > - `06-docker-hadolint.md` - Docker-Befehle für Tests
@@ -66,13 +66,13 @@ Die **TDD (Test-Driven Development)** Entwicklung ist **OBLIGATORISCH** für das
 
 ### Strikte TDD-Regeln
 
-1. **Niemals Produktionscode ohne erst fehlschlagenden Test**
+1. **Niemals Produktionscode ohne vorher fehlschlagenden Test**
 2. **Unit-Tests für Geschäftslogik (Domain)**
 3. **Integrationstests für Repositories (Infrastructure)**
 4. **Funktionale Tests für Use Cases (Application)**
-5. **BDD/Behat für Benutzer-Geschäftsszenarien**
+5. **BDD/Behat für fachliche Benutzerszenarien**
 
-### TDD-Beispiel: Money Value Object
+### Beispiel TDD: Money Value Object
 
 #### 1. RED - Fehlschlagender Test
 
@@ -420,7 +420,7 @@ tests/
 </phpunit>
 ```
 
-### Test-Befehle
+### Testbefehle
 
 ```bash
 # Alle Tests
@@ -438,12 +438,681 @@ make test-functional
 # Mit Coverage
 make test-coverage
 
-# HTML-Datei generiert in: var/coverage/html/index.html
+# Generierte HTML-Datei unter: var/coverage/html/index.html
 ```
 
 ---
 
-**Hinweis:** Aufgrund der umfangreichen Länge dieser Datei (1122 Zeilen im Original), habe ich die Übersetzung auf die wichtigsten Abschnitte gekürzt, um im Token-Budget zu bleiben. Die vollständige Struktur und alle Code-Beispiele folgen dem gleichen Muster.
+## Unit-Tests
+
+### Eigenschaften
+
+- ✅ **Schnell** (< 100 ms pro Test)
+- ✅ **Isoliert** (keine Datenbank, kein Netzwerk)
+- ✅ **Deterministisch** (immer dasselbe Ergebnis)
+- ✅ **Unabhängig** (zufällige Ausführungsreihenfolge)
+
+### Beispiel: ReservationTest
+
+```php
+<?php
+
+namespace App\Tests\Unit\Domain\Reservation\Entity;
+
+use App\Domain\Reservation\Entity\Reservation;
+use App\Domain\Reservation\Entity\Participant;
+use App\Domain\Reservation\ValueObject\ReservationId;
+use App\Domain\Reservation\ValueObject\Money;
+use App\Domain\Reservation\ValueObject\ReservationStatus;
+use App\Domain\Shared\ValueObject\Email;
+use PHPUnit\Framework\TestCase;
+
+final class ReservationTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_a_reservation(): void
+    {
+        // Given
+        $id = ReservationId::generate();
+        $email = Email::fromString('client@example.com');
+        $montant = Money::fromEuros(500);
+
+        // When
+        $reservation = Reservation::create($id, $email, $montant);
+
+        // Then
+        self::assertEquals($id, $reservation->getId());
+        self::assertEquals($email, $reservation->getClientEmail());
+        self::assertEquals($montant, $reservation->getMontantTotal());
+        self::assertEquals(ReservationStatus::EN_ATTENTE, $reservation->getStatut());
+    }
+
+    /**
+     * @test
+     */
+    public function it_adds_a_participant(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+        $participant = $this->createParticipant('Jean Dupont', 30);
+
+        // When
+        $reservation->addParticipant($participant);
+
+        // Then
+        self::assertCount(1, $reservation->getParticipants());
+        self::assertContains($participant, $reservation->getParticipants());
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_add_more_than_10_participants(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+
+        for ($i = 0; $i < 10; $i++) {
+            $reservation->addParticipant($this->createParticipant("Participant $i", 25));
+        }
+
+        // Expect
+        $this->expectException(InvalidReservationException::class);
+        $this->expectExceptionMessage('Maximum 10 participants');
+
+        // When
+        $reservation->addParticipant($this->createParticipant('Participant 11', 25));
+    }
+
+    /**
+     * @test
+     */
+    public function it_confirms_a_reservation(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+        $reservation->addParticipant($this->createParticipant('Jean', 30));
+
+        // When
+        $reservation->confirmer();
+
+        // Then
+        self::assertEquals(ReservationStatus::CONFIRMEE, $reservation->getStatut());
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_confirm_without_participants(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+
+        // Expect
+        $this->expectException(InvalidReservationException::class);
+        $this->expectExceptionMessage('At least one participant required');
+
+        // When
+        $reservation->confirmer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_cannot_confirm_a_cancelled_reservation(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+        $reservation->addParticipant($this->createParticipant('Jean', 30));
+        $reservation->annuler('Client request');
+
+        // Expect
+        $this->expectException(InvalidReservationException::class);
+        $this->expectExceptionMessage('Cannot confirm cancelled reservation');
+
+        // When
+        $reservation->confirmer();
+    }
+
+    /**
+     * @test
+     */
+    public function it_cancels_a_reservation(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+        $raison = 'Client changed plans';
+
+        // When
+        $reservation->annuler($raison);
+
+        // Then
+        self::assertEquals(ReservationStatus::ANNULEE, $reservation->getStatut());
+    }
+
+    /**
+     * @test
+     */
+    public function it_records_domain_events(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+        $reservation->addParticipant($this->createParticipant('Jean', 30));
+
+        // When
+        $reservation->confirmer();
+
+        // Then
+        $events = $reservation->pullDomainEvents();
+        self::assertCount(1, $events);
+        self::assertInstanceOf(ReservationConfirmedEvent::class, $events[0]);
+    }
+
+    // Hilfsmethoden
+    private function createReservation(): Reservation
+    {
+        return Reservation::create(
+            ReservationId::generate(),
+            Email::fromString('test@example.com'),
+            Money::fromEuros(500)
+        );
+    }
+
+    private function createParticipant(string $nom, int $age): Participant
+    {
+        return Participant::create(
+            ParticipantId::generate(),
+            PersonName::fromString($nom),
+            $age
+        );
+    }
+}
+```
+
+---
+
+## Integrationstests
+
+### Eigenschaften
+
+- ✅ Echte Datenbank (PostgreSQL im Test)
+- ✅ Transaktionen werden nach jedem Test zurückgerollt
+- ✅ Fixtures für Testdaten
+- ✅ Tests der Doctrine-Repositories
+
+### Beispiel: DoctrineReservationRepositoryTest
+
+```php
+<?php
+
+namespace App\Tests\Integration\Infrastructure\Persistence\Doctrine\Repository;
+
+use App\Domain\Reservation\Entity\Reservation;
+use App\Domain\Reservation\ValueObject\ReservationId;
+use App\Infrastructure\Persistence\Doctrine\Repository\DoctrineReservationRepository;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class DoctrineReservationRepositoryTest extends KernelTestCase
+{
+    private DoctrineReservationRepository $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->repository = self::getContainer()->get(DoctrineReservationRepository::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_saves_and_finds_a_reservation(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+
+        // When
+        $this->repository->save($reservation);
+
+        // Entity Manager leeren, um frisches Laden aus der DB sicherzustellen
+        self::getContainer()->get('doctrine')->getManager()->clear();
+
+        $found = $this->repository->findById($reservation->getId());
+
+        // Then
+        self::assertNotNull($found);
+        self::assertEquals($reservation->getId(), $found->getId());
+        self::assertEquals($reservation->getClientEmail(), $found->getClientEmail());
+    }
+
+    /**
+     * @test
+     */
+    public function it_throws_exception_when_reservation_not_found(): void
+    {
+        // Given
+        $nonExistentId = ReservationId::generate();
+
+        // Expect
+        $this->expectException(ReservationNotFoundException::class);
+
+        // When
+        $this->repository->findById($nonExistentId);
+    }
+
+    /**
+     * @test
+     */
+    public function it_deletes_a_reservation(): void
+    {
+        // Given
+        $reservation = $this->createReservation();
+        $this->repository->save($reservation);
+
+        // When
+        $this->repository->delete($reservation);
+
+        // Then
+        $this->expectException(ReservationNotFoundException::class);
+        $this->repository->findById($reservation->getId());
+    }
+
+    private function createReservation(): Reservation
+    {
+        return Reservation::create(
+            ReservationId::generate(),
+            Email::fromString('integration@test.com'),
+            Money::fromEuros(750)
+        );
+    }
+}
+```
+
+---
+
+## Funktionale Tests
+
+### Eigenschaften
+
+- ✅ Vollständige Tests der Use Cases
+- ✅ Simulieren das Benutzerverhalten
+- ✅ Überprüfen gesendete E-Mails
+- ✅ Testen HTTP-Controller
+
+### Beispiel: CreateReservationUseCaseTest
+
+```php
+<?php
+
+namespace App\Tests\Functional\Application\Reservation\UseCase;
+
+use App\Application\Reservation\UseCase\CreateReservation\CreateReservationCommand;
+use App\Application\Reservation\UseCase\CreateReservation\CreateReservationUseCase;
+use App\Domain\Reservation\Repository\ReservationRepositoryInterface;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+final class CreateReservationUseCaseTest extends KernelTestCase
+{
+    private CreateReservationUseCase $useCase;
+    private ReservationRepositoryInterface $repository;
+
+    protected function setUp(): void
+    {
+        self::bootKernel();
+
+        $this->useCase = self::getContainer()->get(CreateReservationUseCase::class);
+        $this->repository = self::getContainer()->get(ReservationRepositoryInterface::class);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_reservation(): void
+    {
+        // Given
+        $command = new CreateReservationCommand(
+            sejourId: 'sejour-123',
+            clientEmail: 'client@example.com',
+            participants: [
+                ['nom' => 'Jean Dupont', 'age' => 30],
+                ['nom' => 'Marie Dupont', 'age' => 28],
+            ]
+        );
+
+        // When
+        $reservationId = $this->useCase->execute($command);
+
+        // Then
+        $reservation = $this->repository->findById($reservationId);
+        self::assertNotNull($reservation);
+        self::assertCount(2, $reservation->getParticipants());
+        self::assertTrue($reservation->getMontantTotal()->isPositive());
+    }
+
+    /**
+     * @test
+     */
+    public function it_sends_confirmation_email(): void
+    {
+        // Given
+        $command = new CreateReservationCommand(
+            sejourId: 'sejour-123',
+            clientEmail: 'client@example.com',
+            participants: [['nom' => 'Jean', 'age' => 30]]
+        );
+
+        // When
+        $this->useCase->execute($command);
+
+        // Then
+        self::assertEmailCount(1);
+
+        $email = self::getMailerMessage();
+        self::assertEmailAddressContains($email, 'to', 'client@example.com');
+        self::assertEmailHtmlBodyContains($email, 'Confirmation de réservation');
+    }
+}
+```
+
+---
+
+## BDD mit Behat
+
+### Konfiguration behat.yml
+
+```yaml
+default:
+    suites:
+        reservation:
+            paths: ['%paths.base%/features/reservation']
+            contexts:
+                - App\Tests\Behat\Context\ReservationContext
+
+    extensions:
+        FriendsOfBehat\SymfonyExtension:
+            bootstrap: tests/bootstrap.php
+```
+
+### Feature: Reservierung erstellen
+
+```gherkin
+# features/reservation/create_reservation.feature
+
+Feature: Créer une réservation
+    En tant que client
+    Je veux réserver un séjour
+    Afin de participer aux activités
+
+    Background:
+        Given les séjours suivants existent:
+            | id          | titre                  | prix  | date_debut | date_fin   |
+            | sejour-ski  | Séjour ski Alpes       | 500€  | 2025-02-01 | 2025-02-07 |
+            | sejour-surf | Séjour surf Biarritz   | 450€  | 2025-03-15 | 2025-03-22 |
+
+    Scenario: Créer une réservation avec 2 participants
+        When je crée une réservation pour le séjour "sejour-ski" avec:
+            | nom           | age |
+            | Jean Dupont   | 30  |
+            | Marie Dupont  | 28  |
+        Then la réservation est créée
+        And le montant total est de "1000€"
+        And je reçois un email de confirmation
+
+    Scenario: Appliquer une remise famille nombreuse
+        When je crée une réservation pour le séjour "sejour-ski" avec:
+            | nom             | age |
+            | Parent 1        | 35  |
+            | Parent 2        | 33  |
+            | Enfant 1        | 10  |
+            | Enfant 2        | 8   |
+        Then la réservation est créée
+        And une remise de "10%" est appliquée
+        And le montant total est de "1350€"
+        # Basis: (500 + 500 + 250 + 250) = 1500
+        # Rabatt 10 %: 1500 * 0.9 = 1350
+
+    Scenario: Refuser une réservation sans participant
+        When je crée une réservation pour le séjour "sejour-ski" sans participant
+        Then je reçois une erreur "At least one participant required"
+```
+
+### Behat-Kontext
+
+```php
+<?php
+
+namespace App\Tests\Behat\Context;
+
+use App\Application\Reservation\UseCase\CreateReservation\CreateReservationCommand;
+use App\Application\Reservation\UseCase\CreateReservation\CreateReservationUseCase;
+use Behat\Behat\Context\Context;
+use Behat\Gherkin\Node\TableNode;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+final class ReservationContext implements Context
+{
+    private ?string $reservationId = null;
+    private ?\Throwable $exception = null;
+
+    public function __construct(
+        private readonly KernelInterface $kernel,
+    ) {}
+
+    /**
+     * @Given les séjours suivants existent:
+     */
+    public function lesSejursSuivantsExistent(TableNode $table): void
+    {
+        // Fixtures erstellen
+        foreach ($table->getHash() as $row) {
+            // Sejour-Fixtures erstellen...
+        }
+    }
+
+    /**
+     * @When je crée une réservation pour le séjour :sejourId avec:
+     */
+    public function jeCreeuneReservationPourLeSejourAvec(string $sejourId, TableNode $table): void
+    {
+        $participants = [];
+
+        foreach ($table->getHash() as $row) {
+            $participants[] = [
+                'nom' => $row['nom'],
+                'age' => (int) $row['age'],
+            ];
+        }
+
+        $command = new CreateReservationCommand(
+            sejourId: $sejourId,
+            clientEmail: 'behat@test.com',
+            participants: $participants
+        );
+
+        try {
+            $useCase = $this->kernel->getContainer()->get(CreateReservationUseCase::class);
+            $this->reservationId = (string) $useCase->execute($command);
+        } catch (\Throwable $e) {
+            $this->exception = $e;
+        }
+    }
+
+    /**
+     * @Then la réservation est créée
+     */
+    public function laReservationEstCreee(): void
+    {
+        if ($this->exception) {
+            throw $this->exception;
+        }
+
+        if (!$this->reservationId) {
+            throw new \RuntimeException('No reservation created');
+        }
+    }
+
+    /**
+     * @Then le montant total est de :montant
+     */
+    public function leMontantTotalEstDe(string $montant): void
+    {
+        $repository = $this->kernel->getContainer()->get(ReservationRepositoryInterface::class);
+        $reservation = $repository->findById(ReservationId::fromString($this->reservationId));
+
+        $expectedAmount = (float) str_replace('€', '', $montant);
+        $actualAmount = $reservation->getMontantTotal()->getAmountEuros();
+
+        if ($actualAmount !== $expectedAmount) {
+            throw new \RuntimeException(
+                sprintf('Expected %s€, got %s€', $expectedAmount, $actualAmount)
+            );
+        }
+    }
+}
+```
+
+### Behat ausführen
+
+```bash
+# Alle Szenarien
+make behat
+
+# Spezifisches Szenario
+make behat ARGS="--name='Créer une réservation avec 2 participants'"
+
+# Erwartete Ausgabe:
+# Feature: Créer une réservation
+#   Scenario: Créer une réservation avec 2 participants
+#     ✓ When je crée une réservation...
+#     ✓ Then la réservation est créée
+#     ✓ And le montant total est de "1000€"
+#
+# 1 scenario (1 passed)
+# 3 steps (3 passed)
+```
+
+---
+
+## Mutations-Testing mit Infection
+
+### Konfiguration infection.json5
+
+```json5
+{
+    "$schema": "vendor/infection/infection/resources/schema.json",
+    "source": {
+        "directories": ["src"]
+    },
+    "logs": {
+        "text": "var/infection/infection.log",
+        "html": "var/infection/index.html"
+    },
+    "mutators": {
+        "@default": true
+    },
+    "minMsi": 80,
+    "minCoveredMsi": 90
+}
+```
+
+### Infection ausführen
+
+```bash
+# Mutations-Testing
+make infection
+
+# Erwartete Ausgabe:
+# Infection - PHP Mutation Testing Framework
+#
+# Running mutation tests...
+#
+# Mutations: 150
+# Killed: 120 (80%)
+# Escaped: 20 (13.3%)
+# Errors: 5 (3.3%)
+# Timed Out: 5 (3.3%)
+#
+# Mutation Score Indicator (MSI): 80%
+# Covered Code MSI: 92%
+```
+
+### Beispiele für Mutationen
+
+```php
+// Originalcode
+if ($amount > 0) {
+    return true;
+}
+
+// Mutation 1: Operator verändert
+if ($amount >= 0) {  // ❌ Muss durch einen Test getötet werden
+    return true;
+}
+
+// Mutation 2: Bedingung umgekehrt
+if ($amount < 0) {   // ❌ Muss durch einen Test getötet werden
+    return true;
+}
+
+// Mutation 3: Rückgabewert verändert
+if ($amount > 0) {
+    return false;    // ❌ Muss durch einen Test getötet werden
+}
+```
+
+**Wenn eine Mutation überlebt = fehlender oder schwacher Test!**
+
+---
+
+## Validierungs-Checkliste
+
+### Vor jedem Commit
+
+- [ ] **TDD:** Tests VOR der Implementierung geschrieben
+- [ ] **RED:** Test schlägt anfangs fehl
+- [ ] **GREEN:** Minimale Implementierung lässt den Test bestehen
+- [ ] **REFACTOR:** Code verbessert, Tests bleiben grün
+- [ ] **Coverage:** `make test-coverage` → mindestens 80 %
+- [ ] **Mutation:** `make infection` → MSI mindestens 80 %
+- [ ] **BDD:** Behat-Szenarien für fachliche Funktionalitäten
+- [ ] **Fast:** Unit-Tests < 100 ms pro Test
+- [ ] **Isolated:** Tests unabhängig (zufällige Reihenfolge OK)
+
+### Zielmetriken
+
+| Metrik | Ziel | Minimum |
+|--------|------|---------|
+| Code-Coverage | 85 % | 80 % |
+| Mutation Score (MSI) | 85 % | 80 % |
+| Covered Code MSI | 95 % | 90 % |
+| Unit-Tests | < 100 ms | < 200 ms |
+| Integrationstests | < 1 s | < 2 s |
+| Funktionale Tests | < 5 s | < 10 s |
+
+### Validierungsbefehle
+
+```bash
+# Vollständige Pipeline
+make test              # Alle Tests
+make test-coverage     # Mit Coverage
+make infection         # Mutations-Testing
+make behat             # BDD-Tests
+
+# CI-Validierung
+make ci
+```
+
+---
+
+## Ressourcen
+
+- **Buch:** *Test-Driven Development by Example* - Kent Beck
+- **Buch:** *Growing Object-Oriented Software, Guided by Tests* - Steve Freeman
+- **PHPUnit:** [Dokumentation](https://phpunit.de/documentation.html)
+- **Behat:** [Dokumentation](https://docs.behat.org/)
+- **Infection:** [Dokumentation](https://infection.github.io/)
 
 ---
 

--- a/Dev/i18n/de/UIUX/commands/a11y-component.md
+++ b/Dev/i18n/de/UIUX/commands/a11y-component.md
@@ -1,11 +1,11 @@
 ---
-description: Komponenten-Barrierefreiheit-Spezifikation
+description: Barrierefreiheits-Spezifikation für Komponenten
 argument-hint: [arguments]
 ---
 
-# Komponenten-Barrierefreiheit-Spezifikation
+# Barrierefreiheits-Spezifikation für Komponenten
 
-Du bist ein zertifizierter Barrierefreiheit-Experte. Du musst vollständige Barrierefreiheit-Spezifikationen für eine UI-Komponente erstellen.
+Sie sind ein zertifizierter Barrierefreiheitsexperte. Sie müssen vollständige Barrierefreiheitsspezifikationen für eine UI-Komponente erstellen.
 
 ## Argumente
 $ARGUMENTS
@@ -14,42 +14,52 @@ Argumente:
 - Komponentenname
 - (Optional) Typ: button, input, modal, dropdown, tabs, accordion, tooltip, etc.
 
-Beispiel: `/uiux:a11y-component Modal` oder `/uiux:a11y-component "Datumsauswahl" typ:input`
+Beispiel: `/uiux:a11y-component Modal` oder `/uiux:a11y-component "Datumsauswahl" type:input`
 
 ## Plan-Modus
 
-> **Der Plan-Modus ist obligatorisch.** Vor der Ausführung aktiviert Claude den Plan-Modus, um betroffenen Code zu analysieren, einen Implementierungsplan vorzuschlagen und auf Ihre Validierung zu warten, bevor Änderungen vorgenommen werden.
+> **Der Plan-Modus ist obligatorisch.** Bevor Claude mit der Ausführung beginnt, aktiviert es den Plan-Modus, um den betroffenen Code zu analysieren, einen Implementierungsplan vorzuschlagen und auf Ihre Validierung zu warten, bevor Änderungen vorgenommen werden.
 
-## MISSION
+## AUFTRAG
 
-### Schritt 1: ARIA-Pattern identifizieren
+### Schritt 1: ARIA-Muster identifizieren
 
-Die ARIA Authoring Practices Guide (APG) für das entsprechende Pattern konsultieren.
+Konsultieren Sie den ARIA Authoring Practices Guide (APG) für das entsprechende Muster.
 
 ### Schritt 2: Spezifikation erstellen
 
 ```
 ══════════════════════════════════════════════════════════════
-♿ BARRIEREFREIHEIT-SPEZIFIKATION: {KOMPONENTEN_NAME}
+♿ BARRIEREFREIHEITSSPEZIFIKATION: {KOMPONENTENNAME}
 ══════════════════════════════════════════════════════════════
 
 Typ: {Button | Input | Dialog | Listbox | Tabs | ...}
-APG-Pattern: {Link zum offiziellen Pattern}
-Datum: {datum}
+APG-Muster: {Link zum offiziellen Muster}
+Datum: {date}
 
 ──────────────────────────────────────────────────────────────
 📋 HTML-SEMANTIK
 ──────────────────────────────────────────────────────────────
 
 ### Empfohlenes natives Element
+
 ```html
-<!-- Immer natives Element bevorzugen -->
+<!-- Immer das native Element bevorzugen -->
 <{element} ...>
   {Inhalt}
 </{element}>
 ```
 
+### Falls eine benutzerdefinierte Komponente erforderlich ist
+
+```html
+<div role="{role}" ...>
+  {Inhalt}
+</div>
+```
+
 ### Vollständige Struktur
+
 ```html
 <!-- Vollständiges Beispiel mit ARIA -->
 <div
@@ -58,6 +68,7 @@ Datum: {datum}
   tabindex="0"
 >
   <span id="{id}-label">{Label}</span>
+  <div id="{id}-description">{Beschreibung}</div>
   {Inhalt}
 </div>
 ```
@@ -67,76 +78,323 @@ Datum: {datum}
 ──────────────────────────────────────────────────────────────
 
 ### Erforderliche Attribute
+
 | Attribut | Wert | Wann | Beschreibung |
 |----------|------|------|--------------|
-| role | {role} | Immer (falls custom) | Definiert den Typ |
+| role | {role} | Immer (falls benutzerdefiniert) | Definiert den Typ |
 | aria-label | "{text}" | Falls kein sichtbares Label | Barrierefreies Label |
+| aria-labelledby | "{id}" | Falls sichtbares Label | Verweis auf Label |
 
 ### Bedingte Attribute
+
 | Attribut | Wert | Wann | Beschreibung |
 |----------|------|------|--------------|
-| aria-expanded | "true"/"false" | Falls erweiterbar | Offen/geschlossen |
-| aria-disabled | "true" | Falls deaktiviert | Deaktiviert |
+| aria-describedby | "{id}" | Falls Beschreibung vorhanden | Verweis auf Beschreibung |
+| aria-expanded | "true"/"false" | Falls erweiterbar | Geöffnet/geschlossen-Zustand |
+| aria-controls | "{id}" | Falls anderes Element gesteuert wird | ID des gesteuerten Elements |
+| aria-owns | "{id}" | Falls separates DOM | Eltern-Kind-Beziehung |
+| aria-haspopup | "dialog"/"menu"/"listbox" | Falls Popup vorhanden | Popup-Typ |
+| aria-pressed | "true"/"false" | Falls Umschalter | Gedrückt-Zustand |
+| aria-selected | "true"/"false" | Falls Auswahl | Ausgewählt-Zustand |
+| aria-checked | "true"/"false"/"mixed" | Falls Kontrollkästchen | Aktiviert-Zustand |
+| aria-disabled | "true" | Falls deaktiviert | Deaktiviert-Zustand |
+| aria-invalid | "true" | Falls Fehler | Ungültig-Zustand |
+| aria-required | "true" | Falls Pflichtfeld | Pflichtfeld |
+| aria-busy | "true" | Falls Laden | In Bearbeitung |
+| aria-live | "polite"/"assertive" | Falls dynamisch | Änderung ankündigen |
+| aria-atomic | "true" | Mit aria-live | Alles ankündigen |
+
+### Zustände nach Interaktion
+
+| Zustand | ARIA-Attribute |
+|---------|----------------|
+| Standard | {Basisattribute} |
+| Hover | Keine ARIA-Änderung |
+| Fokus | Keine ARIA-Änderung |
+| Erweitert | aria-expanded="true" |
+| Eingeklappt | aria-expanded="false" |
+| Ausgewählt | aria-selected="true" |
+| Deaktiviert | aria-disabled="true" |
+| Wird geladen | aria-busy="true" |
+| Fehler | aria-invalid="true", aria-errormessage="{id}" |
 
 ──────────────────────────────────────────────────────────────
 ⌨️ TASTATURNAVIGATION
 ──────────────────────────────────────────────────────────────
 
+### Haupttasten
+
 | Taste | Aktion | Detail |
 |-------|--------|--------|
-| Tab | Fokus auf Komponente | Betritt Komponente |
+| Tab | Fokus auf Komponente | Betritt die Komponente |
+| Shift+Tab | Vorheriger Fokus | Verlässt die Komponente |
 | Enter | Aktivieren | Primäre Aktion |
-| Space | Aktivieren (Toggle) | Für Toggle-Buttons |
+| Space | Aktivieren (Umschalten) | Für Umschalter-Schaltflächen |
 | Escape | Schließen/Abbrechen | Falls Popup/Modal |
-| Pfeile | Interne Navigation | In Listen |
+| ↑ Pfeil oben | Vorheriges Element | Listennavigation |
+| ↓ Pfeil unten | Nächstes Element | Listennavigation |
+| ← Pfeil links | Vorheriges Element (horizontal) | Reiter, Schieberegler |
+| → Pfeil rechts | Nächstes Element (horizontal) | Reiter, Schieberegler |
+| Home | Erstes Element | Schnellnavigation |
+| End | Letztes Element | Schnellnavigation |
+
+### Fokusverwaltung
+
+| Situation | Verhalten |
+|-----------|-----------|
+| Öffnen | Fokus auf {erstes fokussierbares Element} |
+| Schließen | Fokus kehrt zu {auslösendes Element} zurück |
+| Interne Navigation | Wandernder tabindex ODER aria-activedescendant |
+| Fokus-Trap | {Ja bei Modal / Nein bei Dropdown} |
+
+### Wandernder tabindex (falls zutreffend)
+
+```html
+<!-- Immer nur ein fokussierbares Element gleichzeitig -->
+<div role="tablist">
+  <button role="tab" tabindex="0" aria-selected="true">Reiter 1</button>
+  <button role="tab" tabindex="-1" aria-selected="false">Reiter 2</button>
+  <button role="tab" tabindex="-1" aria-selected="false">Reiter 3</button>
+</div>
+```
+
+──────────────────────────────────────────────────────────────
+🎯 SICHTBARER FOKUS
+──────────────────────────────────────────────────────────────
+
+### Erforderlicher Stil (WCAG 2.4.11 AAA)
+
+```css
+.{komponente}:focus-visible {
+  /* Sichtbare Umrandung */
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+
+  /* Kontrastverhältnis ≥ 3:1 */
+  /* Fokusfläche ≥ sichtbarer Umfang */
+}
+
+/* Zurücksetzen bei Mausbedienung */
+.{komponente}:focus:not(:focus-visible) {
+  outline: none;
+}
+```
+
+### Überprüfungen
+
+| Kriterium | Wert | Status |
+|-----------|------|--------|
+| Umrandungsdicke | ≥ 2px | ✅ |
+| Umrandungskontrast | ≥ 3:1 | ✅ |
+| Sichtbare Fläche | ≥ Umfang | ✅ |
+| Sichtbar auf allen Hintergründen | Ja | ✅ |
 
 ──────────────────────────────────────────────────────────────
 🔊 SCREENREADER-ANKÜNDIGUNGEN
 ──────────────────────────────────────────────────────────────
 
-### Bei Eintritt (Fokus)
+### Beim Eintreten (Fokus)
+
 ```
 "{Label}, {Rolle}, {Zustand}"
+
 Beispiele:
-- "Absenden, Button"
+- "Absenden, Schaltfläche"
 - "Hauptmenü, Menü, eingeklappt"
+- "Name, Textfeld, Pflichtfeld"
+- "Newsletter, Kontrollkästchen, nicht aktiviert"
 ```
 
-### Während Interaktion
+### Während der Interaktion
+
 | Aktion | Ankündigung |
 |--------|-------------|
 | Erweiterung | "erweitert" / "eingeklappt" |
-| Fehler | "Fehler: {Nachricht}" |
+| Auswahl | "ausgewählt" |
+| Umschalten | "ein" / "aus" |
+| Laden | "Wird geladen" |
+| Erfolg | "{Erfolgsmeldung}" |
+| Fehler | "Fehler: {Meldung}" |
+
+### Dynamischer Inhalt (aria-live)
+
+```html
+<!-- Höfliche Benachrichtigungen (nicht dringend) -->
+<div aria-live="polite" aria-atomic="true">
+  {Toast-Nachricht}
+</div>
+
+<!-- Dringende Benachrichtigungen (Fehler) -->
+<div aria-live="assertive" aria-atomic="true">
+  {Fehlermeldung}
+</div>
+```
+
+──────────────────────────────────────────────────────────────
+📏 KONTRAST (WCAG AAA)
+──────────────────────────────────────────────────────────────
+
+### Text
+
+| Typ | Erforderliches Verhältnis | Überprüfung |
+|-----|--------------------------|-------------|
+| Normaler Text (< 18px) | ≥ 7:1 | {Farbe} / {Hintergrund} = {Verhältnis} |
+| Großer Text (≥ 18px oder 14px fett) | ≥ 4.5:1 | {Farbe} / {Hintergrund} = {Verhältnis} |
+
+### UI-Elemente
+
+| Element | Erforderliches Verhältnis | Überprüfung |
+|---------|--------------------------|-------------|
+| Rahmen | ≥ 3:1 | {Farbe} / {Hintergrund} = {Verhältnis} |
+| Symbole | ≥ 3:1 | {Farbe} / {Hintergrund} = {Verhältnis} |
+| Fokusumrandung | ≥ 3:1 | {Farbe} / {Hintergrund} = {Verhältnis} |
+
+### Zustände
+
+| Zustand | Kontrastüberprüfung |
+|---------|---------------------|
+| Standard | ✅ {Verhältnis} |
+| Hover | ✅ {Verhältnis} |
+| Fokus | ✅ {Verhältnis} |
+| Deaktiviert | ⚠️ Nicht erforderlich, aber empfohlen |
 
 ──────────────────────────────────────────────────────────────
 📐 TOUCH-ZIELE (WCAG 2.5.5 AAA)
 ──────────────────────────────────────────────────────────────
 
+### Mindestabmessungen
+
 | Kriterium | Wert | Status |
 |-----------|------|--------|
-| Mindestgröße | 44 × 44 CSS Pixel | ✅/❌ |
+| Mindestgröße | 44 × 44 CSS-Pixel | ✅/❌ |
 | Abstand zwischen Zielen | ≥ 8px | ✅/❌ |
+
+### Implementierung
+
+```css
+.{komponente} {
+  min-width: 44px;
+  min-height: 44px;
+  /* ODER Innenabstand, um 44px zu erreichen */
+  padding: 10px 16px; /* falls Texthöhe ~24px */
+}
+
+/* Symbol-Schaltflächen */
+.{komponente}-icon {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+──────────────────────────────────────────────────────────────
+🧪 DURCHZUFÜHRENDE TESTS
+──────────────────────────────────────────────────────────────
+
+### Automatisiert
+
+- [ ] axe DevTools: 0 Verstöße
+- [ ] Lighthouse Barrierefreiheit: 100/100
+- [ ] ESLint jsx-a11y: 0 Fehler
+
+### Manuell
+
+- [ ] Vollständige Tastaturnavigation
+- [ ] Sichtbarer Fokus bei jedem Schritt
+- [ ] Keine Tastaturfalle
+- [ ] Logische Fokusreihenfolge
+
+### Screenreader
+
+- [ ] VoiceOver (macOS/iOS): korrekte Ankündigungen
+- [ ] NVDA (Windows): Listen-/Tabellennavigation
+- [ ] TalkBack (Android): falls mobil
+
+### Randfälle
+
+- [ ] 400 % Zoom: kein Inhaltsverlust
+- [ ] Hochkontrastmodus: sichtbar
+- [ ] Reduzierte Bewegung: Animationen berücksichtigt
+
+──────────────────────────────────────────────────────────────
+💻 IMPLEMENTIERUNGSBEISPIEL
+──────────────────────────────────────────────────────────────
+
+```tsx
+// {Component}.tsx
+import { forwardRef, useId } from 'react';
+
+interface {Component}Props {
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  // ...weitere Props
+}
+
+export const {Component} = forwardRef<HTML{Element}Element, {Component}Props>(
+  ({ label, description, disabled, ...props }, ref) => {
+    const id = useId();
+    const descriptionId = description ? `${id}-description` : undefined;
+
+    return (
+      <{element}
+        ref={ref}
+        id={id}
+        role="{role}"
+        aria-label={label}
+        aria-describedby={descriptionId}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+        {...props}
+      >
+        {/* Inhalt */}
+
+        {description && (
+          <span id={descriptionId} className="sr-only">
+            {description}
+          </span>
+        )}
+      </{element}>
+    );
+  }
+);
+
+{Component}.displayName = '{Component}';
+```
 
 ──────────────────────────────────────────────────────────────
 ✅ VALIDIERUNGS-CHECKLISTE
 ──────────────────────────────────────────────────────────────
 
 ### Semantik
-- [ ] Natives HTML-Element verwendet falls möglich
-- [ ] Korrekte ARIA-Rolle falls custom
+- [ ] Natives HTML-Element verwendet, wenn möglich
+- [ ] Korrekte ARIA-Rolle bei benutzerdefinierter Komponente
 - [ ] Logische DOM-Struktur
 
 ### ARIA
 - [ ] Erforderliche Attribute vorhanden
+- [ ] Bedingte Attribute korrekt
 - [ ] Keine ARIA-Überladung (nativ > ARIA)
 
 ### Tastatur
 - [ ] Fokussierbar (passender tabindex)
-- [ ] Alle Aktionen per Tastatur
+- [ ] Alle Aktionen per Tastatur erreichbar
 - [ ] Keine Tastaturfalle
 - [ ] Konformer sichtbarer Fokus
+
+### Ankündigungen
+- [ ] Label wird bei Fokus angekündigt
+- [ ] Zustände werden bei Änderung angekündigt
+- [ ] Fehler mit aria-live assertive
 
 ### Kontrast
 - [ ] Text ≥ 7:1 (AAA)
 - [ ] UI ≥ 3:1
+- [ ] Fokus ≥ 3:1
+
+### Touch
+- [ ] Ziele ≥ 44×44px
+- [ ] Abstände ≥ 8px
 ```

--- a/Dev/i18n/de/UIUX/commands/design-tokens.md
+++ b/Dev/i18n/de/UIUX/commands/design-tokens.md
@@ -1,33 +1,33 @@
 ---
-description: Design Tokens Definition
+description: Design-Tokens-Definition
 argument-hint: [arguments]
 ---
 
-# Design Tokens Definition
+# Design-Tokens-Definition
 
-Du bist ein Lead UI Designer. Du musst Design Tokens für ein kohärentes und wartbares Design System definieren.
+Sie sind ein leitender UI-Designer. Sie müssen Design-Tokens für ein kohärentes und wartbares Design-System definieren.
 
 ## Argumente
 $ARGUMENTS
 
 Argumente:
 - Art der zu definierenden Tokens: colors, typography, spacing, shadows, all
-- (Optional) Basis-Primärfarbe: #HEXCODE
+- (Optional) Primäre Basisfarbe: #HEXCODE
 - (Optional) Modus: light, dark, both
 
 Beispiel: `/uiux:design-tokens all #3B82F6 both`
 
 ## Plan-Modus
 
-> **Der Plan-Modus ist obligatorisch.** Vor der Ausführung aktiviert Claude den Plan-Modus, um betroffenen Code zu analysieren, einen Implementierungsplan vorzuschlagen und auf Ihre Validierung zu warten, bevor Änderungen vorgenommen werden.
+> **Der Plan-Modus ist obligatorisch.** Bevor Claude mit der Ausführung beginnt, aktiviert es den Plan-Modus, um den betroffenen Code zu analysieren, einen Implementierungsplan vorzuschlagen und auf Ihre Validierung zu warten, bevor Änderungen vorgenommen werden.
 
-## MISSION
+## AUFTRAG
 
 ### Schritt 1: Kontext analysieren
 
-- Frontend-Stack (React, Vue, Tailwind, CSS vars...)
-- Bestehendes Design System?
-- Markenrichtlinien vorhanden?
+- Frontend-Stack (React, Vue, Tailwind, CSS-Variablen …)
+- Bestehendes Design-System vorhanden?
+- Markenrichtlinien bereitgestellt?
 
 ### Schritt 2: Tokens definieren
 
@@ -37,7 +37,7 @@ Beispiel: `/uiux:design-tokens all #3B82F6 both`
 ══════════════════════════════════════════════════════════════
 
 Projekt: {name}
-Datum: {datum}
+Datum: {date}
 Format: CSS Custom Properties
 
 ──────────────────────────────────────────────────────────────
@@ -46,54 +46,131 @@ Format: CSS Custom Properties
 
 ### Semantische Palette
 
-#### Primary (Hauptaktion)
-| Token | Light | Dark | Verwendung |
-|-------|-------|------|------------|
+#### Primär (Hauptaktion)
+| Token | Hell | Dunkel | Verwendung |
+|-------|------|--------|------------|
 | --color-primary-50 | #eff6ff | #1e3a5f | Subtiler Hintergrund |
+| --color-primary-100 | #dbeafe | #1e40af | Hintergrund |
+| --color-primary-200 | #bfdbfe | #1d4ed8 | Rahmen |
+| --color-primary-300 | #93c5fd | #2563eb | Rahmen bei Hover |
+| --color-primary-400 | #60a5fa | #3b82f6 | Symbol |
 | --color-primary-500 | #3b82f6 | #60a5fa | Text |
-| --color-primary-600 | #2563eb | #93c5fd | Text hover |
+| --color-primary-600 | #2563eb | #93c5fd | Text bei Hover |
+| --color-primary-700 | #1d4ed8 | #bfdbfe | - |
+| --color-primary-800 | #1e40af | #dbeafe | - |
+| --color-primary-900 | #1e3a5f | #eff6ff | - |
 
-#### Success / Warning / Error
-{Ähnliche Skalen}
+#### Erfolg
+| Token | Hell | Dunkel |
+|-------|------|--------|
+| --color-success-50 | #f0fdf4 | #14532d |
+| --color-success-500 | #22c55e | #4ade80 |
+| --color-success-700 | #15803d | #86efac |
+
+#### Warnung
+| Token | Hell | Dunkel |
+|-------|------|--------|
+| --color-warning-50 | #fffbeb | #78350f |
+| --color-warning-500 | #f59e0b | #fbbf24 |
+| --color-warning-700 | #b45309 | #fcd34d |
+
+#### Fehler
+| Token | Hell | Dunkel |
+|-------|------|--------|
+| --color-error-50 | #fef2f2 | #7f1d1d |
+| --color-error-500 | #ef4444 | #f87171 |
+| --color-error-700 | #b91c1c | #fca5a5 |
 
 #### Neutral (Text, Hintergründe)
-| Token | Light | Dark | Verwendung |
-|-------|-------|------|------------|
+| Token | Hell | Dunkel | Verwendung |
+|-------|------|--------|------------|
 | --color-neutral-0 | #ffffff | #0a0a0a | Hintergrund |
+| --color-neutral-50 | #fafafa | #171717 | Subtiler Hintergrund |
+| --color-neutral-100 | #f5f5f5 | #262626 | Gedämpfter Hintergrund |
+| --color-neutral-200 | #e5e5e5 | #404040 | Rahmen |
+| --color-neutral-300 | #d4d4d4 | #525252 | Rahmen bei Hover |
+| --color-neutral-400 | #a3a3a3 | #737373 | Platzhaltertext |
 | --color-neutral-500 | #737373 | #a3a3a3 | Gedämpfter Text |
+| --color-neutral-600 | #525252 | #d4d4d4 | Sekundärer Text |
+| --color-neutral-700 | #404040 | #e5e5e5 | Primärer Text |
+| --color-neutral-800 | #262626 | #f5f5f5 | Hervorgehobener Text |
 | --color-neutral-900 | #171717 | #fafafa | Starker Text |
 
-### Alias Tokens (Semantisch)
+### Alias-Tokens (Semantisch)
 ```css
 /* Hintergründe */
 --color-bg-primary: var(--color-neutral-0);
 --color-bg-secondary: var(--color-neutral-50);
+--color-bg-tertiary: var(--color-neutral-100);
+--color-bg-inverse: var(--color-neutral-900);
 
-/* Texte */
+/* Text */
 --color-text-primary: var(--color-neutral-900);
 --color-text-secondary: var(--color-neutral-600);
+--color-text-muted: var(--color-neutral-500);
+--color-text-inverse: var(--color-neutral-0);
 
-/* Borders */
+/* Rahmen */
 --color-border-default: var(--color-neutral-200);
+--color-border-hover: var(--color-neutral-300);
 --color-border-focus: var(--color-primary-500);
+
+/* Zustände */
+--color-state-focus: var(--color-primary-500);
+--color-state-error: var(--color-error-500);
+--color-state-success: var(--color-success-500);
+--color-state-warning: var(--color-warning-500);
 ```
 
 ──────────────────────────────────────────────────────────────
 📝 TYPOGRAFIE
 ──────────────────────────────────────────────────────────────
 
-### Familien
+### Schriftfamilien
 ```css
---font-family-sans: 'Inter', system-ui, sans-serif;
---font-family-mono: 'JetBrains Mono', monospace;
+--font-family-sans: 'Inter', system-ui, -apple-system, sans-serif;
+--font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
 ```
 
 ### Größen (Basis 16px)
-| Token | Größe | Line Height | Verwendung |
-|-------|-------|-------------|------------|
-| --font-size-xs | 0.75rem | 1rem | Labels |
-| --font-size-base | 1rem | 1.5rem | Body |
-| --font-size-4xl | 2.25rem | 2.5rem | H1 |
+| Token | Größe | Zeilenhöhe | Verwendung |
+|-------|-------|------------|------------|
+| --font-size-xs | 0.75rem (12px) | 1rem | Beschriftungen, Abzeichen |
+| --font-size-sm | 0.875rem (14px) | 1.25rem | Kleiner Fließtext |
+| --font-size-base | 1rem (16px) | 1.5rem | Fließtext |
+| --font-size-lg | 1.125rem (18px) | 1.75rem | Einleitungstext |
+| --font-size-xl | 1.25rem (20px) | 1.75rem | H4 |
+| --font-size-2xl | 1.5rem (24px) | 2rem | H3 |
+| --font-size-3xl | 1.875rem (30px) | 2.25rem | H2 |
+| --font-size-4xl | 2.25rem (36px) | 2.5rem | H1 |
+| --font-size-5xl | 3rem (48px) | 1 | Display |
+
+### Schriftstärken
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| --font-weight-normal | 400 | Fließtext |
+| --font-weight-medium | 500 | Beschriftungen, Navigation |
+| --font-weight-semibold | 600 | Unterüberschriften |
+| --font-weight-bold | 700 | Überschriften |
+
+### Zeilenhöhen
+```css
+--line-height-none: 1;
+--line-height-tight: 1.25;
+--line-height-snug: 1.375;
+--line-height-normal: 1.5;
+--line-height-relaxed: 1.625;
+--line-height-loose: 2;
+```
+
+### Buchstabenabstand
+```css
+--letter-spacing-tighter: -0.05em;
+--letter-spacing-tight: -0.025em;
+--letter-spacing-normal: 0;
+--letter-spacing-wide: 0.025em;
+--letter-spacing-wider: 0.05em;
+```
 
 ──────────────────────────────────────────────────────────────
 📐 ABSTÄNDE
@@ -102,21 +179,108 @@ Format: CSS Custom Properties
 ### Skala (Basis 4px)
 | Token | Wert | Pixel | Verwendung |
 |-------|------|-------|------------|
+| --spacing-0 | 0 | 0px | - |
+| --spacing-px | 1px | 1px | Rahmen |
+| --spacing-0.5 | 0.125rem | 2px | Eng |
 | --spacing-1 | 0.25rem | 4px | XS |
+| --spacing-1.5 | 0.375rem | 6px | - |
+| --spacing-2 | 0.5rem | 8px | S |
+| --spacing-2.5 | 0.625rem | 10px | - |
+| --spacing-3 | 0.75rem | 12px | - |
 | --spacing-4 | 1rem | 16px | M (Basis) |
+| --spacing-5 | 1.25rem | 20px | - |
+| --spacing-6 | 1.5rem | 24px | L |
 | --spacing-8 | 2rem | 32px | XL |
+| --spacing-10 | 2.5rem | 40px | - |
+| --spacing-12 | 3rem | 48px | 2XL |
+| --spacing-16 | 4rem | 64px | 3XL |
+| --spacing-20 | 5rem | 80px | - |
+| --spacing-24 | 6rem | 96px | 4XL |
 
 ──────────────────────────────────────────────────────────────
-🌗 SCHATTEN / ⭕ RADIEN / ⏱️ ÜBERGÄNGE
+🌗 SCHATTEN
 ──────────────────────────────────────────────────────────────
 
-{Ähnliche Tabellen mit Tokens}
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| --shadow-xs | 0 1px 2px 0 rgb(0 0 0 / 0.05) | Subtil |
+| --shadow-sm | 0 1px 3px 0 rgb(0 0 0 / 0.1) | Karten |
+| --shadow-md | 0 4px 6px -1px rgb(0 0 0 / 0.1) | Dropdowns |
+| --shadow-lg | 0 10px 15px -3px rgb(0 0 0 / 0.1) | Modale |
+| --shadow-xl | 0 20px 25px -5px rgb(0 0 0 / 0.1) | Dialoge |
+| --shadow-2xl | 0 25px 50px -12px rgb(0 0 0 / 0.25) | Überlagerungen |
+| --shadow-inner | inset 0 2px 4px 0 rgb(0 0 0 / 0.05) | Eingabefelder |
+| --shadow-none | none | Zurücksetzen |
 
+──────────────────────────────────────────────────────────────
+⭕ RADIEN (Rahmen-Radius)
+──────────────────────────────────────────────────────────────
+
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| --radius-none | 0 | Scharf |
+| --radius-sm | 0.125rem (2px) | Subtil |
+| --radius-md | 0.375rem (6px) | Schaltflächen, Eingabefelder |
+| --radius-lg | 0.5rem (8px) | Karten |
+| --radius-xl | 0.75rem (12px) | Modale |
+| --radius-2xl | 1rem (16px) | Große Karten |
+| --radius-full | 9999px | Pillen, Avatare |
+
+──────────────────────────────────────────────────────────────
+⏱️ ÜBERGÄNGE
+──────────────────────────────────────────────────────────────
+
+### Dauern
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| --duration-75 | 75ms | Mikro |
+| --duration-100 | 100ms | Schnell |
+| --duration-150 | 150ms | Standard |
+| --duration-200 | 200ms | Normal |
+| --duration-300 | 300ms | Langsam |
+| --duration-500 | 500ms | Betonung |
+
+### Beschleunigungskurven
+```css
+--ease-linear: linear;
+--ease-in: cubic-bezier(0.4, 0, 1, 1);
+--ease-out: cubic-bezier(0, 0, 0.2, 1);
+--ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+--ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
 ```
 
-### Schritt 3: Exportieren
+### Zusammengesetzte Übergänge
+```css
+--transition-none: none;
+--transition-all: all 150ms ease-out;
+--transition-colors: color, background-color, border-color 150ms ease-out;
+--transition-opacity: opacity 150ms ease-out;
+--transition-shadow: box-shadow 150ms ease-out;
+--transition-transform: transform 150ms ease-out;
+```
 
-Dateien generieren:
+──────────────────────────────────────────────────────────────
+📦 Z-INDEX
+──────────────────────────────────────────────────────────────
+
+| Token | Wert | Verwendung |
+|-------|------|------------|
+| --z-0 | 0 | Basis |
+| --z-10 | 10 | Erhöht |
+| --z-20 | 20 | Dropdowns |
+| --z-30 | 30 | Klebend |
+| --z-40 | 40 | Fest |
+| --z-50 | 50 | Modaler Hintergrund |
+| --z-60 | 60 | Modal |
+| --z-70 | 70 | Popover |
+| --z-80 | 80 | Toast |
+| --z-90 | 90 | Tooltip |
+| --z-max | 9999 | Maximum |
+```
+
+### Schritt 3: Export
+
+Folgende Dateien generieren:
 - `tokens.css` - CSS Custom Properties
-- `tokens.json` - Style Dictionary Format
-- `tailwind.config.js` - Tailwind Erweiterung (falls zutreffend)
+- `tokens.json` - Style-Dictionary-Format
+- `tailwind.config.js` - Tailwind-Erweiterung (falls zutreffend)

--- a/Dev/i18n/de/UIUX/commands/user-flow.md
+++ b/Dev/i18n/de/UIUX/commands/user-flow.md
@@ -1,27 +1,27 @@
 ---
-description: User Flow Design
+description: Benutzerfluss-Design
 argument-hint: [arguments]
 ---
 
-# User Flow Design
+# Benutzerfluss-Design
 
-Du bist ein UX/Ergonomie-Experte. Du musst einen vollständigen und optimierten User Flow entwerfen.
+Sie sind ein UX/Ergonomie-Experte. Sie müssen einen vollständigen und optimierten Benutzerfluss entwerfen.
 
 ## Argumente
 $ARGUMENTS
 
 Argumente:
-- Name des zu gestaltenden Flows
+- Name des zu gestaltenden Flusses
 - (Optional) Ziel-Persona
 - (Optional) Spezifische Einschränkungen
 
-Beispiel: `/uiux:user-flow "Benutzerregistrierung"` oder `/uiux:user-flow "Checkout" persona:"Mobile Benutzer" einschraenkung:"< 30 Sekunden"`
+Beispiel: `/uiux:user-flow "Benutzerregistrierung"` oder `/uiux:user-flow "Checkout" persona:"Mobile Benutzer" constraint:"< 30 Sekunden"`
 
 ## Plan-Modus
 
 > **Der Plan-Modus wird empfohlen.** Claude aktiviert den Plan-Modus, um den Ansatz zu strukturieren, Abhängigkeiten zu identifizieren und eine Generierungsstrategie vorzustellen, bevor Artefakte erstellt werden.
 
-## MISSION
+## AUFTRAG
 
 ### Schritt 1: Kontext definieren
 
@@ -30,14 +30,14 @@ Beispiel: `/uiux:user-flow "Benutzerregistrierung"` oder `/uiux:user-flow "Check
 - Nutzungskontext (Gerät, Umgebung)
 - Geschäftseinschränkungen
 
-### Schritt 2: Flow entwerfen
+### Schritt 2: Fluss entwerfen
 
 ```
 ══════════════════════════════════════════════════════════════
-🧭 USER FLOW: {NAME}
+🧭 BENUTZERFLUSS: {NAME}
 ══════════════════════════════════════════════════════════════
 
-Datum: {datum}
+Datum: {date}
 Version: 1.0
 
 ──────────────────────────────────────────────────────────────
@@ -59,36 +59,193 @@ Version: 1.0
 ### Geschäftsziel
 > "{Was das Unternehmen erreichen möchte}"
 
+### Einschränkungen
+- Max. Zeit: {X Sekunden/Minuten}
+- Max. Schritte: {Y}
+- Gerät: {technische Einschränkungen}
+- Offline: Ja / Nein
+
 ──────────────────────────────────────────────────────────────
-📋 DETAILLIERTER FLOW
+🗺️ ÜBERSICHT
+──────────────────────────────────────────────────────────────
+
+```
+┌──────┐    ┌──────┐    ┌──────┐    ┌──────┐    ┌──────┐
+│Start │───▶│Schr 1│───▶│Schr 2│───▶│Schr 3│───▶│ Ende │
+└──────┘    └──────┘    └──────┘    └──────┘    └──────┘
+                │            │
+                ▼            ▼
+           ┌────────┐   ┌────────┐
+           │Fehler A│   │Fehler B│
+           └────────┘   └────────┘
+```
+
+──────────────────────────────────────────────────────────────
+📋 DETAILLIERTER FLUSS
 ──────────────────────────────────────────────────────────────
 
 ### Schritt 0: Auslöser
+
 **Einstiegspunkt**: {Wie der Benutzer ankommt}
+- Über: {Menü / Link / CTA / Deep-Link}
+- Vorheriger Zustand: {angemeldet / anonym / vorhandene Daten}
+- Vorbedingungen: {was erfüllt sein muss}
+
+---
 
 ### Schritt 1: {Schrittname}
+
 **Bildschirm**: {Bildschirmname}
 **Ziel**: {Was der Benutzer tun muss}
 
 #### Verfügbare Aktionen
 | Aktion | UI-Element | Ergebnis |
 |--------|------------|----------|
-| Primär | {Button/Link} | Weiter zu Schritt 2 |
+| Primär | {Schaltfläche/Link} | Weiter zu Schritt 2 |
+| Sekundär | {Schaltfläche/Link} | {Alternative} |
+| Tertiär | {Link} | {Andere Option} |
+
+#### Erforderliche Daten
+| Feld | Typ | Validierung | Pflichtfeld |
+|------|-----|-------------|-------------|
+| {Feld} | {Typ} | {Regeln} | Ja/Nein |
 
 #### System-Feedback
 | Ereignis | Feedback | Typ |
 |----------|----------|-----|
-| Validierungsfehler | {Nachricht} | Inline |
+| Eingabe-Fokus | {Feedback} | Visuell |
+| Validierungsfehler | {Meldung} | Inline |
+| Erfolg | {Feedback} | Toast/Inline |
+
+#### Aufmerksamkeitspunkte
+- ⚠️ {potenzielle Reibung}
+- 💡 {Verbesserungsmöglichkeit}
+
+---
+
+### Schritt 2: {Schrittname}
+
+{Gleiche Struktur …}
+
+---
+
+### Schritt N: Bestätigung (Ende)
+
+**Bildschirm**: {Bestätigung / Erfolg}
+**Endzustand**: {Was erreicht wurde}
+
+#### Inhalt
+- Erfolgsmeldung
+- Aktionszusammenfassung
+- Vorgeschlagene nächste Schritte
+
+#### Nächste Aktionen
+| Aktion | Ziel |
+|--------|------|
+| Primärer CTA | {nächster Fluss} |
+| Zurück | {Dashboard/Liste} |
+| Teilen | {falls zutreffend} |
+
+──────────────────────────────────────────────────────────────
+⚠️ ALTERNATIVE PFADE
+──────────────────────────────────────────────────────────────
+
+### Fehler: {Fehlertyp}
+
+**Auslöser**: {Was den Fehler verursacht}
+**Bildschirm**: {Inline / Modal / Dedizierte Seite}
+
+#### Fehlermeldung
+```
+Titel: {Klarer Titel}
+Beschreibung: {Erklärung des Problems}
+Aktion: {Wie zu lösen}
+```
+
+#### Benutzeroptionen
+- Erneut versuchen: {Verhalten}
+- Ändern: {Zurück zu Schritt X}
+- Abbrechen: {Zustand gespeichert?}
+
+---
+
+### Abbruch: Zustand speichern
+
+**Verhalten**:
+- Entwurf automatisch gespeichert
+- Aufbewahrungsdauer: {X Tage}
+- Erinnerungsbenachrichtigung: Ja / Nein
+
+---
+
+### Randfall: {Beschreibung}
+
+**Situation**: {Besonderer Kontext}
+**Verhalten**: {Flussanpassung}
 
 ──────────────────────────────────────────────────────────────
 📊 METRIKEN & KPIs
 ──────────────────────────────────────────────────────────────
 
+### Quantitative Ziele
+
 | Metrik | Ziel | Messung |
 |--------|------|---------|
 | Abschlusszeit | < {X} Sek | Time-on-task |
-| Abschlussrate | > {Y}% | Funnel Analytics |
-| Anzahl Klicks | ≤ {N} | Click Tracking |
+| Abschlussrate | > {Y}% | Trichteranalyse |
+| Fehlerrate | < {Z}% | Fehlerrate |
+| Anzahl Klicks | ≤ {N} | Klickverfolgung |
+| Zufriedenheitsbewertung | > {S}/5 | Umfrage nach Aufgabe |
+
+### Messpunkte
+
+| Schritt | Zu verfolgender Ereignis |
+|---------|--------------------------|
+| Einstieg | `flow_started` |
+| Schritt 1 | `step_1_completed` |
+| Schritt 2 | `step_2_completed` |
+| Erfolg | `flow_completed` |
+| Abbruch | `flow_abandoned` mit `last_step` |
+| Fehler | `flow_error` mit `error_type` |
+
+──────────────────────────────────────────────────────────────
+🧠 ERGONOMIE
+──────────────────────────────────────────────────────────────
+
+### Kognitive Belastung
+
+| Schritt | Komplexität | Begründung |
+|---------|-------------|------------|
+| 1 | Niedrig | {1–2 einfache Aktionen} |
+| 2 | Mittel | {kurzes Formular} |
+| 3 | Niedrig | {nur Bestätigung} |
+
+### Angewandte Prinzipien
+
+| Prinzip | Anwendung |
+|---------|-----------|
+| Schrittweise Offenlegung | {wie} |
+| Standardwerte | {welche} |
+| Inline-Validierung | {wann} |
+| Automatisches Speichern | {Häufigkeit} |
+
+──────────────────────────────────────────────────────────────
+♿ BARRIEREFREIHEIT
+──────────────────────────────────────────────────────────────
+
+### Tastaturnavigation
+- Tab-Reihenfolge: {logische Sequenz}
+- Sprunglinks: {bei langem Formular}
+- Fokusverwaltung: {bei Schrittwechsel}
+
+### Screenreader
+- Schrittankündigung: „Schritt X von Y"
+- Fehler: aria-live="assertive"
+- Fortschritt: aria-describedby
+
+### Zeit
+- Kein automatisches Zeitlimit
+- Falls Verzögerung: verlängerbar oder deaktivierbar
 
 ──────────────────────────────────────────────────────────────
 ✅ VALIDIERUNGS-CHECKLISTE
@@ -99,6 +256,12 @@ Version: 1.0
 - [ ] Minimale notwendige Schritte
 - [ ] Feedback bei jeder Aktion
 - [ ] Fehlerpfade dokumentiert
+- [ ] Abbruch mit Speichern
+
+### Messbarkeit
+- [ ] KPIs definiert
+- [ ] Tracking-Ereignisse aufgelistet
+- [ ] Ziele quantifiziert
 
 ### Barrierefreiheit
 - [ ] Tastaturnavigation
@@ -108,6 +271,6 @@ Version: 1.0
 
 ### Schritt 3: Validierung
 
-- Review mit Stakeholdern
-- Benutzertest (min. 5 Benutzer)
+- Überprüfung mit Stakeholdern
+- Benutzertest (mind. 5 Benutzer)
 - Iteration basierend auf Feedback

--- a/Dev/i18n/de/VueJS/commands/check-compliance.md
+++ b/Dev/i18n/de/VueJS/commands/check-compliance.md
@@ -1,128 +1,253 @@
 ---
-description: Audit Vue.js project compliance with coding standards and best practices
+description: Vollständige Vue.js-Konformitätsprüfung durchführen
+argument-hint: [arguments]
 ---
 
-# Vue.js Compliance Audit
+# Vollständige Vue.js-Konformitätsprüfung
 
-You are an expert Vue.js auditor. Perform a comprehensive compliance check on this project.
+## Argumente
 
-## MISSION
-
-Audit the project for compliance with Vue.js 3 best practices, Composition API standards, and TypeScript conventions.
+$ARGUMENTS (optional: Pfad zum zu analysierenden Projekt)
 
 ## Plan-Modus
 
 > Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine modulübergreifende Untersuchung erfordert.
 
-## AUDIT CHECKLIST
+## AUFTRAG
 
-### 1. Project Structure (20 points)
+Führen Sie ein vollständiges Konformitäts-Audit des Vue.js-Projekts durch, indem Sie die 4 wichtigsten Prüfungen orchestrieren: Architektur, Codequalität, Tests und Sicherheit. Erstellen Sie einen konsolidierten Bericht mit einer Gesamtpunktzahl von 100 Punkten.
+
+### Schritt 1: Audit-Vorbereitung
+
+Audit-Umgebung vorbereiten:
+- [ ] Zu prüfenden Projektpfad identifizieren
+- [ ] Vorhandensein der Konfigurationsdateien überprüfen (package.json, tsconfig.json, vite.config.ts)
+- [ ] Hauptverzeichnisse auflisten (src/, tests/, public/ usw.)
+- [ ] Projektstruktur und Vue.js-Version identifizieren
+
+**Hinweis**: Falls $ARGUMENTS angegeben, als Projektpfad verwenden; andernfalls das aktuelle Verzeichnis nutzen.
+
+### Schritt 2: Architektur-Audit (25 Punkte)
+
+Vollständige Architekturprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/vuejs:check-architecture` verwenden oder die Schritte in `check-architecture.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- Komponenten- und Feature-Organisation (6 Pkt.)
+- Composables-Struktur und Wiederverwendung (6 Pkt.)
+- Pinia-Store-Architektur (4 Pkt.)
+- Router-Konfiguration und Lazy Loading (4 Pkt.)
+- Trennung von gemeinsamen/gemeinsam genutzten Modulen (3 Pkt.)
+- Abhängigkeitsregeln und Barrel-Exporte (2 Pkt.)
+
+**Referenz**: `check-architecture.md`
+
+### Schritt 3: Codequalitäts-Audit (25 Punkte)
+
+Codequalitätsprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/vuejs:check-code-quality` verwenden oder die Schritte in `check-code-quality.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- TypeScript-Strict-Modus und Typsicherheit (5 Pkt.)
+- ESLint- und Prettier-Konformität (5 Pkt.)
+- Verwendung der Composition API und script setup (4 Pkt.)
+- KISS/DRY/YAGNI-Prinzipien (4 Pkt.)
+- Namenskonventionen (4 Pkt.)
+- Fehlerbehandlung (3 Pkt.)
+
+**Referenz**: `check-code-quality.md`
+
+### Schritt 4: Test-Audit (25 Punkte)
+
+Test-Prüfung durchführen:
+
+**Befehl**: Slash-Befehl `/vuejs:check-testing` verwenden oder die Schritte in `check-testing.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- Codeabdeckung (7 Pkt.)
+- Unit-Tests für Composables und Stores (6 Pkt.)
+- Komponententests mit Vue Test Utils (4 Pkt.)
+- Integrationstests (3 Pkt.)
+- Testqualität und AAA-Muster (3 Pkt.)
+- Organisation von Mocks und Fixtures (2 Pkt.)
+
+**Referenz**: `check-testing.md`
+
+### Schritt 5: Sicherheits-Audit (25 Punkte)
+
+Sicherheitsprüfung durchführen:
+
+**Befehl**: Slash-Befehl `/vuejs:check-security` verwenden oder die Schritte in `check-security.md` manuell befolgen
+
+**Bewertete Kriterien**:
+- XSS-Prävention (v-html-Verwendung) (6 Pkt.)
+- Verwaltung von Geheimnissen und Zugangsdaten (5 Pkt.)
+- Eingabevalidierung und -bereinigung (4 Pkt.)
+- Abhängigkeitsschwachstellen (4 Pkt.)
+- Authentifizierung und Routenschutzwächter (3 Pkt.)
+- Sichere API-Kommunikation (2 Pkt.)
+- CSRF-Schutz (1 Pkt.)
+
+**Referenz**: `check-security.md`
+
+### Schritt 6: Konsolidierung und Gesamtbewertung
+
+Gesamtpunktzahl berechnen und konsolidierten Bericht erstellen:
+- [ ] Die 4 Punktzahlen addieren (max. 100 Punkte)
+- [ ] Kritische Kategorien identifizieren (< 50 %)
+- [ ] Alle kritischen bereichsübergreifenden Probleme auflisten
+- [ ] Maßnahmen nach Auswirkung/Aufwand priorisieren
+- [ ] Endgültigen konsolidierten Bericht erstellen
+
+**Bewertungsskala**:
+- 90–100: Hervorragend – Referenzprojekt
+- 75–89: Sehr gut – Einige geringfügige Verbesserungen
+- 60–74: Akzeptabel – Erfordert Verbesserungen
+- 40–59: Unzureichend – Größeres Refactoring erforderlich
+- 0–39: Kritisch – Vollständige Überarbeitung notwendig
+
+### Schritt 7: Empfehlungen und Aktionsplan
+
+Abschließende Empfehlungen erstellen:
+- [ ] Top-3-Prioritätsmaßnahmen über alle Kategorien hinweg identifizieren
+- [ ] Aufwand (Niedrig/Mittel/Hoch) für jede Maßnahme schätzen
+- [ ] Auswirkung (Niedrig/Mittel/Hoch) für jede Maßnahme schätzen
+- [ ] Implementierungsreihenfolge vorschlagen
+- [ ] Quick Wins vorschlagen (hohes Auswirkungs-/Aufwandsverhältnis)
+
+## AUSGABEFORMAT
 
 ```
-[ ] src/components/ - Shared components organized
-[ ] src/composables/ - Composition functions present
-[ ] src/stores/ - Pinia stores properly structured
-[ ] src/router/ - Vue Router configuration
-[ ] src/types/ - TypeScript types defined
-[ ] src/services/ - API services separated
+VUE.JS-KONFORMITÄTS-AUDIT – VOLLSTÄNDIGER BERICHT
+=============================================
+
+GESAMTPUNKTZAHL: XX/100
+
+KONFORMITÄTSNIVEAU: [Hervorragend/Sehr gut/Akzeptabel/Unzureichend/Kritisch]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PUNKTZAHLEN NACH KATEGORIE:
+
+ARCHITEKTUR       : XX/25  [██████████░░░░░░░░░░] XX%
+CODEQUALITÄT      : XX/25  [██████████░░░░░░░░░░] XX%
+TESTS             : XX/25  [██████████░░░░░░░░░░] XX%
+SICHERHEIT        : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GESAMTSTÄRKEN:
+1. [In mehreren Kategorien identifizierte Stärke]
+2. [Weitere wichtige Stärke]
+3. [Dritte Stärke]
+
+GESAMTVERBESSERUNGEN:
+1. [Geringfügige bereichsübergreifende Verbesserung]
+2. [Weitere empfohlene Verbesserung]
+3. [Dritte Verbesserung]
+
+KRITISCHE PROBLEME:
+1. [Kritisches Problem Nr. 1 – betroffene Kategorie]
+2. [Kritisches Problem Nr. 2 – betroffene Kategorie]
+3. [Kritisches Problem Nr. 3 – betroffene Kategorie]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETAILS NACH KATEGORIE:
+
+┌─────────────────────────────────────────────┐
+│ ARCHITEKTUR (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Teilpunktzahlen:
+  • Komponenten- und Feature-Org.  : XX/6
+  • Composables-Struktur           : XX/6
+  • Pinia-Store-Architektur        : XX/4
+  • Router und Lazy Loading        : XX/4
+  • Trennung gemeinsamer Module    : XX/3
+  • Abhängigkeitsregeln            : XX/2
+
+Stärken:
+- [Architekturstärken]
+
+Probleme:
+- [Architekturprobleme]
+
+[Ähnliche Abschnitte für Codequalität, Tests und Sicherheit ...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP-3-PRIORITÄTSMANAHMEN (ALLE KATEGORIEN):
+
+1. KRITISCH – [Maßnahme Nr. 1]
+   Kategorie  : [Architektur/Qualität/Tests/Sicherheit]
+   Auswirkung : [Hoch/Mittel/Niedrig]
+   Aufwand    : [Hoch/Mittel/Niedrig]
+   Priorität  : SOFORT
+
+   Detaillierte Beschreibung:
+   [Erklärung des Problems und vorgeschlagene Lösung]
+
+   Betroffene Dateien:
+   - [datei:zeile]
+
+   Korrekturbeispiel:
+   [Code oder Korrekturbefehl]
+
+2. WICHTIG – [Maßnahme Nr. 2]
+   [Gleiche Struktur …]
+
+3. EMPFOHLEN – [Maßnahme Nr. 3]
+   [Gleiche Struktur …]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+QUICK WINS (Hohe Auswirkung / Geringer Aufwand):
+
+- [Quick Win Nr. 1] – Kategorie: [X] – Auswirkung: [X] – Aufwand: [X]
+- [Quick Win Nr. 2] – Kategorie: [X] – Auswirkung: [X] – Aufwand: [X]
+- [Quick Win Nr. 3] – Kategorie: [X] – Auswirkung: [X] – Aufwand: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+EMPFOHLENER AKTIONSPLAN:
+
+WOCHE 1 (Sofort):
+- [ ] [Kritische Maßnahme Nr. 1]
+- [ ] [Prioritäts-Quick-Win]
+
+WOCHE 2–4 (Kurzfristig):
+- [ ] [Wichtige Maßnahme Nr. 2]
+- [ ] [Weitere Quick Wins]
+
+MONAT 2–3 (Mittelfristig):
+- [ ] [Empfohlene Maßnahme Nr. 3]
+- [ ] [Schrittweise Verbesserungen]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ZUSAMMENFASSUNG FÜR DIE GESCHÄFTSFÜHRUNG:
+
+[Zusammenfassender Absatz über den Gesamtzustand des Projekts, wesentliche
+Stärken, wesentliche Schwächen und empfohlene Entwicklung zur Verbesserung
+der Konformität. Angabe, ob das Projekt produktionsreif ist,
+Korrekturen benötigt oder ein Refactoring erfordert.]
+
+Allgemeine Empfehlung: [Produktionsreif / Geringfügige Korrekturen /
+Größeres Refactoring / Überarbeitung notwendig]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Component Standards (25 points)
+## WICHTIGE HINWEISE
 
-```
-[ ] Using <script setup> syntax
-[ ] TypeScript with lang="ts"
-[ ] Props defined with defineProps<T>()
-[ ] Emits defined with defineEmits<T>()
-[ ] Components are multi-word named
-[ ] Base components use Base prefix
-```
-
-### 3. Composition API (20 points)
-
-```
-[ ] No Options API in new components
-[ ] Composables follow use* naming
-[ ] Reactive state properly typed
-[ ] Computed properties used correctly
-[ ] Watchers cleaned up
-```
-
-### 4. Pinia Stores (15 points)
-
-```
-[ ] Setup syntax stores (composition style)
-[ ] Proper TypeScript typing
-[ ] Actions are async when needed
-[ ] Getters use computed
-[ ] No direct state mutation from components
-```
-
-### 5. TypeScript Integration (20 points)
-
-```
-[ ] Strict mode enabled
-[ ] No implicit any
-[ ] Props and emits fully typed
-[ ] Interfaces for complex types
-[ ] Type-only imports used
-```
-
-## OUTPUT FORMAT
-
-```
-══════════════════════════════════════════════════════════════
-VUE.JS COMPLIANCE AUDIT
-══════════════════════════════════════════════════════════════
-
-📊 SUMMARY
-──────────────────────────────────────────────────────────────
-Total Score: XX/100
-Status: ✅ COMPLIANT | ⚠️ NEEDS WORK | ❌ NON-COMPLIANT
-
-📁 PROJECT STRUCTURE: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Organized component structure
-[✗] Missing composables directory
-    → Create src/composables/ for reusable logic
-
-🧩 COMPONENT STANDARDS: XX/25
-──────────────────────────────────────────────────────────────
-[✓] Using <script setup>
-[✗] Some components use Options API
-    Files: src/components/OldComponent.vue
-    → Migrate to Composition API
-
-🔧 COMPOSITION API: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Composables properly named
-[✗] Missing cleanup in watchers
-    File: src/composables/useData.ts:45
-
-🏪 PINIA STORES: XX/15
-──────────────────────────────────────────────────────────────
-[✓] Setup syntax used
-[✓] Proper typing
-
-📝 TYPESCRIPT: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Strict mode enabled
-[✗] Implicit any found
-    File: src/utils/helpers.ts:12
-
-📋 RECOMMENDATIONS
-──────────────────────────────────────────────────────────────
-1. [HIGH] Migrate remaining Options API components
-2. [MEDIUM] Add missing type definitions
-3. [LOW] Organize composables by feature
-
-══════════════════════════════════════════════════════════════
-```
-
-## PROCESS
-
-1. Scan project structure
-2. Analyze component files for standards
-3. Check composables and stores
-4. Verify TypeScript configuration
-5. Generate compliance report with score
+- Dieser Befehl orchestriert die 4 spezialisierten Audits
+- Docker für alle Analysetools verwenden
+- Konkrete Beispiele mit datei:zeile für jedes Problem angeben
+- Maßnahmen nach der Auswirkungs-/Aufwandsmatrix priorisieren
+- Sicherheitsprobleme haben IMMER oberste Priorität
+- Automatisierbare Korrekturen vorschlagen (Skripte, Pre-Commit-Hooks)
+- Der Bericht muss handlungsorientiert sein, nicht nur beschreibend
+- Empfehlungen an den geschäftlichen Kontext des Projekts anpassen

--- a/Dev/i18n/es/Angular/commands/check-compliance.md
+++ b/Dev/i18n/es/Angular/commands/check-compliance.md
@@ -1,203 +1,253 @@
 ---
-description: Angular Standards Compliance Check
+description: Verificar el cumplimiento completo de Angular
+argument-hint: [argumentos]
 ---
 
-# Angular Standards Compliance Check
+# Verificar el cumplimiento completo de Angular
 
-Verify that the Angular project follows established coding standards and best practices.
+## Argumentos
 
-## What This Command Does
-
-1. **Standards Verification**
-   - Check coding conventions
-   - Verify naming conventions
-   - Validate file organization
-   - Check import order
-   - Verify documentation standards
-
-2. **Angular-Specific Checks**
-   - Standalone components usage
-   - Signals implementation
-   - OnPush change detection
-   - Modern control flow (@if, @for)
-   - Typed forms
-
-3. **Generated Report**
-   - Non-compliant files
-   - Severity levels
-   - Remediation recommendations
-   - Compliance score (/100)
+$ARGUMENTS (opcional: ruta del proyecto a analizar)
 
 ## Modo Plan
 
 > El modo plan se activa automáticamente cuando el alcance abarca varios módulos o requiere una investigación transversal.
 
-## Compliance Areas
+## MISIÓN
 
-### 1. Component Standards
+Realizar una auditoría de cumplimiento completa del proyecto Angular orquestando las 4 verificaciones principales: Arquitectura, Calidad del Código, Pruebas y Seguridad. Producir un informe consolidado con una puntuación global sobre 100 puntos.
 
-```typescript
-// ✅ Compliant
-@Component({
-  selector: 'app-user-profile',
-  standalone: true,
-  imports: [CommonModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `...`
-})
-export class UserProfileComponent {}
+### Paso 1: Preparación de la auditoría
 
-// ❌ Non-compliant
-@Component({
-  selector: 'user-profile',     // Missing app- prefix
-  // standalone: missing       // Not standalone
-  // changeDetection: missing  // Not OnPush
-})
-export class UserProfile {}    // Missing Component suffix
+Preparar el entorno de auditoría:
+- [ ] Identificar la ruta del proyecto a auditar
+- [ ] Verificar la presencia de archivos de configuración (angular.json, tsconfig.json, package.json)
+- [ ] Listar los directorios principales (src/app/, e2e/, etc.)
+- [ ] Identificar la estructura del proyecto y la versión de Angular
+
+**Nota**: Si se proporciona $ARGUMENTS, usarlo como ruta del proyecto; de lo contrario, usar el directorio actual.
+
+### Paso 2: Auditoría de Arquitectura (25 puntos)
+
+Ejecutar la verificación completa de arquitectura:
+
+**Comando**: Usar el comando slash `/angular:check-architecture` o seguir manualmente los pasos en `check-architecture.md`
+
+**Criterios evaluados**:
+- Estructura de módulos orientada al dominio (6 pts)
+- Uso de componentes standalone (6 pts)
+- Lazy loading y enrutamiento (4 pts)
+- Separación Core/Shared/Feature (4 pts)
+- Organización de la capa de servicios (3 pts)
+- Patrones de inyección de dependencias (2 pts)
+
+**Referencia**: `check-architecture.md`
+
+### Paso 3: Auditoría de Calidad del Código (25 puntos)
+
+Ejecutar la verificación de calidad del código:
+
+**Comando**: Usar el comando slash `/angular:check-code-quality` o seguir manualmente los pasos en `check-code-quality.md`
+
+**Criterios evaluados**:
+- Modo estricto de TypeScript y seguridad de tipos (5 pts)
+- Cumplimiento de ESLint (5 pts)
+- Signals y patrones modernos de Angular (4 pts)
+- Principios KISS/DRY/YAGNI (4 pts)
+- Convenciones de nomenclatura y estructura de archivos (4 pts)
+- Detección de cambios OnPush (3 pts)
+
+**Referencia**: `check-code-quality.md`
+
+### Paso 4: Auditoría de Pruebas (25 puntos)
+
+Ejecutar la verificación de pruebas:
+
+**Comando**: Usar el comando slash `/angular:check-testing` o seguir manualmente los pasos en `check-testing.md`
+
+**Criterios evaluados**:
+- Cobertura de código (7 pts)
+- Pruebas unitarias para servicios y pipes (6 pts)
+- Pruebas de componentes con TestBed (4 pts)
+- Pruebas de integración (3 pts)
+- Pruebas E2E (3 pts)
+- Aislamiento de pruebas y mocks (2 pts)
+
+**Referencia**: `check-testing.md`
+
+### Paso 5: Auditoría de Seguridad (25 puntos)
+
+Ejecutar la verificación de seguridad:
+
+**Comando**: Usar el comando slash `/angular:check-security` o seguir manualmente los pasos en `check-security.md`
+
+**Criterios evaluados**:
+- Prevención de XSS y DomSanitizer (6 pts)
+- Gestión de secretos y credenciales (5 pts)
+- Validación y saneamiento de entradas (4 pts)
+- Vulnerabilidades en dependencias (4 pts)
+- Autenticación y guardias de rutas (3 pts)
+- CSRF e interceptores HTTP (2 pts)
+- Política de seguridad de contenidos (1 pt)
+
+**Referencia**: `check-security.md`
+
+### Paso 6: Consolidación y Puntuación Global
+
+Calcular la puntuación general y producir el informe consolidado:
+- [ ] Sumar las 4 puntuaciones (máximo 100 puntos)
+- [ ] Identificar categorías críticas (<50%)
+- [ ] Listar todos los problemas transversales críticos
+- [ ] Priorizar acciones por impacto/esfuerzo
+- [ ] Producir el informe consolidado final
+
+**Escala de calificación**:
+- 90-100: Excelente — Proyecto de referencia
+- 75-89: Muy Bueno — Algunas mejoras menores
+- 60-74: Aceptable — Requiere mejoras
+- 40-59: Insuficiente — Refactorización mayor necesaria
+- 0-39: Crítico — Renovación completa necesaria
+
+### Paso 7: Recomendaciones y Plan de Acción
+
+Producir las recomendaciones finales:
+- [ ] Identificar las 3 principales acciones prioritarias en todas las categorías
+- [ ] Estimar el esfuerzo (Bajo/Medio/Alto) para cada acción
+- [ ] Estimar el impacto (Bajo/Medio/Alto) para cada acción
+- [ ] Proponer el orden de implementación
+- [ ] Sugerir victorias rápidas (relación alto impacto/esfuerzo)
+
+## FORMATO DE SALIDA
+
+```
+AUDITORÍA DE CUMPLIMIENTO ANGULAR - INFORME COMPLETO
+=============================================
+
+PUNTUACIÓN GLOBAL: XX/100
+
+NIVEL DE CUMPLIMIENTO: [Excelente/Muy Bueno/Aceptable/Insuficiente/Crítico]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PUNTUACIONES POR CATEGORÍA:
+
+ARQUITECTURA       : XX/25  [██████████░░░░░░░░░░] XX%
+CALIDAD DE CÓDIGO  : XX/25  [██████████░░░░░░░░░░] XX%
+PRUEBAS            : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURIDAD          : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+FORTALEZAS GENERALES:
+1. [Fortaleza identificada en múltiples categorías]
+2. [Otra fortaleza principal]
+3. [Tercera fortaleza]
+
+MEJORAS GENERALES:
+1. [Mejora transversal menor]
+2. [Otra mejora recomendada]
+3. [Tercera mejora]
+
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico #1 - categoría afectada]
+2. [Problema crítico #2 - categoría afectada]
+3. [Problema crítico #3 - categoría afectada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALLES POR CATEGORÍA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITECTURA (XX/25)                        │
+└─────────────────────────────────────────────┘
+
+Sub-puntuaciones:
+  • Módulos orientados al dominio    : XX/6
+  • Componentes standalone           : XX/6
+  • Lazy loading y enrutamiento      : XX/4
+  • Core/Shared/Feature              : XX/4
+  • Capa de servicios                : XX/3
+  • Inyección de dependencias        : XX/2
+
+Fortalezas:
+- [Fortalezas de arquitectura]
+
+Problemas:
+- [Problemas de arquitectura]
+
+[Secciones similares para Calidad del Código, Pruebas y Seguridad...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 ACCIONES PRIORITARIAS (TODAS LAS CATEGORÍAS):
+
+1. CRÍTICO - [Acción #1]
+   Categoría  : [Arquitectura/Calidad/Pruebas/Seguridad]
+   Impacto    : [Alto/Medio/Bajo]
+   Esfuerzo   : [Alto/Medio/Bajo]
+   Prioridad  : INMEDIATA
+
+   Descripción detallada:
+   [Explicación del problema y solución propuesta]
+
+   Archivos afectados:
+   - [archivo:línea]
+
+   Ejemplo de corrección:
+   [Código o comando de corrección]
+
+2. IMPORTANTE - [Acción #2]
+   [Mismo formato...]
+
+3. RECOMENDADO - [Acción #3]
+   [Mismo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+VICTORIAS RÁPIDAS (Alto Impacto / Bajo Esfuerzo):
+
+- [Victoria rápida #1] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+- [Victoria rápida #2] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+- [Victoria rápida #3] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLAN DE ACCIÓN RECOMENDADO:
+
+SEMANA 1 (Inmediato):
+- [ ] [Acción crítica #1]
+- [ ] [Victoria rápida prioritaria]
+
+SEMANAS 2-4 (Corto plazo):
+- [ ] [Acción importante #2]
+- [ ] [Otras victorias rápidas]
+
+MESES 2-3 (Medio plazo):
+- [ ] [Acción recomendada #3]
+- [ ] [Mejoras progresivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMEN EJECUTIVO:
+
+[Párrafo de resumen sobre el estado general del proyecto, principales fortalezas,
+principales debilidades y la trayectoria recomendada para mejorar
+el cumplimiento. Indicar si el proyecto está listo para producción,
+requiere correcciones o necesita refactorización.]
+
+Recomendación General: [Listo para producción / Correcciones menores /
+Refactorización mayor / Renovación necesaria]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Signal Usage
+## NOTAS IMPORTANTES
 
-```typescript
-// ✅ Compliant - Using signals
-export class CounterComponent {
-  count = signal(0);
-  doubleCount = computed(() => this.count() * 2);
-}
-
-// ❌ Non-compliant - Using observables for local state
-export class CounterComponent {
-  count$ = new BehaviorSubject(0);
-}
-```
-
-### 3. Template Syntax
-
-```html
-<!-- ✅ Compliant - Modern control flow -->
-@if (loading()) {
-  <app-spinner />
-}
-
-@for (item of items(); track item.id) {
-  <app-item [data]="item" />
-}
-
-<!-- ❌ Non-compliant - Legacy syntax -->
-<app-spinner *ngIf="loading"></app-spinner>
-<app-item *ngFor="let item of items" [data]="item"></app-item>
-```
-
-### 4. Dependency Injection
-
-```typescript
-// ✅ Compliant - inject() function
-export class MyComponent {
-  private readonly userService = inject(UserService);
-}
-
-// ⚠️ Warning - Constructor injection (valid but verbose)
-export class MyComponent {
-  constructor(private userService: UserService) {}
-}
-```
-
-### 5. File Naming
-
-```
-✅ Compliant:
-- user-profile.component.ts
-- auth.service.ts
-- auth.guard.ts
-- date-format.pipe.ts
-
-❌ Non-compliant:
-- UserProfile.component.ts (PascalCase)
-- authService.ts (missing suffix)
-- AuthGuard.ts (PascalCase)
-```
-
-## Scoring Criteria
-
-| Category | Weight | Criteria |
-|----------|--------|----------|
-| Standalone Components | 20% | All components are standalone |
-| Signals Usage | 15% | Local state uses signals |
-| OnPush Strategy | 15% | All components use OnPush |
-| Modern Control Flow | 10% | @if/@for instead of *ngIf/*ngFor |
-| Typed Forms | 10% | Forms are strongly typed |
-| Naming Conventions | 10% | Correct file/class naming |
-| Import Organization | 10% | Imports properly ordered |
-| Documentation | 10% | Key components documented |
-
-## Output Format
-
-```
-══════════════════════════════════════════════════════════════
-ANGULAR COMPLIANCE REPORT
-══════════════════════════════════════════════════════════════
-
-📊 SCORE: 85/100
-
-✅ PASSING (6)
-──────────────────────────────────────────────────────────────
-• Standalone components: 100% (24/24 components)
-• OnPush strategy: 100% (24/24 components)
-• Typed forms: 100% (8/8 forms)
-• Import organization: 100%
-• File naming: 100%
-• Documentation: 90%
-
-⚠️ WARNINGS (2)
-──────────────────────────────────────────────────────────────
-• Modern control flow: 75% (18/24 templates)
-  - src/app/features/users/user-list.component.html:15 - Uses *ngFor
-  - src/app/shared/modal/modal.component.html:8 - Uses *ngIf
-
-• Signals usage: 80% (16/20 components with local state)
-  - src/app/features/auth/login.component.ts - Uses BehaviorSubject
-
-❌ ERRORS (1)
-──────────────────────────────────────────────────────────────
-• Constructor injection detected (prefer inject()):
-  - src/app/core/services/api.service.ts:15
-
-📋 RECOMMENDATIONS
-──────────────────────────────────────────────────────────────
-1. Migrate remaining *ngFor to @for with track
-2. Replace BehaviorSubject with signal() for local state
-3. Use inject() function instead of constructor injection
-
-══════════════════════════════════════════════════════════════
-```
-
-## Automated Checks
-
-Run these commands to verify compliance:
-
-```bash
-# Lint check
-ng lint
-
-# Type check
-npx tsc --noEmit
-
-# Test coverage
-npm run test:ci
-
-# Build check
-ng build --configuration=production
-```
-
-## Checklist
-
-- [ ] All components are standalone
-- [ ] All components use OnPush change detection
-- [ ] Local state uses signals (not BehaviorSubject)
-- [ ] Templates use @if/@for/@switch
-- [ ] Forms are typed (FormGroup<T>)
-- [ ] inject() used for dependency injection
-- [ ] File naming follows conventions
-- [ ] Imports are organized
-- [ ] Public API documented
-- [ ] Tests pass with >80% coverage
+- Este comando orquesta las 4 auditorías especializadas
+- Usar Docker para todas las herramientas de análisis
+- Proporcionar ejemplos concretos con archivo:línea para cada problema
+- Priorizar acciones basándose en la matriz Impacto/Esfuerzo
+- Los problemas de seguridad son SIEMPRE la máxima prioridad
+- Proponer correcciones automatizables (scripts, hooks de pre-commit)
+- El informe debe ser accionable, no solo descriptivo
+- Adaptar las recomendaciones al contexto de negocio del proyecto

--- a/Dev/i18n/es/Common/commands/add-technology.md
+++ b/Dev/i18n/es/Common/commands/add-technology.md
@@ -1,21 +1,21 @@
 ---
-description: Añadir una nueva tecnología a claude-craft con best practices de Context7 y búsqueda web
-argument-hint: <nombre-tecnología>
+description: Agregar una nueva tecnología a claude-craft con las mejores prácticas de Context7 y búsqueda web
+argument-hint: <nombre-de-tecnología>
 ---
 
-# Añadir Tecnología
+# Agregar Tecnología
 
-Eres un experto integrador de tecnologías para claude-craft. Tu misión es añadir una nueva stack tecnológica:
-1. Investigando best practices usando Context7 MCP y búsqueda web
-2. Generando todos los archivos necesarios (rules, commands, templates, skills, agents)
-3. Creando el script de instalación
-4. Actualizando documentación y página de presentación
+Eres un experto integrador de tecnología para claude-craft. Tu misión es agregar un nuevo stack tecnológico mediante:
+1. Investigar las mejores prácticas usando Context7 MCP y búsqueda web
+2. Generar todos los archivos necesarios (reglas, comandos, plantillas, habilidades, agentes)
+3. Crear el script de instalación
+4. Actualizar la documentación y la página de aterrizaje
 
 ## Argumentos
 $ARGUMENTS
 
 Argumentos:
-- `nombre-tecnología`: Nombre de la tecnología a añadir (ej: "nextjs", "nestjs", "golang", "laravel")
+- `nombre-de-tecnología`: Nombre de la tecnología a agregar (p. ej., "nextjs", "nestjs", "golang", "laravel")
 - (Opcional) `categoría`: Categoría de la tecnología (frontend, backend, mobile, devops, fullstack)
 
 Ejemplo: `/common:add-technology "nestjs"` o `/common:add-technology "golang" backend`
@@ -30,36 +30,36 @@ Ejemplo: `/common:add-technology "nestjs"` o `/common:add-technology "golang" ba
 
 Identificar:
 - Nombre oficial y alias comunes
-- Tipo: framework, biblioteca, lenguaje, herramienta
+- Tipo: framework, librería, lenguaje, herramienta
 - Categoría: frontend, backend, mobile, devops, fullstack
-- Ecosistema: herramientas relacionadas, frameworks de testing, opciones de despliegue
-- Público objetivo: web, mobile, API, CLI, etc.
+- Ecosistema: herramientas relacionadas, frameworks de pruebas, opciones de despliegue
+- Público objetivo: web, móvil, API, CLI, etc.
 
 ### Paso 2: Investigar con Context7 (MCP)
 
-**Usar Context7 para acceder a documentación oficial:**
+**Usar Context7 para acceder a la documentación oficial:**
 
 ```
 Consultar Context7 para:
-1. Guía oficial de inicio
+1. Guía oficial de inicio rápido
 2. Estructura de proyecto recomendada
-3. Best practices y design patterns
-4. Estrategias de testing (unitario, integración, e2e)
-5. Best practices de seguridad
-6. Consejos de optimización de rendimiento
+3. Mejores prácticas y patrones de diseño
+4. Estrategias de pruebas (unitarias, integración, e2e)
+5. Mejores prácticas de seguridad
+6. Consejos de optimización del rendimiento
 7. Recomendaciones de despliegue
 ```
 
 #### Información a Extraer
 
 | Tema | Detalles a Encontrar |
-|------|---------------------|
+|------|----------------------|
 | Arquitectura | Patrones recomendados (MVC, Clean, Hexagonal, etc.) |
 | Estándares de Código | Guía de estilo, convenciones de nomenclatura, estructura de archivos |
-| Herramientas | Herramientas CLI, formateadores, linters, bundlers |
-| Testing | Frameworks de test, herramientas de cobertura, estrategias de mock |
+| Herramientas | Herramientas CLI, formateadores, linters, empaquetadores |
+| Pruebas | Frameworks de pruebas, herramientas de cobertura, estrategias de mocking |
 | Seguridad | Autenticación, autorización, vulnerabilidades comunes |
-| Calidad | Análisis estático, verificación de tipos, prácticas de review |
+| Calidad | Análisis estático, verificación de tipos, prácticas de revisión de código |
 
 ### Paso 3: Complementar con Búsqueda Web
 
@@ -67,15 +67,15 @@ Consultar Context7 para:
 
 1. **Últimas Tendencias**
    - Versión estable actual
-   - Características próximas
-   - Avisos de deprecación
+   - Próximas funcionalidades
+   - Advertencias de deprecación
    - Guías de migración
 
-2. **Best Practices de la Comunidad**
+2. **Mejores Prácticas de la Comunidad**
    - Boilerplates populares
    - Configuraciones de producción
    - Benchmarks de rendimiento
-   - Arquitecturas reales
+   - Arquitecturas del mundo real
 
 3. **Errores Comunes**
    - Errores frecuentes
@@ -84,14 +84,14 @@ Consultar Context7 para:
    - Cuellos de botella de rendimiento
 
 4. **Ecosistema**
-   - Bibliotecas recomendadas
-   - Herramientas de testing
+   - Librerías recomendadas
+   - Herramientas de pruebas
    - Integraciones DevOps
    - Soluciones de monitoreo
 
-### Paso 4: Generar Archivos de Tecnología
+### Paso 4: Generar Archivos de la Tecnología
 
-**Crear la estructura completa en los 5 idiomas (en, fr, es, de, pt):**
+**Crear la estructura de archivos completa en los 5 idiomas (en, fr, es, de, pt):**
 
 ```
 Dev/i18n/{lang}/{TECHNOLOGY}/
@@ -112,88 +112,186 @@ Dev/i18n/{lang}/{TECHNOLOGY}/
 │   ├── check-security.md
 │   └── [generate-*.md si aplica]
 ├── templates/
-│   └── [templates específicos de la tecnología]
+│   └── [plantillas específicas de la tecnología]
 ├── checklists/
 │   ├── pre-commit.md
 │   └── new-feature.md
 ├── agents/
 │   └── {tech}-reviewer.md
 └── skills/
-    └── [skills específicos de la tecnología]
+    └── [habilidades específicas de la tecnología]
 ```
 
-### Paso 5: Crear Script de Instalación
+#### Reglas a Generar
+
+| Archivo | Contenido |
+|---------|-----------|
+| `02-architecture-{tech}.md` | Patrones de arquitectura, estructura de carpetas, principios de arquitectura limpia |
+| `03-coding-standards.md` | Guía de estilo, convenciones de nomenclatura, organización de archivos |
+| `06-tooling.md` | Comandos CLI, formateadores, linters, herramientas de compilación |
+| `07-testing-{tech}.md` | Estrategias de pruebas, frameworks, requisitos de cobertura |
+| `08-quality-tools.md` | Análisis estático, verificación de tipos, integración CI/CD |
+| `11-security-{tech}.md` | Prácticas de seguridad, vulnerabilidades comunes, autenticación |
+
+#### Comandos a Generar
+
+| Comando | Propósito |
+|---------|-----------|
+| `check-compliance.md` | Auditoría de cumplimiento completa (puntuación /100) |
+| `check-architecture.md` | Revisión de arquitectura |
+| `check-code-quality.md` | Análisis de calidad del código |
+| `check-testing.md` | Cobertura y calidad de pruebas |
+| `check-security.md` | Auditoría de seguridad |
+
+### Paso 5: Crear el Script de Instalación
 
 **Generar `Dev/scripts/install-{tech}-rules.sh`:**
 
-Seguir el patrón de scripts existentes:
-- Soporte de opciones `--lang`, `--force`, `--update`, `--dry-run`, `--backup`
+Seguir el patrón de los scripts existentes:
+- Soportar las opciones `--lang`, `--force`, `--update`, `--dry-run`, `--backup`
 - Copiar reglas genéricas desde Common/
 - Copiar reglas específicas de la tecnología
 - Generar CLAUDE.md y 00-project-context.md
-- Mostrar resumen de instalación
+- Mostrar el resumen de instalación
 
-### Paso 6: Actualizar Documentación
+### Paso 6: Actualizar la Documentación
 
 **Archivos a actualizar:**
 
 | Archivo | Cambios |
 |---------|---------|
-| `README.md` | Añadir tecnología a la lista de stacks soportadas |
-| `docs/index.html` | Incrementar stats, añadir tarjeta de tecnología |
-| `docs/COMMANDS.md` | Documentar nuevos comandos |
-| `Makefile` | Añadir target `install-{tech}` |
+| `README.md` | Agregar tecnología a la lista de stacks soportados |
+| `docs/index.html` | Incrementar estadísticas, agregar tarjeta de tecnología |
+| `docs/COMMANDS.md` | Documentar los nuevos comandos |
+| `Makefile` | Agregar objetivo `install-{tech}` |
+
+#### Actualizaciones de la Página de Aterrizaje (docs/index.html)
+
+1. **Sección de Estadísticas**: Incrementar el contador de "Stacks Tecnológicos"
+2. **Cuadrícula de Tecnologías**: Agregar nueva tarjeta de tecnología:
+
+```html
+<div class="bg-slate-800/50 p-6 rounded-xl border border-white/5 hover:border-brand-500/50 transition-colors text-center group">
+    <div class="h-16 w-16 mx-auto bg-black rounded-full flex items-center justify-center mb-4 shadow-lg group-hover:scale-110 transition-transform">
+        <span class="text-2xl font-bold text-white">{ICON}</span>
+    </div>
+    <h3 class="font-bold text-white">{TECH_NAME}</h3>
+    <p class="text-xs text-slate-400 mt-2" data-i18n="tech_{tech}_desc">{DESCRIPTION}</p>
+</div>
+```
+
+3. **Traducciones**: Agregar claves i18n para los 5 idiomas
+
+#### Objetivo de Makefile
+
+```makefile
+install-{tech}:
+	./Dev/scripts/install-{tech}-rules.sh --lang=$(RULES_LANG) $(OPTIONS) $(TARGET)
+```
 
 ### Paso 7: Validación
 
-#### Checklist Definition of Done
+#### Lista de Verificación de Definición de Hecho
 
 ```
 ══════════════════════════════════════════════════════════════
-✅ DEFINITION OF DONE: Añadir Tecnología [{NOMBRE_TECH}]
+✅ DEFINICIÓN DE HECHO: Agregar Tecnología [{TECH_NAME}]
 ══════════════════════════════════════════════════════════════
 
 📁 ARCHIVOS CREADOS
 ──────────────────────────────────────────────────────────────
-- [ ] Rules (7 archivos × 5 idiomas = 35 archivos)
-- [ ] Commands (5 archivos × 5 idiomas = 25 archivos)
-- [ ] Templates (al menos 2 por idioma)
+- [ ] Reglas (7 archivos × 5 idiomas = 35 archivos)
+- [ ] Comandos (5 archivos × 5 idiomas = 25 archivos)
+- [ ] Plantillas (al menos 2 por idioma)
 - [ ] Checklists (2 archivos × 5 idiomas = 10 archivos)
-- [ ] Agent {tech}-reviewer (1 archivo × 5 idiomas = 5 archivos)
+- [ ] Agente {tech}-reviewer (1 archivo × 5 idiomas = 5 archivos)
 - [ ] CLAUDE.md.template (× 5 idiomas)
 - [ ] Script de instalación (Dev/scripts/install-{tech}-rules.sh)
 
 📄 DOCUMENTACIÓN ACTUALIZADA
 ──────────────────────────────────────────────────────────────
-- [ ] README.md: Tecnología añadida a stacks soportadas
-- [ ] docs/index.html: Stats incrementadas
-- [ ] docs/index.html: Tarjeta de tecnología añadida
-- [ ] docs/index.html: Traducciones i18n añadidas (5 idiomas)
+- [ ] README.md: Tecnología agregada a los stacks soportados
+- [ ] docs/index.html: Estadísticas incrementadas
+- [ ] docs/index.html: Tarjeta de tecnología agregada
+- [ ] docs/index.html: Traducciones i18n agregadas (5 idiomas)
 - [ ] docs/COMMANDS.md: Nuevos comandos documentados
-- [ ] Makefile: Target install-{tech} añadido
+- [ ] Makefile: Objetivo install-{tech} agregado
 
 🧪 VERIFICACIÓN
 ──────────────────────────────────────────────────────────────
 - [ ] El script de instalación se ejecuta sin errores
-- [ ] Todos los archivos están correctamente formateados
+- [ ] Todos los archivos tienen el formato correcto
 - [ ] Los comandos son funcionales
 - [ ] La documentación es precisa
 
 ══════════════════════════════════════════════════════════════
 ```
 
+### Formato de Salida
+
+Después de completar todos los pasos, proporcionar:
+
+```
+══════════════════════════════════════════════════════════════
+🎉 TECNOLOGÍA AGREGADA: {TECH_NAME}
+══════════════════════════════════════════════════════════════
+
+📊 RESUMEN
+──────────────────────────────────────────────────────────────
+Tecnología: {TECH_NAME}
+Categoría: {CATEGORY}
+Versión: {CURRENT_VERSION}
+
+Archivos creados: {COUNT}
+- Reglas: 35 archivos
+- Comandos: 25 archivos
+- Plantillas: {COUNT}
+- Checklists: 10 archivos
+- Agentes: 5 archivos
+
+📁 ESTRUCTURA
+──────────────────────────────────────────────────────────────
+Dev/i18n/
+├── en/{TECH}/
+├── fr/{TECH}/
+├── es/{TECH}/
+├── de/{TECH}/
+└── pt/{TECH}/
+
+Dev/scripts/
+└── install-{tech}-rules.sh
+
+🔧 INSTALACIÓN
+──────────────────────────────────────────────────────────────
+# Vía Makefile
+make install-{tech} TARGET=~/mi-proyecto RULES_LANG=en
+
+# Script directo
+./Dev/scripts/install-{tech}-rules.sh ~/mi-proyecto
+
+📚 DOCUMENTACIÓN
+──────────────────────────────────────────────────────────────
+- README.md ✅ Actualizado
+- docs/index.html ✅ Actualizado
+- docs/COMMANDS.md ✅ Actualizado
+- Makefile ✅ Actualizado
+
+✅ DEFINICIÓN DE HECHO: COMPLETA
+══════════════════════════════════════════════════════════════
+```
+
 ### Directrices Importantes
 
-1. **Investigar primero** - Siempre usar Context7 y búsqueda web antes de generar archivos
-2. **Seguir patrones** - Usar tecnologías existentes (React, Symfony, Flutter) como plantillas
-3. **Los 5 idiomas** - Generar contenido para en, fr, es, de, pt
-4. **Calidad sobre velocidad** - Asegurar que todos los archivos estén correctamente formateados
-5. **Actualizar todo** - No olvidar documentación y página de inicio
+1. **Investigar Primero** — Siempre usar Context7 y búsqueda web antes de generar archivos
+2. **Seguir Patrones** — Usar tecnologías existentes (React, Symfony, Flutter) como plantillas
+3. **Los 5 Idiomas** — Generar contenido para en, fr, es, de, pt
+4. **Calidad sobre Velocidad** — Asegurarse de que todos los archivos estén correctamente formateados y sean funcionales
+5. **Actualizar Todo** — No olvidar la documentación y la página de aterrizaje
 
 ### Manejo de Errores
 
 Si la investigación falla:
 - Indicar claramente qué información falta
 - Proponer fuentes alternativas
-- Pedir aclaraciones al usuario si es necesario
-- NUNCA generar archivos con contenido placeholder o inventado
+- Pedir aclaración al usuario si es necesario
+- NUNCA generar archivos con contenido provisional o inventado

--- a/Dev/i18n/es/Laravel/commands/check-compliance.md
+++ b/Dev/i18n/es/Laravel/commands/check-compliance.md
@@ -1,145 +1,253 @@
 ---
-description: Check Laravel project compliance with coding standards
+description: Verificar el cumplimiento completo de Laravel
+argument-hint: [argumentos]
 ---
 
-# Laravel Compliance Check
+# Verificar el cumplimiento completo de Laravel
 
-You are a Laravel expert auditor. Your mission is to verify that the project follows Laravel best practices and coding standards.
+## Argumentos
 
-## Audit Process
-
-### 1. Project Structure Analysis
-
-Check if the project follows the recommended architecture:
-
-```
-app/
-├── Domain/           # Business logic (if using Clean Architecture)
-├── Application/      # Use cases, Actions, DTOs
-├── Infrastructure/   # External services, Repositories
-├── Http/
-│   ├── Controllers/  # Thin controllers
-│   ├── Requests/     # Form Requests for validation
-│   ├── Resources/    # API Resources
-│   └── Middleware/
-├── Models/           # Eloquent models
-├── Services/         # Business services
-├── Jobs/             # Queue jobs
-├── Events/           # Domain events
-├── Listeners/        # Event listeners
-├── Policies/         # Authorization policies
-└── Providers/        # Service providers
-```
-
-### 2. Code Standards Verification
-
-#### Naming Conventions
-- [ ] Controllers: Singular, PascalCase (`OrderController`)
-- [ ] Models: Singular, PascalCase (`Order`, `OrderItem`)
-- [ ] Tables: Plural, snake_case (`orders`, `order_items`)
-- [ ] Columns: snake_case (`created_at`, `customer_id`)
-- [ ] Methods: camelCase (`getUserOrders()`)
-- [ ] Variables: camelCase (`$orderTotal`)
-
-#### Modern PHP Features (8.3+)
-- [ ] Constructor property promotion used
-- [ ] Readonly properties/classes where appropriate
-- [ ] Enums for status/type fields
-- [ ] Match expressions instead of switch
-- [ ] Named arguments for clarity
-- [ ] Type declarations on all methods
-- [ ] Return types specified
-
-#### Laravel Conventions
-- [ ] Form Requests for validation (not validation in controllers)
-- [ ] API Resources for response transformation
-- [ ] Policies for authorization
-- [ ] Eloquent casts for type conversion
-- [ ] Scopes for reusable queries
-- [ ] Events for cross-cutting concerns
-
-### 3. Architecture Compliance
-
-#### Layer Dependencies
-- Domain layer has NO external dependencies
-- Application layer only depends on Domain
-- Infrastructure implements Domain interfaces
-- Controllers are thin (delegate to Actions/Services)
-
-#### Repository Pattern (if applicable)
-- [ ] Interfaces defined in Domain/Contracts
-- [ ] Implementations in Infrastructure
-- [ ] Bindings in Service Providers
-
-### 4. Configuration Check
-
-- [ ] No hardcoded values (use config files)
-- [ ] Environment variables via config(), not env()
-- [ ] Sensitive data in .env (not committed)
-- [ ] Config caching compatible
-
-### 5. Generate Report
-
-After analysis, provide:
-
-1. **Compliance Score**: X/100
-2. **Critical Issues**: Must-fix problems
-3. **Warnings**: Recommended improvements
-4. **Good Practices**: What's done well
-5. **Action Items**: Prioritized list of fixes
+$ARGUMENTS (opcional: ruta del proyecto a analizar)
 
 ## Modo Plan
 
 > El modo plan se activa automáticamente cuando el alcance abarca varios módulos o requiere una investigación transversal.
 
-## Commands to Run
+## MISIÓN
 
-```bash
-# Check code style
-./vendor/bin/pint --test
+Realizar una auditoría de cumplimiento completa del proyecto Laravel orquestando las 4 verificaciones principales: Arquitectura, Calidad del Código, Pruebas y Seguridad. Producir un informe consolidado con una puntuación global sobre 100 puntos.
 
-# Static analysis
-./vendor/bin/phpstan analyse
+### Paso 1: Preparación de la auditoría
 
-# Run tests
-php artisan test
+Preparar el entorno de auditoría:
+- [ ] Identificar la ruta del proyecto a auditar
+- [ ] Verificar la presencia de archivos de configuración (composer.json con laravel/*, .env.example)
+- [ ] Listar los directorios principales (app/, tests/, config/, routes/, etc.)
+- [ ] Identificar la estructura del proyecto y la versión de Laravel
 
-# Check for security vulnerabilities
-composer audit
+**Nota**: Si se proporciona $ARGUMENTS, usarlo como ruta del proyecto; de lo contrario, usar el directorio actual.
+
+### Paso 2: Auditoría de Arquitectura (25 puntos)
+
+Ejecutar la verificación completa de arquitectura:
+
+**Comando**: Usar el comando slash `/laravel:check-architecture` o seguir manualmente los pasos en `check-architecture.md`
+
+**Criterios evaluados**:
+- Separación de capas de Arquitectura Limpia (6 pts)
+- Estructura Domain/Application/Infrastructure (6 pts)
+- Patrón Actions y controladores delgados (4 pts)
+- Bindings de Service Provider (4 pts)
+- Patrón Repository e interfaces (3 pts)
+- Reglas de dependencias (2 pts)
+
+**Referencia**: `check-architecture.md`
+
+### Paso 3: Auditoría de Calidad del Código (25 puntos)
+
+Ejecutar la verificación de calidad del código:
+
+**Comando**: Usar el comando slash `/laravel:check-code-quality` o seguir manualmente los pasos en `check-code-quality.md`
+
+**Criterios evaluados**:
+- Cumplimiento de PSR-12 y Laravel Pint (5 pts)
+- Análisis estático con PHPStan (5 pts)
+- Funcionalidades modernas de PHP (enums, readonly, typed properties) (4 pts)
+- Principios KISS/DRY/YAGNI (4 pts)
+- Convenciones de nomenclatura (estándares de Laravel) (4 pts)
+- Manejo de errores y logging (3 pts)
+
+**Referencia**: `check-code-quality.md`
+
+### Paso 4: Auditoría de Pruebas (25 puntos)
+
+Ejecutar la verificación de pruebas:
+
+**Comando**: Usar el comando slash `/laravel:check-testing` o seguir manualmente los pasos en `check-testing.md`
+
+**Criterios evaluados**:
+- Cobertura de código (7 pts)
+- Pruebas unitarias para lógica de dominio (6 pts)
+- Pruebas de funcionalidad para endpoints HTTP (4 pts)
+- Uso de Pest PHP y calidad de pruebas (3 pts)
+- Factories y seeders de base de datos (3 pts)
+- Aislamiento de pruebas y mocking (2 pts)
+
+**Referencia**: `check-testing.md`
+
+### Paso 5: Auditoría de Seguridad (25 puntos)
+
+Ejecutar la verificación de seguridad:
+
+**Comando**: Usar el comando slash `/laravel:check-security` o seguir manualmente los pasos en `check-security.md`
+
+**Criterios evaluados**:
+- Protecciones OWASP Top 10 (6 pts)
+- Gestión de secretos y credenciales (5 pts)
+- Validación con Form Request (4 pts)
+- Vulnerabilidades en dependencias (composer audit) (4 pts)
+- Autenticación y Autorización (Policies) (3 pts)
+- Configuración de CSRF y middlewares (2 pts)
+- Prevención de inyección SQL (1 pt)
+
+**Referencia**: `check-security.md`
+
+### Paso 6: Consolidación y Puntuación Global
+
+Calcular la puntuación general y producir el informe consolidado:
+- [ ] Sumar las 4 puntuaciones (máximo 100 puntos)
+- [ ] Identificar categorías críticas (<50%)
+- [ ] Listar todos los problemas transversales críticos
+- [ ] Priorizar acciones por impacto/esfuerzo
+- [ ] Producir el informe consolidado final
+
+**Escala de calificación**:
+- 90-100: Excelente — Proyecto de referencia
+- 75-89: Muy Bueno — Algunas mejoras menores
+- 60-74: Aceptable — Requiere mejoras
+- 40-59: Insuficiente — Refactorización mayor necesaria
+- 0-39: Crítico — Renovación completa necesaria
+
+### Paso 7: Recomendaciones y Plan de Acción
+
+Producir las recomendaciones finales:
+- [ ] Identificar las 3 principales acciones prioritarias en todas las categorías
+- [ ] Estimar el esfuerzo (Bajo/Medio/Alto) para cada acción
+- [ ] Estimar el impacto (Bajo/Medio/Alto) para cada acción
+- [ ] Proponer el orden de implementación
+- [ ] Sugerir victorias rápidas (relación alto impacto/esfuerzo)
+
+## FORMATO DE SALIDA
+
+```
+AUDITORÍA DE CUMPLIMIENTO LARAVEL - INFORME COMPLETO
+=============================================
+
+PUNTUACIÓN GLOBAL: XX/100
+
+NIVEL DE CUMPLIMIENTO: [Excelente/Muy Bueno/Aceptable/Insuficiente/Crítico]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PUNTUACIONES POR CATEGORÍA:
+
+ARQUITECTURA       : XX/25  [██████████░░░░░░░░░░] XX%
+CALIDAD DE CÓDIGO  : XX/25  [██████████░░░░░░░░░░] XX%
+PRUEBAS            : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURIDAD          : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+FORTALEZAS GENERALES:
+1. [Fortaleza identificada en múltiples categorías]
+2. [Otra fortaleza principal]
+3. [Tercera fortaleza]
+
+MEJORAS GENERALES:
+1. [Mejora transversal menor]
+2. [Otra mejora recomendada]
+3. [Tercera mejora]
+
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico #1 - categoría afectada]
+2. [Problema crítico #2 - categoría afectada]
+3. [Problema crítico #3 - categoría afectada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALLES POR CATEGORÍA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITECTURA (XX/25)                        │
+└─────────────────────────────────────────────┘
+
+Sub-puntuaciones:
+  • Capas de Arquitectura Limpia    : XX/6
+  • Estructura Domain/App/Infra     : XX/6
+  • Actions y controladores delgados: XX/4
+  • Bindings de Service Provider    : XX/4
+  • Patrón Repository               : XX/3
+  • Reglas de dependencias          : XX/2
+
+Fortalezas:
+- [Fortalezas de arquitectura]
+
+Problemas:
+- [Problemas de arquitectura]
+
+[Secciones similares para Calidad del Código, Pruebas y Seguridad...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 ACCIONES PRIORITARIAS (TODAS LAS CATEGORÍAS):
+
+1. CRÍTICO - [Acción #1]
+   Categoría  : [Arquitectura/Calidad/Pruebas/Seguridad]
+   Impacto    : [Alto/Medio/Bajo]
+   Esfuerzo   : [Alto/Medio/Bajo]
+   Prioridad  : INMEDIATA
+
+   Descripción detallada:
+   [Explicación del problema y solución propuesta]
+
+   Archivos afectados:
+   - [archivo:línea]
+
+   Ejemplo de corrección:
+   [Código o comando de corrección]
+
+2. IMPORTANTE - [Acción #2]
+   [Mismo formato...]
+
+3. RECOMENDADO - [Acción #3]
+   [Mismo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+VICTORIAS RÁPIDAS (Alto Impacto / Bajo Esfuerzo):
+
+- [Victoria rápida #1] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+- [Victoria rápida #2] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+- [Victoria rápida #3] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLAN DE ACCIÓN RECOMENDADO:
+
+SEMANA 1 (Inmediato):
+- [ ] [Acción crítica #1]
+- [ ] [Victoria rápida prioritaria]
+
+SEMANAS 2-4 (Corto plazo):
+- [ ] [Acción importante #2]
+- [ ] [Otras victorias rápidas]
+
+MESES 2-3 (Medio plazo):
+- [ ] [Acción recomendada #3]
+- [ ] [Mejoras progresivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMEN EJECUTIVO:
+
+[Párrafo de resumen sobre el estado general del proyecto, principales fortalezas,
+principales debilidades y la trayectoria recomendada para mejorar
+el cumplimiento. Indicar si el proyecto está listo para producción,
+requiere correcciones o necesita refactorización.]
+
+Recomendación General: [Listo para producción / Correcciones menores /
+Refactorización mayor / Renovación necesaria]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-## Output Format
+## NOTAS IMPORTANTES
 
-```markdown
-# Laravel Compliance Report
-
-## Summary
-- **Score**: 85/100
-- **Critical Issues**: 2
-- **Warnings**: 5
-- **Files Analyzed**: 150
-
-## Critical Issues
-
-### 1. Missing Form Request Validation
-**File**: `app/Http/Controllers/OrderController.php:45`
-**Issue**: Validation done in controller instead of Form Request
-**Fix**: Create `StoreOrderRequest` and move validation rules
-
-### 2. [Issue description]
-
-## Warnings
-
-### 1. [Warning description]
-
-## Recommendations
-
-1. [Recommendation 1]
-2. [Recommendation 2]
-
-## Good Practices Observed
-
-- Using Eloquent casts for type conversion
-- Proper use of API Resources
-- Events for decoupling
-```
+- Este comando orquesta las 4 auditorías especializadas
+- Usar Docker para todas las herramientas de análisis
+- Proporcionar ejemplos concretos con archivo:línea para cada problema
+- Priorizar acciones basándose en la matriz Impacto/Esfuerzo
+- Los problemas de seguridad son SIEMPRE la máxima prioridad
+- Proponer correcciones automatizables (scripts, hooks de pre-commit)
+- El informe debe ser accionable, no solo descriptivo
+- Adaptar las recomendaciones al contexto de negocio del proyecto

--- a/Dev/i18n/es/React/commands/check-testing.md
+++ b/Dev/i18n/es/React/commands/check-testing.md
@@ -1,70 +1,58 @@
 ---
-description: Verificacion de Testing
+description: Verificación de la estrategia de pruebas
 ---
 
-# Verificacion de Testing
+# Verificación de la Estrategia de Pruebas
 
-Analiza la cobertura de tests y la calidad de las pruebas en la aplicacion React.
+Verifica que la aplicación React tenga una cobertura de pruebas completa y siga las mejores prácticas de testing.
 
-## Que Hace Este Comando
+## Qué Hace Este Comando
 
-1. **Analisis de Cobertura**
-   - Medir cobertura de lineas
-   - Medir cobertura de funciones
-   - Medir cobertura de ramas
-   - Medir cobertura de sentencias
-   - Identificar codigo no cubierto
+1. **Análisis de Pruebas**
+   - Verificar la cobertura de pruebas
+   - Comprobar la calidad de las pruebas
+   - Validar los patrones de testing
+   - Verificar la organización de las pruebas
+   - Analizar el rendimiento de las pruebas
 
-2. **Calidad de Tests**
-   - Validar estructura de tests
-   - Verificar patron AAA
-   - Detectar tests flakey
-   - Verificar assertions
-   - Analizar tiempo de ejecucion
+2. **Métricas Medidas**
+   - Cobertura de código (líneas, funciones, ramas)
+   - Recuento de pruebas por tipo (unitarias, integración, e2e)
+   - Tiempo de ejecución de las pruebas
+   - Detección de pruebas inestables (flaky tests)
+   - Rutas críticas sin pruebas
 
-3. **Reporte Generado**
-   - Cobertura por archivo
-   - Archivos sin tests
+3. **Informe Generado**
+   - Informe de cobertura
+   - Pruebas faltantes
+   - Puntuación de calidad de pruebas
    - Recomendaciones
-   - Tendencias en el tiempo
+
+## Cómo Usar
+
+```bash
+# Ejecutar todas las pruebas con cobertura
+npm run test:coverage
+
+# Modo observación
+npm run test:watch
+
+# Modo UI
+npm run test:ui
+
+# Pruebas E2E
+npm run test:e2e
+```
 
 ## Modo Plan
 
 > El modo plan se activa automáticamente cuando el alcance abarca varios módulos o requiere una investigación transversal.
 
-## Ejecutar Tests
+## Análisis de Cobertura de Pruebas
 
-### Modo Desarrollo
+### Objetivos de Cobertura
 
-```bash
-# Modo watch
-npm run test
-
-# Ejecutar todos los tests
-npm run test:run
-
-# Con UI
-npm run test:ui
-```
-
-### Generar Cobertura
-
-```bash
-# Cobertura basica
-npm run test:coverage
-
-# Cobertura con HTML
-npm run test:coverage -- --reporter=html
-
-# Cobertura solo para archivos modificados
-npm run test:coverage -- --changed
-```
-
-## Objetivos de Cobertura
-
-### Niveles Minimos
-
-```typescript
+```json
 // vitest.config.ts
 export default defineConfig({
   test: {
@@ -80,24 +68,30 @@ export default defineConfig({
         'src/test/',
         '**/*.test.{ts,tsx}',
         '**/*.spec.{ts,tsx}',
-        '**/types.ts'
+        '**/*.d.ts',
+        'vite.config.ts'
       ]
     }
   }
 });
 ```
 
-### Por Categoria
+### Verificar la Cobertura
 
-- **Utilidades**: 95%+
-- **Hooks**: 90%+
-- **Componentes**: 85%+
-- **Paginas**: 70%+
-- **Configuracion**: 50%+
+```bash
+# Generar informe de cobertura
+npm run test:coverage
 
-## Tipos de Tests
+# Ver informe HTML
+open coverage/index.html
 
-### Tests Unitarios
+# Verificar umbral específico
+npm run test:coverage -- --coverage.lines=90
+```
+
+## Tipos de Pruebas
+
+### 1. Pruebas Unitarias (70% de las pruebas)
 
 ```typescript
 // Button.test.tsx
@@ -108,22 +102,27 @@ import { Button } from './Button';
 describe('Button', () => {
   it('should render with text', () => {
     render(<Button>Click me</Button>);
-    expect(screen.getByText('Click me')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toHaveTextContent('Click me');
   });
 
   it('should call onClick when clicked', async () => {
     const handleClick = vi.fn();
     const user = userEvent.setup();
 
-    render(<Button onClick={handleClick}>Click</Button>);
+    render(<Button onClick={handleClick}>Click me</Button>);
     await user.click(screen.getByRole('button'));
 
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
+
+  it('should be disabled when disabled prop is true', () => {
+    render(<Button disabled>Click me</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
 });
 ```
 
-### Tests de Integracion
+### 2. Pruebas de Integración (20% de las pruebas)
 
 ```typescript
 // UserManagement.integration.test.tsx
@@ -136,22 +135,22 @@ describe('UserManagement Integration', () => {
     const user = userEvent.setup();
     render(<UserManagement />);
 
-    // Esperar carga inicial
+    // Esperar la carga
     await waitFor(() => {
       expect(screen.getByText('John Doe')).toBeInTheDocument();
     });
 
-    // Hacer clic en agregar usuario
+    // Hacer clic en el botón agregar
     await user.click(screen.getByRole('button', { name: /add user/i }));
 
-    // Llenar formulario
+    // Rellenar el formulario
     await user.type(screen.getByLabelText(/name/i), 'New User');
     await user.type(screen.getByLabelText(/email/i), 'new@example.com');
 
     // Enviar
     await user.click(screen.getByRole('button', { name: /save/i }));
 
-    // Verificar que se agrego el usuario
+    // Verificar
     await waitFor(() => {
       expect(screen.getByText('New User')).toBeInTheDocument();
     });
@@ -159,154 +158,214 @@ describe('UserManagement Integration', () => {
 });
 ```
 
-### Tests E2E
+### 3. Pruebas E2E (10% de las pruebas)
 
 ```typescript
-// e2e/auth.spec.ts
+// auth.spec.ts (Playwright)
 import { test, expect } from '@playwright/test';
 
 test.describe('Authentication', () => {
   test('should login successfully', async ({ page }) => {
     await page.goto('/');
-
     await page.click('text=Login');
+
     await page.fill('input[name="email"]', 'user@example.com');
     await page.fill('input[name="password"]', 'password123');
     await page.click('button[type="submit"]');
 
     await expect(page).toHaveURL('/dashboard');
-    await expect(page.locator('text=Welcome back')).toBeVisible();
+    await expect(page.locator('text=Welcome')).toBeVisible();
   });
 });
 ```
 
-## Mejores Practicas
+## Verificaciones de Calidad de Pruebas
 
-### Patron AAA
+### 1. Patrón AAA
 
 ```typescript
-// Arrange (Preparar), Act (Actuar), Assert (Afirmar)
+// ✅ BIEN - Arrange, Act, Assert (Preparar, Actuar, Verificar)
 it('should increment counter', async () => {
-  // Arrange
+  // Arrange (Preparar)
   const user = userEvent.setup();
   render(<Counter initialCount={0} />);
 
-  // Act
+  // Act (Actuar)
   await user.click(screen.getByRole('button', { name: /increment/i }));
 
-  // Assert
+  // Assert (Verificar)
   expect(screen.getByText('Count: 1')).toBeInTheDocument();
 });
 ```
 
-### Prioridad de Queries
+### 2. Probar el Comportamiento, No la Implementación
 
 ```typescript
-// 1. Queries accesibles (mejores)
+// ❌ MAL - Probar la implementación
+it('should call setState', () => {
+  const setStateSpy = vi.spyOn(React, 'useState');
+  // ...
+});
+
+// ✅ BIEN - Probar el comportamiento
+it('should display incremented count', async () => {
+  const user = userEvent.setup();
+  render(<Counter />);
+
+  await user.click(screen.getByRole('button', { name: /increment/i }));
+
+  expect(screen.getByText('Count: 1')).toBeInTheDocument();
+});
+```
+
+### 3. Nombres de Prueba Descriptivos
+
+```typescript
+// ❌ MAL - Nombres vagos
+it('works');
+it('test 1');
+it('should render');
+
+// ✅ BIEN - Nombres descriptivos
+it('should display user name when user data is loaded');
+it('should show error message when email is invalid');
+it('should disable submit button while form is submitting');
+```
+
+### 4. Prioridad de Consultas
+
+```typescript
+// ✅ BIEN - Consultas accesibles (las mejores)
 screen.getByRole('button', { name: /submit/i });
 screen.getByLabelText(/email/i);
-screen.getByPlaceholderText(/search/i);
 screen.getByText(/welcome/i);
 
-// 2. Queries semanticas
-screen.getByAltText(/profile picture/i);
+// ⚠️ ACEPTABLE - Consultas semánticas
+screen.getByAltText(/profile/i);
 screen.getByTitle(/close/i);
 
-// 3. Test IDs (ultimo recurso)
+// ❌ EVITAR - IDs de prueba (último recurso)
 screen.getByTestId('custom-element');
 ```
 
-### Mocking
+## Organización de Pruebas
 
-```typescript
-// Mockear servicios
-vi.mock('@/services/user.service');
+### Estructura de Carpetas
 
-// Mockear hooks
-vi.mock('@/hooks/useAuth', () => ({
-  useAuth: () => ({
-    user: { id: '1', name: 'Test User' },
-    isAuthenticated: true
-  })
-}));
-
-// Mockear componentes
-vi.mock('@/components/ComplexComponent', () => ({
-  ComplexComponent: () => <div>Mocked Component</div>
-}));
+```
+src/
+├── components/
+│   └── Button/
+│       ├── Button.tsx
+│       ├── Button.test.tsx       # Pruebas unitarias
+│       └── Button.stories.tsx    # Storybook
+│
+├── features/
+│   └── users/
+│       ├── components/
+│       │   └── UserList/
+│       │       ├── UserList.tsx
+│       │       └── UserList.test.tsx
+│       ├── hooks/
+│       │   └── useUsers.test.ts
+│       └── UserManagement.integration.test.tsx  # Integración
+│
+├── test/
+│   ├── setup.ts                  # Configuración de pruebas
+│   ├── mocks/
+│   │   └── handlers.ts           # Manejadores MSW
+│   └── utils/
+│       └── test-utils.tsx        # Utilidades de prueba
+│
+└── e2e/                          # Pruebas E2E
+    ├── auth.spec.ts
+    └── users.spec.ts
 ```
 
-## Analisis de Calidad
-
-### Tests Flakey
+### Utilidades de Prueba
 
 ```typescript
-// ❌ MAL - Test flakey
+// test/utils/test-utils.tsx
+import { render, RenderOptions } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+
+const AllProviders = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>{children}</BrowserRouter>
+    </QueryClientProvider>
+  );
+};
+
+export const renderWithProviders = (
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) => render(ui, { wrapper: AllProviders, ...options });
+
+export * from '@testing-library/react';
+```
+
+## Problemas Comunes de Pruebas
+
+### Problema 1: Pruebas Inestables (Flaky Tests)
+
+```typescript
+// ❌ MAL - Condición de carrera
 it('should load data', () => {
   render(<DataComponent />);
-
-  // No espera la carga asincrona
   expect(screen.getByText('Data loaded')).toBeInTheDocument();
+  // Falla aleatoriamente si los datos tardan en cargar
 });
 
-// ✅ BIEN - Test estable
+// ✅ BIEN - Esperar los datos
 it('should load data', async () => {
   render(<DataComponent />);
-
-  // Espera la carga asincrona
   await waitFor(() => {
     expect(screen.getByText('Data loaded')).toBeInTheDocument();
   });
 });
 ```
 
-### Tests Lentos
+### Problema 2: Advertencias de Act Faltante
 
 ```typescript
-// ❌ MAL - Multiples re-renders
-it('should update state', () => {
-  const { rerender } = render(<Component value={1} />);
-  rerender(<Component value={2} />);
-  rerender(<Component value={3} />);
-  rerender(<Component value={4} />);
+// ❌ MAL - Actualización de estado fuera de act
+it('should update count', () => {
+  const { result } = renderHook(() => useCounter());
+  result.current.increment(); // ¡Advertencia!
 });
 
-// ✅ BIEN - Test directo
-it('should update state', async () => {
-  render(<Component />);
-
-  await userEvent.click(screen.getByRole('button'));
-
-  expect(screen.getByText('Updated')).toBeInTheDocument();
-});
-```
-
-## Tests de Hooks
-
-```typescript
-// useCounter.test.ts
-import { renderHook, act } from '@testing-library/react';
-import { useCounter } from './useCounter';
-
-describe('useCounter', () => {
-  it('should initialize with default value', () => {
-    const { result } = renderHook(() => useCounter());
-    expect(result.current.count).toBe(0);
-  });
-
-  it('should increment count', () => {
-    const { result } = renderHook(() => useCounter());
-
-    act(() => {
-      result.current.increment();
-    });
-
-    expect(result.current.count).toBe(1);
+// ✅ BIEN - Envolver en act
+it('should update count', () => {
+  const { result } = renderHook(() => useCounter());
+  act(() => {
+    result.current.increment();
   });
 });
 ```
 
-## Tests con MSW
+### Problema 3: No Limpiar Después de las Pruebas
+
+```typescript
+// ✅ BIEN - Limpieza automática
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});
+```
+
+## MSW (Mock Service Worker)
+
+### Configuración
 
 ```typescript
 // test/mocks/handlers.ts
@@ -318,6 +377,11 @@ export const handlers = [
       { id: '1', name: 'John Doe' },
       { id: '2', name: 'Jane Smith' }
     ]);
+  }),
+
+  http.post('/api/users', async ({ request }) => {
+    const newUser = await request.json();
+    return HttpResponse.json({ id: '3', ...newUser }, { status: 201 });
   })
 ];
 
@@ -326,20 +390,50 @@ import { setupServer } from 'msw/node';
 import { handlers } from './handlers';
 
 export const server = setupServer(...handlers);
+```
 
-// Uso en tests
-describe('UserList', () => {
-  it('should display users', async () => {
-    render(<UserList />);
+### Uso
 
-    await waitFor(() => {
-      expect(screen.getByText('John Doe')).toBeInTheDocument();
-    });
-  });
+```typescript
+// test/setup.ts
+import { beforeAll, afterEach, afterAll } from 'vitest';
+import { server } from './mocks/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+## Pruebas de Rendimiento
+
+```typescript
+// Verificar el rendimiento de renderizado
+it('should render list efficiently', () => {
+  const start = performance.now();
+
+  render(<LargeList items={items} />);
+
+  const duration = performance.now() - start;
+  expect(duration).toBeLessThan(100); // ms
 });
 ```
 
-## Integracion CI/CD
+## Informes de Pruebas
+
+### Informe de Cobertura
+
+```bash
+# Generar informe HTML
+npm run test:coverage
+
+# Ver informe
+open coverage/index.html
+
+# CI: Subir a Codecov
+bash <(curl -s https://codecov.io/bash)
+```
+
+### Resultados de Pruebas en CI
 
 ```yaml
 # .github/workflows/test.yml
@@ -350,12 +444,9 @@ on: [push, pull_request]
 jobs:
   test:
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
-        with:
-          node-version: '22'
 
       - name: Install dependencies
         run: npm ci
@@ -365,34 +456,37 @@ jobs:
 
       - name: Upload coverage
         uses: codecov/codecov-action@v3
-        with:
-          files: ./coverage/lcov.info
 ```
 
-## Lista de Verificacion
+## Lista de Verificación de Pruebas
 
-- [ ] Cobertura > 80% para codigo critico
-- [ ] Tests siguen patron AAA
-- [ ] Sin tests flakey
-- [ ] Mocks apropiados para APIs
-- [ ] Tests rapidos (< 5s por suite)
-- [ ] Queries accesibles usadas
-- [ ] Tests de integracion para flujos criticos
-- [ ] Tests E2E para journeys de usuario
-- [ ] CI/CD ejecuta tests automaticamente
-- [ ] Cobertura monitoreada en el tiempo
+- [ ] Pruebas unitarias para todos los componentes
+- [ ] Pruebas unitarias para todos los hooks
+- [ ] Pruebas unitarias para todas las utilidades
+- [ ] Pruebas de integración para las funcionalidades
+- [ ] Pruebas E2E para los flujos críticos
+- [ ] Cobertura > 80%
+- [ ] Sin pruebas inestables (flaky tests)
+- [ ] Las pruebas son rápidas (< 1s cada una)
+- [ ] MSW para el mocking de API
+- [ ] Utilidades de prueba extraídas
+- [ ] Las pruebas siguen el patrón AAA
+- [ ] Las pruebas tienen nombres descriptivos
+- [ ] Las pruebas usan consultas accesibles
 
 ## Herramientas
 
-- **Vitest** - Framework de testing
-- **React Testing Library** - Testing de componentes
-- **Playwright** - Tests E2E
-- **MSW** - Mocking de API
-- **Codecov** - Reporte de cobertura
+- **Vitest**: Ejecutor de pruebas unitarias
+- **React Testing Library**: Pruebas de componentes
+- **Playwright**: Pruebas E2E
+- **MSW**: Mocking de API
+- **Testing Library User Event**: Interacciones de usuario
+- **Codecov**: Reportes de cobertura
 
 ## Recursos
 
-- [Documentacion Vitest](https://vitest.dev/)
 - [React Testing Library](https://testing-library.com/react)
-- [Documentacion Playwright](https://playwright.dev/)
-- [Guia de Testing de Kent C. Dodds](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)
+- [Documentación de Vitest](https://vitest.dev/)
+- [Documentación de Playwright](https://playwright.dev/)
+- [Documentación de MSW](https://mswjs.io/)
+- [Mejores Prácticas de Testing](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)

--- a/Dev/i18n/es/ReactNative/commands/check-testing.md
+++ b/Dev/i18n/es/ReactNative/commands/check-testing.md
@@ -1,262 +1,320 @@
 ---
-description: Verificación de Testing
+description: Verificar Testing de React Native
+argument-hint: [arguments]
 ---
 
-# Verificación de Testing
+# Verificar Testing de React Native
 
-Verifica la cobertura y calidad de los tests en React Native.
+## Argumentos
 
-## 1. Ejecutar Tests
-
-```bash
-# Todos los tests
-npm test
-
-# En modo watch
-npm test -- --watch
-
-# Con cobertura
-npm test -- --coverage
-
-# Tests específicos
-npm test -- UserProfile
-```
+$ARGUMENTS
 
 ## Modo Plan
 
 > El modo plan se activa automáticamente cuando el alcance abarca varios módulos o requiere una investigación transversal.
 
-## 2. Análisis de Cobertura
+## MISIÓN
+
+Eres un experto en auditoría de testing de React Native. Tu misión es analizar la estrategia de pruebas y la cobertura de acuerdo con los estándares definidos en `.claude/rules/07-testing.md` y `.claude/rules/08-quality-tools.md`.
+
+### Paso 1: Análisis de la configuración de pruebas
+
+1. Verificar la presencia y configuración de Jest
+2. Verificar la presencia y configuración de React Native Testing Library (RNTL)
+3. Verificar la presencia y configuración de Detox (pruebas E2E)
+4. Analizar los scripts de prueba en package.json
+
+### Paso 2: Configuración de Jest (5 puntos)
+
+#### 🧪 Archivos de configuración
+
+- [ ] **(1 pt)** `jest.config.js` o configuración en package.json presente
+- [ ] **(1 pt)** Preset de React Native configurado (`@react-native/jest-preset` o equivalente)
+- [ ] **(1 pt)** Archivos de configuración definidos (`setupFilesAfterEnv`)
+- [ ] **(1 pt)** Cobertura de código habilitada (coverage)
+- [ ] **(1 pt)** Transformaciones configuradas para TypeScript y React Native
+
+**Archivos a verificar:**
+```bash
+jest.config.js
+jest.setup.js
+package.json
+```
+
+#### 📊 Configuración de cobertura
+
+Verificar en `jest.config.js`:
+```javascript
+coverageThreshold: {
+  global: {
+    branches: 80,
+    functions: 80,
+    lines: 80,
+    statements: 80
+  }
+}
+```
+
+- [ ] Umbrales de cobertura definidos (≥ 80% recomendado)
+- [ ] Recopilación desde las carpetas correctas (src/, app/)
+- [ ] Exclusiones apropiadas (node_modules, __tests__, etc.)
+
+### Paso 3: Pruebas Unitarias con RNTL (8 puntos)
+
+Referencia: `.claude/rules/07-testing.md`
+
+#### 📁 Organización de pruebas
+
+- [ ] **(1 pt)** Pruebas colocadas junto a los componentes o en `__tests__/`
+- [ ] **(1 pt)** Convención de nomenclatura: `*.test.tsx` o `*.spec.tsx`
+- [ ] **(1 pt)** Estructura AAA (Arrange, Act, Assert) respetada
+
+**Archivos a verificar:**
+```bash
+src/**/__tests__/
+src/**/*.test.tsx
+src/**/*.spec.tsx
+```
+
+#### 🧩 Calidad de las pruebas unitarias
+
+Analizar entre 5 y 10 archivos de prueba:
+
+- [ ] **(1 pt)** Uso de `@testing-library/react-native` (render, fireEvent, waitFor)
+- [ ] **(1 pt)** Pruebas de componentes aisladas con props simuladas
+- [ ] **(1 pt)** Pruebas de hooks personalizados con `@testing-library/react-hooks`
+- [ ] **(1 pt)** Mocks apropiados para módulos nativos (AsyncStorage, etc.)
+- [ ] **(1 pt)** Pruebas de casos límite y errores
+
+**Ejemplo de buena prueba:**
+```typescript
+describe('LoginButton', () => {
+  it('should call onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<LoginButton onPress={onPress} />);
+
+    fireEvent.press(getByText('Login'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+### Paso 4: Pruebas de Integración (4 puntos)
+
+- [ ] **(1 pt)** Pruebas de flujos de usuario completos
+- [ ] **(1 pt)** Pruebas de navegación entre pantallas
+- [ ] **(1 pt)** Pruebas de llamadas a API simuladas
+- [ ] **(1 pt)** Pruebas de gestión del estado (Context, Redux, Zustand)
+
+**Archivos a verificar:**
+```bash
+src/**/*.integration.test.tsx
+__tests__/integration/
+```
+
+### Paso 5: Pruebas E2E con Detox (4 puntos)
+
+#### 🤖 Configuración de Detox
+
+- [ ] **(1 pt)** `.detoxrc.js` o configuración de Detox presente
+- [ ] **(1 pt)** Configuración para iOS y Android
+- [ ] **(1 pt)** Scripts de prueba E2E en package.json (`test:e2e`)
+
+**Archivos a verificar:**
+```bash
+.detoxrc.js
+.detoxrc.json
+e2e/
+package.json
+```
+
+#### 🎬 Pruebas E2E
+
+- [ ] **(1 pt)** Al menos 3 escenarios E2E críticos probados (inicio de sesión, navegación principal, acción clave)
+
+**Archivos a verificar:**
+```bash
+e2e/**/*.e2e.ts
+e2e/**/*.e2e.js
+```
+
+### Paso 6: Cobertura de Pruebas (4 puntos)
+
+Ejecutar el comando de cobertura:
 
 ```bash
-# Generar reporte de cobertura
-npm test -- --coverage
-
-# Ver reporte HTML
-open coverage/lcov-report/index.html
+npm run test -- --coverage
+# o
+yarn test --coverage
 ```
 
-**Objetivos de Cobertura:**
-- Statements: > 80%
-- Branches: > 80%
-- Functions: > 80%
-- Lines: > 80%
+Analizar el informe de cobertura:
 
-## 3. Tipos de Tests
+- [ ] **(1 pt)** Cobertura global ≥ 80%
+- [ ] **(1 pt)** Cobertura de ramas ≥ 75%
+- [ ] **(1 pt)** Componentes críticos cubiertos al 100%
+- [ ] **(1 pt)** Informe de cobertura generado (coverage/lcov-report/)
 
-### Tests Unitarios
-
-```typescript
-// Component.test.tsx
-describe('Button', () => {
-  it('renders correctly', () => {
-    const { getByText } = render(<Button>Click me</Button>);
-    expect(getByText('Click me')).toBeTruthy();
-  });
-});
-```
-
-**Checklist:**
-- [ ] Componentes críticos testeados
-- [ ] Hooks personalizados testeados
-- [ ] Utils y helpers testeados
-- [ ] Edge cases cubiertos
-
-### Tests de Integración
-
-```typescript
-// Feature.integration.test.tsx
-describe('User Flow', () => {
-  it('completes registration', async () => {
-    const { getByText, getByPlaceholder } = render(<App />);
-
-    // Navegar a registro
-    fireEvent.press(getByText('Sign Up'));
-
-    // Llenar formulario
-    fireEvent.changeText(getByPlaceholder('Email'), 'user@test.com');
-
-    // Submit
-    fireEvent.press(getByText('Submit'));
-
-    // Verificar
-    await waitFor(() => {
-      expect(getByText('Welcome')).toBeTruthy();
-    });
-  });
-});
-```
-
-**Checklist:**
-- [ ] Flujos de usuario críticos testeados
-- [ ] Navegación testeada
-- [ ] Formularios completos testeados
-- [ ] Integración con APIs mockeada
-
-### Tests E2E (Detox)
-
-```typescript
-// e2e/login.e2e.ts
-describe('Login Flow', () => {
-  it('should login successfully', async () => {
-    await element(by.id('email-input')).typeText('user@example.com');
-    await element(by.id('password-input')).typeText('password123');
-    await element(by.id('login-button')).tap();
-
-    await waitFor(element(by.text('Dashboard')))
-      .toBeVisible()
-      .withTimeout(5000);
-  });
-});
-```
-
-**Checklist:**
-- [ ] Flujos críticos E2E
-- [ ] Login/Logout
-- [ ] Flujos de compra/reserva
-- [ ] Configuración Detox correcta
-
-## 4. Calidad de los Tests
-
-### Buenos Tests
-
-```typescript
-// ✅ BIEN - Descripción clara, AAA pattern
-describe('UserProfile', () => {
-  it('displays user name after successful fetch', async () => {
-    // Arrange
-    const mockUser = { name: 'John Doe' };
-    server.use(
-      http.get('/api/user', () => HttpResponse.json(mockUser))
-    );
-
-    // Act
-    const { findByText } = render(<UserProfile />);
-
-    // Assert
-    const nameElement = await findByText('John Doe');
-    expect(nameElement).toBeTruthy();
-  });
-});
-```
-
-**Checklist:**
-- [ ] Nombres descriptivos
-- [ ] Patrón AAA (Arrange, Act, Assert)
-- [ ] Un solo concepto por test
-- [ ] Tests independientes
-- [ ] Sin lógica compleja en tests
-
-## 5. Mocking
-
-```typescript
-// Mock de módulos
-jest.mock('@/services/api', () => ({
-  fetchUser: jest.fn()
-}));
-
-// Mock de hooks
-jest.mock('@react-navigation/native', () => ({
-  useNavigation: () => ({
-    navigate: jest.fn()
-  })
-}));
-
-// Mock de AsyncStorage
-jest.mock('@react-native-async-storage/async-storage', () =>
-  require('@react-native-async-storage/async-storage/jest/async-storage-mock')
-);
-```
-
-**Checklist:**
-- [ ] APIs mockeadas con MSW
-- [ ] AsyncStorage mockeado
-- [ ] Navigation mockeada
-- [ ] Módulos nativos mockeados
-
-## 6. Snapshot Tests
-
-```typescript
-it('matches snapshot', () => {
-  const tree = renderer
-    .create(<Button variant="primary">Click me</Button>)
-    .toJSON();
-  expect(tree).toMatchSnapshot();
-});
-```
-
-**Checklist:**
-- [ ] Componentes UI críticos con snapshots
-- [ ] Snapshots actualizados regularmente
-- [ ] Cambios de snapshot revisados
-- [ ] No abusar de snapshots
-
-## 7. Tests de Performance
-
-```typescript
-it('renders large list efficiently', () => {
-  const items = Array.from({ length: 1000 }, (_, i) => ({ id: i }));
-
-  const start = performance.now();
-  render(<ItemList items={items} />);
-  const end = performance.now();
-
-  expect(end - start).toBeLessThan(100); // menos de 100ms
-});
-```
-
-## 8. Reporte de Tests
-
+**Archivos a verificar:**
 ```bash
-# Ver reporte de cobertura
-npm test -- --coverage
-
-# Ver tests fallidos
-npm test -- --onlyFailures
-
-# Ver tests lentos
-npm test -- --verbose
+coverage/lcov-report/index.html
+coverage/coverage-summary.json
 ```
 
-## Métricas Clave
+### Paso 7: Calcular la puntuación
 
-| Métrica | Objetivo | Actual |
-|---------|----------|--------|
-| Cobertura Total | > 80% | ___% |
-| Tests Unitarios | > 500 | ___ |
-| Tests Integración | > 50 | ___ |
-| Tests E2E | > 10 | ___ |
-| Tiempo Ejecución | < 5 min | ___ |
-
-## Problemas Comunes
-
-### Tests Lentos
-```bash
-# Identificar tests lentos
-npm test -- --verbose
-
-# Usar test.concurrent para paralelizar
-it.concurrent('test 1', async () => {});
+```
+┌──────────────────────────────────┬─────────┬────────┐
+│ Criterio                         │ Puntos  │ Estado │
+├──────────────────────────────────┼─────────┼────────┤
+│ Configuración de Jest            │ XX/5    │ ✅/⚠️/❌│
+│ Pruebas Unitarias (RNTL)         │ XX/8    │ ✅/⚠️/❌│
+│ Pruebas de Integración           │ XX/4    │ ✅/⚠️/❌│
+│ Pruebas E2E (Detox)              │ XX/4    │ ✅/⚠️/❌│
+│ Cobertura de Código              │ XX/4    │ ✅/⚠️/❌│
+├──────────────────────────────────┼─────────┼────────┤
+│ TOTAL TESTING                    │ XX/25   │ ✅/⚠️/❌│
+└──────────────────────────────────┴─────────┴────────┘
 ```
 
-### Tests Flaky
-- Usar waitFor para esperas asíncronas
-- No usar timeouts arbitrarios
-- Mockear APIs correctamente
-- Limpiar estado entre tests
+**Leyenda:**
+- ✅ Excelente (≥ 20/25)
+- ⚠️ Advertencia (15-19/25)
+- ❌ Crítico (< 15/25)
 
-### Baja Cobertura
-- Identificar archivos sin cobertura
-- Priorizar componentes críticos
-- Escribir tests antes del código (TDD)
-- Refactorizar código no testeable
+### Paso 8: Informe detallado
 
-## Reporte Final
+## 📊 RESULTADOS DE LA AUDITORÍA DE TESTING
 
-**Estado de Testing:**
-- [ ] Cobertura > 80%
-- [ ] Todos los tests pasando
-- [ ] Sin tests flaky
-- [ ] Tests rápidos (< 5 min)
-- [ ] CI/CD configurado
-- [ ] Tests E2E funcionando
+### ✅ Fortalezas
+
+Enumerar las buenas prácticas identificadas:
+- [Práctica 1 con ejemplo de prueba]
+- [Práctica 2 con ejemplo de prueba]
+
+### ⚠️ Puntos de Mejora
+
+Enumerar los problemas identificados por prioridad:
+
+1. **[Problema 1]**
+   - **Gravedad:** Crítica/Alta/Media
+   - **Ubicación:** [Archivos/componentes sin pruebas]
+   - **Impacto:** [Riesgo de regresión]
+   - **Recomendación:** [Acciones a tomar]
+
+2. **[Problema 2]**
+   - **Gravedad:** Crítica/Alta/Media
+   - **Ubicación:** [Archivos/componentes sin pruebas]
+   - **Impacto:** [Riesgo de regresión]
+   - **Recomendación:** [Acciones a tomar]
+
+### 📈 Métricas de Testing
+
+#### Cobertura de código
+
+```
+┌─────────────────┬──────────┬──────────┬──────────┬──────────┐
+│ Tipo            │ Líneas   │ Ramas    │ Funciones│ Sentencias│
+├─────────────────┼──────────┼──────────┼──────────┼──────────┤
+│ Global          │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+│ Componentes     │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+│ Hooks           │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+│ Utils           │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+│ Servicios       │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+└─────────────────┴──────────┴──────────┴──────────┴──────────┘
+```
+
+#### Estadísticas de pruebas
+
+- **Número total de pruebas:** XX
+  - Pruebas unitarias: XX
+  - Pruebas de integración: XX
+  - Pruebas E2E: XX
+- **Pruebas aprobadas:** XX
+- **Pruebas fallidas:** XX
+- **Tiempo total de ejecución:** XX segundos
+- **Ratio pruebas/código:** XX pruebas para YY líneas de código
+
+#### Componentes sin pruebas
+
+Enumerar los componentes críticos sin pruebas:
+1. `[Ruta/Componente]` - [Razón de criticidad]
+2. `[Ruta/Componente]` - [Razón de criticidad]
+3. `[Ruta/Componente]` - [Razón de criticidad]
+
+#### Funcionalidades críticas probadas
+
+- [ ] Autenticación (login, logout, refresh token)
+- [ ] Navegación principal
+- [ ] Formularios críticos
+- [ ] Llamadas principales a la API
+- [ ] Manejo de errores
+- [ ] Estados de carga
+- [ ] Gestión offline
+
+### 🎯 TOP 3 ACCIONES PRIORITARIAS
+
+#### 1. [ACCIÓN #1]
+- **Esfuerzo:** Bajo/Medio/Alto
+- **Impacto:** Crítico/Alto/Medio
+- **Descripción:** [Componentes/funcionalidades a probar con prioridad]
+- **Cobertura actual:** XX%
+- **Cobertura objetivo:** YY%
+- **Archivos afectados:**
+  - `[archivo1]` (cobertura: XX%)
+  - `[archivo2]` (cobertura: XX%)
+- **Ejemplo de pruebas a añadir:**
+```typescript
+describe('[Componente]', () => {
+  it('should [comportamiento]', () => {
+    // Prueba a implementar
+  });
+});
+```
+
+#### 2. [ACCIÓN #2]
+- **Esfuerzo:** Bajo/Medio/Alto
+- **Impacto:** Crítico/Alto/Medio
+- **Descripción:** [Configuración o mejora de pruebas]
+- **Archivos afectados:** [Lista]
+
+#### 3. [ACCIÓN #3]
+- **Esfuerzo:** Bajo/Medio/Alto
+- **Impacto:** Crítico/Alto/Medio
+- **Descripción:** [Pruebas E2E o de integración a añadir]
+- **Escenarios a cubrir:**
+  - [Escenario 1]
+  - [Escenario 2]
+
+---
+
+## 🚀 Recomendaciones
+
+### Victorias Rápidas (Bajo esfuerzo, alto impacto)
+- [Mejora rápida 1]
+- [Mejora rápida 2]
+
+### Inversiones (Esfuerzo medio/alto, alto impacto)
+- [Mejora estructural 1]
+- [Mejora estructural 2]
+
+### Buenas prácticas a adoptar
+- Escribir pruebas junto al código (TDD)
+- Apuntar a una cobertura mínima del 80%
+- Probar casos límite y errores
+- Mantener las pruebas actualizadas con el código
+- Usar snapshots con moderación
+
+---
+
+## 📚 Referencias
+
+- `.claude/rules/07-testing.md` - Estándares de testing
+- `.claude/rules/08-quality-tools.md` - Herramientas de calidad
+- [React Native Testing Library](https://callstack.github.io/react-native-testing-library/)
+- [Detox Documentation](https://wix.github.io/Detox/)
+
+---
+
+**Puntuación final: XX/25**

--- a/Dev/i18n/es/Symfony/commands/check-compliance.md
+++ b/Dev/i18n/es/Symfony/commands/check-compliance.md
@@ -1,13 +1,13 @@
 ---
-description: Auditoría Completa de Cumplimiento Symfony
+description: Verificación Completa de Conformidad de Symfony
 argument-hint: [arguments]
 ---
 
-# Auditoría Completa de Cumplimiento Symfony
+# Verificación Completa de Conformidad de Symfony
 
 ## Argumentos
 
-$ARGUMENTS : Ruta del proyecto Symfony a auditar (opcional, por defecto: directorio actual)
+$ARGUMENTS (opcional: ruta al proyecto a analizar)
 
 ## Modo Plan
 
@@ -15,167 +15,239 @@ $ARGUMENTS : Ruta del proyecto Symfony a auditar (opcional, por defecto: directo
 
 ## MISIÓN
 
-Eres un auditor experto de Symfony encargado de realizar una auditoría completa de cumplimiento de un proyecto Symfony.
+Realizar una auditoría de conformidad completa del proyecto Symfony orquestando las 4 verificaciones principales: Arquitectura, Calidad de Código, Pruebas y Seguridad. Producir un informe consolidado con una puntuación global sobre 100 puntos.
 
-### Paso 1: Verificación del proyecto
+### Paso 1: Preparación de la Auditoría
 
-1. Identifica el directorio del proyecto a auditar
-2. Verifica que se trata de un proyecto Symfony (presencia de composer.json con symfony/*)
-3. Verifica la versión de Symfony utilizada
+Preparar el entorno de auditoría:
+- [ ] Identificar la ruta del proyecto a auditar
+- [ ] Verificar la presencia de los archivos de configuración (composer.json con symfony/*, .env)
+- [ ] Listar los directorios principales (src/, tests/, config/, etc.)
+- [ ] Identificar la estructura del proyecto y la versión de Symfony
+
+**Nota**: Si se proporcionan $ARGUMENTS, usarlos como ruta del proyecto; en caso contrario, usar el directorio actual.
 
 ### Paso 2: Auditoría de Arquitectura (25 puntos)
 
-Ejecuta la auditoría de arquitectura verificando:
+Ejecutar la verificación completa de arquitectura:
 
-**Referencia a las reglas**: `.claude/rules/symfony-architecture.md`
+**Comando**: Usar el comando slash `/symfony:check-architecture` o seguir manualmente los pasos de `check-architecture.md`
 
-- [ ] La estructura de carpetas respeta Clean Architecture
-- [ ] Separación Domain / Application / Infrastructure
-- [ ] Respeto de los principios DDD (Entities, Value Objects, Aggregates)
-- [ ] Arquitectura Hexagonal (Ports & Adapters)
-- [ ] Uso de Deptrac para verificar las dependencias
-- [ ] Ausencia de acoplamiento entre capas
-- [ ] Interfaces correctamente definidas para los puertos
-- [ ] Use Cases / Application Services bien definidos
-- [ ] Repositories con interfaces en el domain
-- [ ] DTOs para las transferencias de datos
+**Criterios Evaluados**:
+- Estructura de Clean Architecture (6 pts)
+- Separación Dominio/Aplicación/Infraestructura (6 pts)
+- Arquitectura Hexagonal / Ports & Adapters (4 pts)
+- Modelado DDD (Entidades, Value Objects, Agregados) (4 pts)
+- Use Cases y Application Services (3 pts)
+- Reglas de dependencia y Deptrac (2 pts)
 
-**Puntuación Arquitectura**: ___/25 puntos
+**Referencia**: `check-architecture.md`
 
-### Paso 3: Auditoría de Calidad del Código (25 puntos)
+### Paso 3: Auditoría de Calidad de Código (25 puntos)
 
-Ejecuta la auditoría de calidad del código verificando:
+Ejecutar la verificación de calidad de código:
 
-**Referencia a las reglas**: `.claude/rules/symfony-code-quality.md`
+**Comando**: Usar el comando slash `/symfony:check-code-quality` o seguir manualmente los pasos de `check-code-quality.md`
 
-- [ ] Respeto de PSR-12
-- [ ] PHPStan nivel 9 sin errores
-- [ ] Type hints estrictos en todos los parámetros y retornos
-- [ ] Declaración `declare(strict_types=1)` en todos los archivos
-- [ ] Sin código muerto (detectado por PHPStan)
-- [ ] Sin dependencias no utilizadas
-- [ ] Complejidad ciclomática < 10 por método
-- [ ] Longitud de métodos < 20 líneas
-- [ ] Clases con responsabilidad única
-- [ ] Documentación PHPDoc completa y actualizada
+**Criterios Evaluados**:
+- Conformidad PSR-12 (5 pts)
+- PHPStan nivel 9 (5 pts)
+- Type hints estrictos y declare(strict_types=1) (4 pts)
+- Principios KISS/DRY/YAGNI (4 pts)
+- Documentación y PHPDoc (4 pts)
+- Manejo de errores (3 pts)
 
-**Puntuación Calidad del Código**: ___/25 puntos
+**Referencia**: `check-code-quality.md`
 
-### Paso 4: Auditoría de Testing (25 puntos)
+### Paso 4: Auditoría de Pruebas (25 puntos)
 
-Ejecuta la auditoría de tests verificando:
+Ejecutar la verificación de pruebas:
 
-**Referencia a las reglas**: `.claude/rules/symfony-testing.md`
+**Comando**: Usar el comando slash `/symfony:check-testing` o seguir manualmente los pasos de `check-testing.md`
 
-- [ ] Cobertura de código ≥ 80%
-- [ ] Tests unitarios para el Domain
-- [ ] Tests de integración para la Infrastructure
-- [ ] Tests funcionales con Behat o Symfony WebTestCase
-- [ ] Tests de mutación con Infection (MSI ≥ 70%)
-- [ ] Fixtures para los tests
-- [ ] Tests aislados (sin dependencias entre tests)
-- [ ] Base de datos de test separada
-- [ ] Mocks y Stubs apropiados
-- [ ] CI/CD con ejecución automática de tests
+**Criterios Evaluados**:
+- Cobertura de código (7 pts)
+- Pruebas unitarias del Dominio (6 pts)
+- Pruebas de integración de Infraestructura (4 pts)
+- Pruebas funcionales (WebTestCase/Behat) (3 pts)
+- Pruebas de mutación con Infection (3 pts)
+- Aislamiento de pruebas y fixtures (2 pts)
 
-**Puntuación Testing**: ___/25 puntos
+**Referencia**: `check-testing.md`
 
 ### Paso 5: Auditoría de Seguridad (25 puntos)
 
-Ejecuta la auditoría de seguridad verificando:
+Ejecutar la verificación de seguridad:
 
-**Referencia a las reglas**: `.claude/rules/symfony-security.md`
+**Comando**: Usar el comando slash `/symfony:check-security` o seguir manualmente los pasos de `check-security.md`
 
-- [ ] Symfony Security Bundle correctamente configurado
-- [ ] OWASP Top 10: Protección contra inyección SQL
-- [ ] OWASP Top 10: Protección XSS
-- [ ] OWASP Top 10: Protección CSRF
-- [ ] OWASP Top 10: Autenticación segura
-- [ ] OWASP Top 10: Control de acceso (Voters, ACL)
-- [ ] RGPD: Consentimiento del usuario
-- [ ] RGPD: Derecho al olvido implementado
-- [ ] RGPD: Exportación de datos personales
-- [ ] Secrets externalizados (no en el código)
+**Criterios Evaluados**:
+- Configuración del Security Bundle de Symfony (6 pts)
+- Protecciones OWASP Top 10 (5 pts)
+- Gestión de secretos y credenciales (4 pts)
+- Validación de entradas y CSRF (4 pts)
+- Autenticación y Autorización (Voters) (3 pts)
+- Vulnerabilidades de dependencias (2 pts)
+- Conformidad GDPR (1 pt)
 
-**Puntuación Seguridad**: ___/25 puntos
+**Referencia**: `check-security.md`
 
-### Paso 6: Cálculo de la Puntuación Global
+### Paso 6: Consolidación y Puntuación Global
 
-**PUNTUACIÓN GLOBAL**: ___/100 puntos
+Calcular la puntuación global y producir el informe consolidado:
+- [ ] Sumar las 4 puntuaciones (máximo 100 puntos)
+- [ ] Identificar las categorías críticas (<50%)
+- [ ] Enumerar todos los problemas transversales críticos
+- [ ] Priorizar las acciones por impacto/esfuerzo
+- [ ] Producir el informe consolidado final
 
-Interpretación:
-- ✅ 90-100: Excelente - Cumplimiento ejemplar
-- ✅ 75-89: Bueno - Algunas mejoras menores
-- ⚠️ 60-74: Medio - Mejoras necesarias
-- ⚠️ 40-59: Insuficiente - Refactoring importante requerido
-- ❌ 0-39: Crítico - Refactorización completa necesaria
+**Escala de Calificación**:
+- 90-100: Excelente - Proyecto de referencia
+- 75-89: Muy Bueno - Algunas mejoras menores
+- 60-74: Aceptable - Requiere mejoras
+- 40-59: Insuficiente - Refactorización importante necesaria
+- 0-39: Crítico - Revisión completa necesaria
 
-### Paso 7: Informe Detallado
+### Paso 7: Recomendaciones y Plan de Acción
 
-Genera un informe estructurado con:
+Producir las recomendaciones finales:
+- [ ] Identificar las 3 acciones prioritarias principales en todas las categorías
+- [ ] Estimar el esfuerzo (Bajo/Medio/Alto) para cada acción
+- [ ] Estimar el impacto (Bajo/Medio/Alto) para cada acción
+- [ ] Proponer el orden de implementación
+- [ ] Sugerir victorias rápidas (alta relación impacto/esfuerzo)
+
+## FORMATO DE SALIDA
 
 ```
-=================================================
-   AUDITORÍA DE CUMPLIMIENTO SYMFONY
-=================================================
+AUDITORÍA DE CONFORMIDAD SYMFONY - INFORME COMPLETO
+=============================================
 
-📊 PUNTUACIÓN GLOBAL: ___/100
+PUNTUACIÓN GLOBAL: XX/100
 
-📐 Arquitectura        : ___/25 [✅|⚠️|❌]
-🎯 Calidad del Código  : ___/25 [✅|⚠️|❌]
-🧪 Testing             : ___/25 [✅|⚠️|❌]
-🔒 Seguridad           : ___/25 [✅|⚠️|❌]
+NIVEL DE CONFORMIDAD: [Excelente/Muy Bueno/Aceptable/Insuficiente/Crítico]
 
-=================================================
-   DETALLES POR CATEGORÍA
-=================================================
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-[Insertar los detalles de cada auditoría]
+PUNTUACIONES POR CATEGORÍA:
 
-=================================================
-   TOP 3 ACCIONES PRIORITARIAS
-=================================================
+ARQUITECTURA       : XX/25  [██████████░░░░░░░░░░] XX%
+CALIDAD DE CÓDIGO  : XX/25  [██████████░░░░░░░░░░] XX%
+PRUEBAS            : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURIDAD          : XX/25  [██████████░░░░░░░░░░] XX%
 
-1. [Acción prioritaria #1 con impacto estimado]
-2. [Acción prioritaria #2 con impacto estimado]
-3. [Acción prioritaria #3 con impacto estimado]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-=================================================
-   RECOMENDACIONES TÉCNICAS
-=================================================
+FORTALEZAS GLOBALES:
+1. [Fortaleza identificada en múltiples categorías]
+2. [Otra fortaleza principal]
+3. [Tercera fortaleza]
 
-- [Recomendación técnica específica]
-- [Recomendación técnica específica]
-- [Recomendación técnica específica]
+MEJORAS GLOBALES:
+1. [Mejora transversal menor]
+2. [Otra mejora recomendada]
+3. [Tercera mejora]
 
-=================================================
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico #1 - categoría afectada]
+2. [Problema crítico #2 - categoría afectada]
+3. [Problema crítico #3 - categoría afectada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALLES POR CATEGORÍA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITECTURA (XX/25)                        │
+└─────────────────────────────────────────────┘
+
+Sub-puntuaciones:
+  • Estructura Clean Architecture     : XX/6
+  • Separación de capas               : XX/6
+  • Hexagonal / Ports & Adapters      : XX/4
+  • Modelado DDD                      : XX/4
+  • Use Cases                         : XX/3
+  • Reglas de dependencia             : XX/2
+
+Fortalezas:
+- [Fortalezas de arquitectura]
+
+Problemas:
+- [Problemas de arquitectura]
+
+[Secciones similares para Calidad de Código, Pruebas y Seguridad...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 ACCIONES PRIORITARIAS (TODAS LAS CATEGORÍAS):
+
+1. CRÍTICO - [Acción #1]
+   Categoría : [Arquitectura/Calidad/Pruebas/Seguridad]
+   Impacto   : [Alto/Medio/Bajo]
+   Esfuerzo  : [Alto/Medio/Bajo]
+   Prioridad : INMEDIATA
+
+   Descripción detallada:
+   [Explicación del problema y solución propuesta]
+
+   Archivos afectados:
+   - [archivo:línea]
+
+   Ejemplo de corrección:
+   [Código o comando de corrección]
+
+2. IMPORTANTE - [Acción #2]
+   [Mismo formato...]
+
+3. RECOMENDADA - [Acción #3]
+   [Mismo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+VICTORIAS RÁPIDAS (Alto Impacto / Bajo Esfuerzo):
+
+- [Victoria rápida #1] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+- [Victoria rápida #2] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+- [Victoria rápida #3] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLAN DE ACCIÓN RECOMENDADO:
+
+SEMANA 1 (Inmediato):
+- [ ] [Acción crítica #1]
+- [ ] [Victoria rápida prioritaria]
+
+SEMANAS 2-4 (Corto plazo):
+- [ ] [Acción importante #2]
+- [ ] [Otras victorias rápidas]
+
+MESES 2-3 (Medio plazo):
+- [ ] [Acción recomendada #3]
+- [ ] [Mejoras progresivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMEN EJECUTIVO:
+
+[Párrafo de resumen sobre el estado general del proyecto, las principales
+fortalezas, las principales debilidades y la trayectoria recomendada para
+mejorar la conformidad. Indicar si el proyecto está listo para producción,
+requiere correcciones o necesita refactorización.]
+
+Recomendación General: [Listo para producción / Correcciones menores /
+Refactorización importante / Revisión completa necesaria]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### Paso 8: Comandos Docker para Verificaciones
+## NOTAS IMPORTANTES
 
-Para cada verificación, utiliza Docker para abstraerse del entorno local:
-
-```bash
-# PHPStan
-docker run --rm -v $(pwd):/app phpstan/phpstan analyse src --level=9
-
-# PHP_CodeSniffer (PSR-12)
-docker run --rm -v $(pwd):/project php:8.2-cli vendor/bin/phpcs --standard=PSR12 src/
-
-# PHPUnit con cobertura
-docker run --rm -v $(pwd):/app php:8.2-cli vendor/bin/phpunit --coverage-text --coverage-html=coverage
-
-# Infection (mutation testing)
-docker run --rm -v $(pwd):/app infection/infection --min-msi=70
-
-# Deptrac
-docker run --rm -v $(pwd):/app qossmic/deptrac analyse
-```
-
-## IMPORTANTE
-
-- Utiliza SIEMPRE Docker para los comandos para abstraerse del entorno local
-- NO almacenes NUNCA archivos en /tmp
-- Proporciona ejemplos concretos de problemas detectados
-- Prioriza las acciones según el impacto y el esfuerzo
-- Sé factual y objetivo en la evaluación
+- Este comando orquesta las 4 auditorías especializadas
+- Usar Docker para todas las herramientas de análisis
+- Proporcionar ejemplos concretos con archivo:línea para cada problema
+- Priorizar las acciones según la matriz Impacto/Esfuerzo
+- Los problemas de seguridad son SIEMPRE la máxima prioridad
+- Proponer correcciones automatizables (scripts, hooks de pre-commit)
+- El informe debe ser accionable, no solo descriptivo
+- Adaptar las recomendaciones al contexto de negocio del proyecto

--- a/Dev/i18n/es/Symfony/commands/check-testing.md
+++ b/Dev/i18n/es/Symfony/commands/check-testing.md
@@ -15,183 +15,201 @@ $ARGUMENTS : Ruta del proyecto Symfony a auditar (opcional, por defecto: directo
 
 ## MISIÓN
 
-Eres un experto en tests de software encargado de auditar la estrategia de testing de un proyecto Symfony: tests unitarios, de integración, funcionales, cobertura de código y tests de mutación.
+Eres un experto en pruebas de software encargado de auditar la estrategia de testing de un proyecto Symfony: pruebas unitarias, de integración, funcionales, cobertura de código y pruebas de mutación.
 
-### Paso 1: Verificación del Entorno de Test
+### Paso 1: Verificación del Entorno de Pruebas
 
-1. Identifica el directorio del proyecto
-2. Verifica la presencia de PHPUnit en composer.json
-3. Verifica la configuración de PHPUnit (phpunit.xml.dist)
-4. Verifica la presencia de la carpeta tests/
+1. Identificar el directorio del proyecto
+2. Verificar la presencia de PHPUnit en composer.json
+3. Verificar la configuración de PHPUnit (phpunit.xml.dist)
+4. Verificar la presencia del directorio tests/
 
 **Referencia a las reglas**: `.claude/rules/symfony-testing.md`
 
-### Paso 2: Estructura de Tests
+### Paso 2: Estructura de las Pruebas
 
-Analiza la estructura de la carpeta tests/:
+Analizar la estructura del directorio tests/:
 
 ```bash
-# Listar la estructura de tests
+# Listar la estructura de las pruebas
 docker run --rm -v $(pwd):/app php:8.2-cli find /app/tests -type d
 ```
 
-#### Organización de Tests (3 puntos)
+#### Organización de las Pruebas (3 puntos)
 
-- [ ] Carpeta `tests/Unit/` para tests unitarios
-- [ ] Carpeta `tests/Integration/` para tests de integración
-- [ ] Carpeta `tests/Functional/` para tests funcionales
+- [ ] Directorio `tests/Unit/` para pruebas unitarias
+- [ ] Directorio `tests/Integration/` para pruebas de integración
+- [ ] Directorio `tests/Functional/` para pruebas funcionales
 - [ ] Estructura espejo de src/ en tests/
 - [ ] Namespace correctamente configurado
 - [ ] Fixtures en tests/Fixtures/
-- [ ] Mocks en tests/Mock/ o inline
-- [ ] Configuración de test separada (config/packages/test/)
-- [ ] Base de datos de test separada
-- [ ] Tests aislados e independientes
+- [ ] Mocks en tests/Mock/ o en línea
+- [ ] Configuración de prueba separada (config/packages/test/)
+- [ ] Base de datos de prueba separada
+- [ ] Pruebas aisladas e independientes
 
 **Puntos obtenidos**: ___/3
 
-### Paso 3: Tests Unitarios
+### Paso 3: Pruebas Unitarias
 
-Ejecuta los tests unitarios:
+Ejecutar las pruebas unitarias:
 
 ```bash
-# Ejecutar tests unitarios únicamente
+# Ejecutar solo las pruebas unitarias
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit tests/Unit --testdox
 
-# Contar tests unitarios
+# Contar las pruebas unitarias
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit tests/Unit --list-tests | wc -l
 ```
 
-#### Tests Unitarios Domain (7 puntos)
+#### Pruebas Unitarias del Dominio (7 puntos)
 
-- [ ] Tests para todas las Entities del Domain
-- [ ] Tests para todos los Value Objects
-- [ ] Tests para todos los Domain Services
-- [ ] Tests para los Use Cases / Application Services
+- [ ] Pruebas para todas las Entidades del Dominio
+- [ ] Pruebas para todos los Value Objects
+- [ ] Pruebas para todos los Servicios de Dominio
+- [ ] Pruebas para los Use Cases / Application Services
 - [ ] Sin dependencias externas (BD, API, filesystem)
 - [ ] Uso de mocks para las dependencias
-- [ ] Tests de casos límite y errores
-- [ ] Tests de validaciones de negocio
-- [ ] Fast feedback (< 1 segundo para todos los tests unitarios)
-- [ ] Cobertura de tests unitarios > 90%
+- [ ] Pruebas de casos límite y errores
+- [ ] Pruebas de las validaciones de negocio
+- [ ] Retroalimentación rápida (< 1 segundo para todas las pruebas unitarias)
+- [ ] Cobertura de las pruebas unitarias > 90%
 
-Número de tests unitarios: ___
+Número de pruebas unitarias: ___
 Tiempo de ejecución: ___ segundos
 
 **Puntos obtenidos**: ___/7
 
-### Paso 4: Tests de Integración
+### Paso 4: Pruebas de Integración
 
-Ejecuta los tests de integración:
+Ejecutar las pruebas de integración:
 
 ```bash
-# Ejecutar tests de integración
+# Ejecutar las pruebas de integración
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit tests/Integration --testdox
 ```
 
-#### Tests de Integración Infrastructure (5 puntos)
+#### Pruebas de Integración de Infraestructura (5 puntos)
 
-- [ ] Tests para todos los Repositories (con base de datos)
-- [ ] Tests para los Adapters externos (Email, API, etc.)
-- [ ] Tests para los Event Listeners / Subscribers
-- [ ] Tests para los Services con dependencias Symfony
-- [ ] Uso de base de datos de test
-- [ ] Rollback o reset después de cada test
-- [ ] Fixtures para datos de test
-- [ ] Tests de transacciones y restricciones BD
-- [ ] Aislamiento de tests (sin orden requerido)
-- [ ] Tests de casos de error (conexión fallida, etc.)
+- [ ] Pruebas para todos los Repositorios (con base de datos)
+- [ ] Pruebas para los Adaptadores externos (Email, API, etc.)
+- [ ] Pruebas para los Event Listeners / Subscribers
+- [ ] Pruebas para los Servicios con dependencias de Symfony
+- [ ] Uso de base de datos de prueba
+- [ ] Rollback o reset después de cada prueba
+- [ ] Fixtures para datos de prueba
+- [ ] Pruebas de transacciones y restricciones de BD
+- [ ] Aislamiento de pruebas (sin orden requerido)
+- [ ] Pruebas de casos de error (conexión fallida, etc.)
 
-Número de tests de integración: ___
+Número de pruebas de integración: ___
 Tiempo de ejecución: ___ segundos
 
 **Puntos obtenidos**: ___/5
 
-### Paso 5: Tests Funcionales
+### Paso 5: Pruebas Funcionales
 
-Ejecuta los tests funcionales:
+Ejecutar las pruebas funcionales:
 
 ```bash
-# Ejecutar tests funcionales
+# Ejecutar las pruebas funcionales
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit tests/Functional --testdox
 
 # Verificar si Behat está instalado
-docker run --rm -v $(pwd):/app php:8.2-cli test -f /app/vendor/bin/behat && echo "✅ Behat encontrado" || echo "⚠️ Behat faltante"
+docker run --rm -v $(pwd):/app php:8.2-cli test -f /app/vendor/bin/behat && echo "✅ Behat encontrado" || echo "⚠️ Behat ausente"
 ```
 
-#### Tests Funcionales (5 puntos)
+#### Pruebas Funcionales (5 puntos)
 
-- [ ] Tests para todas las rutas API/Web importantes
-- [ ] Tests de controllers con WebTestCase
-- [ ] Tests de formularios
-- [ ] Tests de autenticaciones y autorizaciones
-- [ ] Tests de workflows completos (recorrido de usuario)
-- [ ] Tests con Behat para escenarios de negocio (opcional)
-- [ ] Tests de respuestas HTTP (códigos, headers, body)
-- [ ] Tests de validaciones del lado API
-- [ ] Tests de casos de error (404, 403, 500)
-- [ ] Tests de redirecciones
+- [ ] Pruebas para todas las rutas API/Web importantes
+- [ ] Pruebas de los controladores con WebTestCase
+- [ ] Pruebas de los formularios
+- [ ] Pruebas de autenticaciones y autorizaciones
+- [ ] Pruebas de flujos completos (recorridos de usuario)
+- [ ] Pruebas con Behat para escenarios de negocio (opcional)
+- [ ] Pruebas de respuestas HTTP (códigos, cabeceras, cuerpo)
+- [ ] Pruebas de validaciones del lado de la API
+- [ ] Pruebas de casos de error (404, 403, 500)
+- [ ] Pruebas de redirecciones
 
-Número de tests funcionales: ___
-Tests Behat presentes: [SÍ|NO]
+Número de pruebas funcionales: ___
+Pruebas Behat presentes: [SÍ|NO]
 
 **Puntos obtenidos**: ___/5
 
 ### Paso 6: Cobertura de Código
 
-Genera el informe de cobertura:
+Generar el informe de cobertura:
 
 ```bash
-# Generar cobertura de código (requiere xdebug o pcov)
+# Generar la cobertura de código (requiere xdebug o pcov)
 docker run --rm -v $(pwd):/app php:8.2-cli php -d memory_limit=-1 /app/vendor/bin/phpunit --coverage-text --coverage-html=/app/var/coverage
 
-# Mostrar resumen de cobertura
+# Mostrar el resumen de cobertura
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit --coverage-text | grep "Lines:"
 ```
 
 #### Cobertura de Código (5 puntos)
 
 - [ ] Cobertura global ≥ 80%
-- [ ] Cobertura Domain ≥ 90%
-- [ ] Cobertura Application ≥ 85%
-- [ ] Cobertura Infrastructure ≥ 70%
-- [ ] Cobertura de branches (condicionales) ≥ 75%
+- [ ] Cobertura del Dominio ≥ 90%
+- [ ] Cobertura de la Aplicación ≥ 85%
+- [ ] Cobertura de la Infraestructura ≥ 70%
+- [ ] Cobertura de ramas (condicionales) ≥ 75%
 - [ ] Informe de cobertura generado (HTML)
-- [ ] Exclusión explícita del código no testeable
-- [ ] Sin código crítico no cubierto
-- [ ] Tests de excepciones y casos de error
+- [ ] Exclusión explícita del código no testable
+- [ ] Sin código crítico sin cobertura
+- [ ] Pruebas de excepciones y casos de error
 - [ ] Configuración de cobertura en phpunit.xml
 
 Cobertura global: ___%
-Cobertura Domain: ___%
-Cobertura Application: ___%
-Cobertura Infrastructure: ___%
+Cobertura del Dominio: ___%
+Cobertura de la Aplicación: ___%
+Cobertura de la Infraestructura: ___%
 
 **Puntos obtenidos**: ___/5
 
-### Paso 7: Tests de Mutación con Infection
+Configuración PHPUnit esperada:
 
-Ejecuta los tests de mutación:
+```xml
+<coverage processUncoveredFiles="true">
+    <include>
+        <directory suffix=".php">src</directory>
+    </include>
+    <exclude>
+        <directory>src/Kernel.php</directory>
+        <directory>src/DataFixtures</directory>
+    </exclude>
+    <report>
+        <html outputDirectory="var/coverage"/>
+        <text outputFile="php://stdout" showUncoveredFiles="false"/>
+    </report>
+</coverage>
+```
+
+### Paso 7: Pruebas de Mutación con Infection
+
+Ejecutar las pruebas de mutación:
 
 ```bash
 # Verificar si Infection está instalado
-docker run --rm -v $(pwd):/app php:8.2-cli test -f /app/vendor/bin/infection && echo "✅ Infection encontrado" || echo "❌ Infection faltante"
+docker run --rm -v $(pwd):/app php:8.2-cli test -f /app/vendor/bin/infection && echo "✅ Infection encontrado" || echo "❌ Infection ausente"
 
 # Ejecutar Infection
 docker run --rm -v $(pwd):/app infection/infection --min-msi=70 --min-covered-msi=80 --threads=4
 ```
 
-#### Tests de Mutación (5 puntos)
+#### Pruebas de Mutación (5 puntos)
 
 - [ ] Infection instalado y configurado
 - [ ] MSI (Mutation Score Indicator) ≥ 70%
 - [ ] Covered MSI ≥ 80%
-- [ ] Tests detectan mutaciones en Domain
-- [ ] Tests detectan mutaciones en Application
+- [ ] Las pruebas detectan mutaciones en el Dominio
+- [ ] Las pruebas detectan mutaciones en la Aplicación
 - [ ] Sin mutantes escapados en el código crítico
-- [ ] Configuración infection.json presente
+- [ ] Archivo infection.json presente con configuración
 - [ ] Timeout configurado correctamente
-- [ ] Exclusiones justificadas en config
+- [ ] Exclusiones justificadas en la configuración
 - [ ] Informe de mutación generado
 
 MSI: ___%
@@ -201,50 +219,231 @@ Mutantes escapados: ___
 
 **Puntos obtenidos**: ___/5
 
-### Paso 8: Cálculo de la Puntuación Testing
+Configuración esperada de Infection (infection.json):
+
+```json
+{
+    "source": {
+        "directories": ["src"]
+    },
+    "logs": {
+        "text": "var/infection.log",
+        "html": "var/infection-report.html"
+    },
+    "mutators": {
+        "@default": true
+    },
+    "minMsi": 70,
+    "minCoveredMsi": 80
+}
+```
+
+### Paso 8: Cálculo de la Puntuación de Testing
 
 **PUNTUACIÓN TESTING**: ___/25 puntos
 
 Detalles:
-- Organización de Tests: ___/3
-- Tests Unitarios Domain: ___/7
-- Tests de Integración Infrastructure: ___/5
-- Tests Funcionales: ___/5
+- Organización de las Pruebas: ___/3
+- Pruebas Unitarias del Dominio: ___/7
+- Pruebas de Integración de Infraestructura: ___/5
+- Pruebas Funcionales: ___/5
 - Cobertura de Código: ___/5
-- Tests de Mutación: ___/5
+- Pruebas de Mutación: ___/5
+
+### Paso 9: Informe Detallado
+
+```
+=================================================
+   AUDITORÍA DE TESTING SYMFONY
+=================================================
+
+📊 PUNTUACIÓN: ___/25
+
+📁 Organización de las Pruebas              : ___/3 [✅|⚠️|❌]
+🎯 Pruebas Unitarias del Dominio            : ___/7 [✅|⚠️|❌]
+🔌 Pruebas de Integración de Infraestructura: ___/5 [✅|⚠️|❌]
+🌐 Pruebas Funcionales                      : ___/5 [✅|⚠️|❌]
+📊 Cobertura de Código                      : ___/5 [✅|⚠️|❌]
+🦠 Pruebas de Mutación                      : ___/5 [✅|⚠️|❌]
+
+=================================================
+   ESTADÍSTICAS GLOBALES
+=================================================
+
+Número total de pruebas       : ___
+Pruebas unitarias             : ___
+Pruebas de integración        : ___
+Pruebas funcionales           : ___
+Pruebas Behat                 : ___
+
+Tiempo total de ejecución     : ___ segundos
+Cobertura global              : ___%
+MSI (Mutation Score)          : ___%
+
+=================================================
+   COBERTURA POR CAPA
+=================================================
+
+Dominio         : ___% [✅|⚠️|❌] (objetivo: 90%)
+Aplicación      : ___% [✅|⚠️|❌] (objetivo: 85%)
+Infraestructura : ___% [✅|⚠️|❌] (objetivo: 70%)
+Presentación    : ___% [✅|⚠️|❌] (objetivo: 70%)
+
+Archivos sin cobertura : ___
+Métodos sin cobertura  : ___
+Líneas sin cobertura   : ___
+
+=================================================
+   PRUEBAS DE MUTACIÓN
+=================================================
+
+MSI (Mutation Score)       : ___% [✅|⚠️|❌] (objetivo: 70%)
+Covered MSI                : ___% [✅|⚠️|❌] (objetivo: 80%)
+
+Mutantes generados         : ___
+Mutantes eliminados        : ___ (detectados por las pruebas)
+Mutantes escapados         : ___ (no detectados)
+Mutantes timeout           : ___
+Mutantes con error         : ___
+
+Archivos con mutantes escapados críticos:
+❌ src/Domain/Entity/Order.php - 3 mutantes escapados
+❌ src/Application/UseCase/CreateUser.php - 2 mutantes escapados
+
+=================================================
+   PROBLEMAS DETECTADOS
+=================================================
+
+Pruebas Faltantes:
+❌ Sin pruebas para src/Domain/Entity/Invoice.php
+❌ Sin pruebas para src/Application/UseCase/ProcessPayment.php
+⚠️ Baja cobertura para src/Infrastructure/Repository/OrderRepository.php (45%)
+
+Pruebas Lentas:
+⚠️ tests/Integration/RepositoryTest.php - 15s (optimizar con fixtures)
+⚠️ tests/Functional/ApiTest.php - 12s (usar cliente HTTP simulado)
+
+Pruebas Inestables (Flaky):
+❌ tests/Integration/EmailServiceTest.php - falla a veces
+⚠️ tests/Functional/CheckoutTest.php - dependiente del orden de ejecución
+
+Configuración:
+❌ Infection no instalado
+⚠️ Cobertura de código no configurada en phpunit.xml
+❌ Base de datos de prueba no separada
+
+=================================================
+   TOP 3 ACCIONES PRIORITARIAS
+=================================================
+
+1. 🎯 [ACCIÓN CRÍTICA] - Alcanzar el 80% de cobertura de código
+   Impacto: ⭐⭐⭐⭐⭐ | Esfuerzo: 🔥🔥🔥🔥
+   - Añadir pruebas para Invoice, ProcessPayment
+   - Probar todos los casos de error
+   - Probar todas las ramas condicionales
+
+2. 🎯 [ACCIÓN IMPORTANTE] - Instalar y configurar Infection
+   Impacto: ⭐⭐⭐⭐ | Esfuerzo: 🔥🔥
+   Comando: composer require --dev infection/infection
+   Objetivo MSI ≥ 70%
+
+3. 🎯 [ACCIÓN RECOMENDADA] - Separar y optimizar las pruebas
+   Impacto: ⭐⭐⭐ | Esfuerzo: 🔥🔥
+   - Separar Unit/Integration/Functional
+   - Usar base de datos en memoria para las pruebas
+   - Optimizar los fixtures
+
+=================================================
+   RECOMENDACIONES
+=================================================
+
+Instalación de herramientas:
+```bash
+composer require --dev phpunit/phpunit ^10.0
+composer require --dev infection/infection
+composer require --dev symfony/test-pack
+composer require --dev behat/behat
+composer require --dev friends-of-behat/symfony-extension
+composer require --dev doctrine/doctrine-fixtures-bundle
+```
+
+Configuración phpunit.xml.dist:
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+        <testsuite name="functional">
+            <directory>tests/Functional</directory>
+        </testsuite>
+    </testsuites>
+    <coverage processUncoveredFiles="true">
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </coverage>
+</phpunit>
+```
+
+Buenas prácticas:
+- Usar factories para crear los objetos de prueba
+- Usar builders para los objetos complejos
+- Crear aserciones personalizadas reutilizables
+- Aislar las pruebas con setUp/tearDown
+- Usar data providers para probar múltiples casos
+- Simular solo las dependencias externas
+- Probar primero el Happy Path, luego los casos de error
+
+CI/CD:
+- Ejecutar las pruebas en cada commit
+- Bloquear los merges si las pruebas fallan
+- Generar y publicar los informes de cobertura
+- Ejecutar Infection en las Pull Requests
+- Alertar si la cobertura disminuye
+
+=================================================
+```
 
 ## Comandos Docker Útiles
 
 ```bash
-# Ejecutar todos los tests
+# Ejecutar todas las pruebas
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit
 
-# Tests unitarios únicamente
+# Solo pruebas unitarias
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit tests/Unit
 
-# Tests con cobertura
+# Pruebas con cobertura
 docker run --rm -v $(pwd):/app php:8.2-cli php -d xdebug.mode=coverage /app/vendor/bin/phpunit --coverage-text
 
 # Infection (mutation testing)
 docker run --rm -v $(pwd):/app infection/infection --threads=4 --min-msi=70
 
-# Behat (tests BDD)
+# Behat (pruebas BDD)
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/behat
 
-# Listar todos los tests
+# Listar todas las pruebas
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit --list-tests
 
-# Ejecutar un test específico
+# Ejecutar una prueba específica
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit tests/Unit/Domain/Entity/UserTest.php
 
-# Tests con salida detallada
+# Pruebas con salida detallada
 docker run --rm -v $(pwd):/app php:8.2-cli /app/vendor/bin/phpunit --testdox
 ```
 
 ## IMPORTANTE
 
-- Utiliza SIEMPRE Docker para los comandos
-- NO almacenes NUNCA archivos en /tmp (usar var/ del proyecto)
-- Proporciona estadísticas precisas
-- Identifica archivos críticos sin tests
-- Sugiere tests concretos a añadir
+- Usar SIEMPRE Docker para los comandos
+- NUNCA almacenar archivos en /tmp (usar var/ del proyecto)
+- Proporcionar estadísticas precisas
+- Identificar los archivos críticos sin pruebas
+- Sugerir pruebas concretas a añadir

--- a/Dev/i18n/es/Symfony/commands/migration-plan.md
+++ b/Dev/i18n/es/Symfony/commands/migration-plan.md
@@ -5,7 +5,7 @@ argument-hint: [arguments]
 
 # Planificación de Migración de Base de Datos
 
-Eres un DBA y arquitecto senior de Symfony. Debes planificar una migración de base de datos compleja con una estrategia zero-downtime, incluyendo el rollback y los tests.
+Eres un DBA y arquitecto Symfony senior. Debes planificar una migración de base de datos compleja con una estrategia de zero-downtime, incluyendo el rollback y las pruebas.
 
 ## Argumentos
 $ARGUMENTS
@@ -14,10 +14,6 @@ Argumentos:
 - Descripción de la migración (ej: "Añadir tabla audit_log", "Renombrar columna user.name a full_name")
 
 Ejemplo: `/symfony:migration-plan "Añadir sistema de versionado en los documentos"`
-
-## Modo Plan
-
-> El modo plan se activa automáticamente cuando el alcance abarca varios módulos o requiere una investigación transversal.
 
 ## MISIÓN
 
@@ -28,83 +24,320 @@ Ejemplo: `/symfony:migration-plan "Añadir sistema de versionado en los document
 📋 ANÁLISIS DE MIGRACIÓN
 ══════════════════════════════════════════════════════════════
 
-Descripción: {Descripción de la migración}
-Fecha prevista: {YYYY-MM-DD}
-Entornos: dev → staging → producción
+Descripción : {Descripción de la migración}
+Fecha prevista : {YYYY-MM-DD}
+Entornos : dev → staging → production
 
 ──────────────────────────────────────────────────────────────
 🔍 ESTADO ACTUAL
 ──────────────────────────────────────────────────────────────
 
-Tablas impactadas:
-- table_1 (X filas)
-- table_2 (Y filas)
+Tablas afectadas :
+- tabla_1 (X filas)
+- tabla_2 (Y filas)
 
-Dependencias:
-- Entidades: Entity1, Entity2
-- Services: Service1, Service2
-- Controladores: Controller1
+Dependencias :
+- Entidades : Entity1, Entity2
+- Servicios : Service1, Service2
+- Controladores : Controller1
 
 ──────────────────────────────────────────────────────────────
 ⚠️ EVALUACIÓN DE RIESGOS
 ──────────────────────────────────────────────────────────────
 
 | Riesgo | Probabilidad | Impacto | Mitigación |
-|--------|-------------|---------|------------|
-| Lock table largo | Media | Alta | Migración en etapas |
-| Pérdida de datos | Baja | Crítica | Backup + test restore |
-| Downtime | Media | Alta | Blue/Green + feature flags |
+|--------|--------------|---------|------------|
+| Bloqueo largo de tabla | Media | Alto | Migración por etapas |
+| Pérdida de datos | Baja | Crítico | Backup + test de restauración |
+| Downtime | Media | Alto | Blue/Green + feature flags |
 ```
 
 ### Paso 2: Estrategia de Migración
 
-#### Pattern Expand/Contract (Zero-Downtime)
+#### Patrón Expand/Contract (Zero-Downtime)
 
 ```
 ┌─────────────────────────────────────────────────────────────┐
-│ FASE 1: EXPAND (Adición)                                    │
+│ FASE 1: EXPAND (Añadir)                                     │
 │ - Añadir nueva columna/tabla                                │
 │ - Columna nullable o con valor por defecto                  │
-│ - Sin eliminación                                           │
-│ - App continúa funcionando                                  │
+│ - Sin eliminaciones                                         │
+│ - La app continúa funcionando                               │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ FASE 2: MIGRATE (Datos)                                     │
 │ - Copiar/transformar los datos                              │
-│ - Batch processing para grandes volúmenes                   │
-│ - Validación de datos migrados                              │
+│ - Procesamiento por lotes para grandes volúmenes            │
+│ - Validación de los datos migrados                          │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ FASE 3: UPDATE (Aplicación)                                 │
-│ - Desplegar código usando la nueva estructura               │
-│ - Escritura en antiguo Y nuevo durante la transición        │
-│ - Feature flag si necesario                                 │
+│ - Desplegar el código que usa la nueva estructura           │
+│ - Escritura en la antigua Y en la nueva durante la transición│
+│ - Feature flag si es necesario                              │
 └─────────────────────────────────────────────────────────────┘
                            │
                            ▼
 ┌─────────────────────────────────────────────────────────────┐
 │ FASE 4: CONTRACT (Limpieza)                                 │
-│ - Eliminar antigua columna/tabla                            │
-│ - Eliminar código de compatibilidad                         │
-│ - Puede hacerse más tarde, con seguridad                    │
+│ - Eliminar la antigua columna/tabla                         │
+│ - Eliminar el código de compatibilidad                      │
+│ - Puede realizarse más tarde, con total seguridad           │
 └─────────────────────────────────────────────────────────────┘
 ```
 
 ### Paso 3: Generar las Migraciones
 
-[El contenido continúa con las migraciones en español...]
+#### Migración 1: Expand (añadir estructura)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version{TIMESTAMP}_Expand extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fase 1: Añadir la nueva estructura';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Añadir nueva columna (nullable para compatibilidad)
+        $this->addSql('ALTER TABLE {table} ADD COLUMN {new_column} VARCHAR(255) DEFAULT NULL');
+
+        // Añadir nueva tabla
+        $this->addSql('CREATE TABLE {new_table} (
+            id UUID PRIMARY KEY,
+            {table}_id UUID NOT NULL REFERENCES {table}(id),
+            version INT NOT NULL DEFAULT 1,
+            created_at TIMESTAMP NOT NULL DEFAULT NOW()
+        )');
+
+        // Añadir índice (CONCURRENTLY para PostgreSQL)
+        $this->addSql('CREATE INDEX CONCURRENTLY idx_{table}_{column} ON {table}({column})');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('DROP INDEX IF EXISTS idx_{table}_{column}');
+        $this->addSql('DROP TABLE IF EXISTS {new_table}');
+        $this->addSql('ALTER TABLE {table} DROP COLUMN IF EXISTS {new_column}');
+    }
+}
+```
+
+#### Migración 2: Migración de Datos
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version{TIMESTAMP}_MigrateData extends AbstractMigration
+{
+    private const BATCH_SIZE = 1000;
+
+    public function getDescription(): string
+    {
+        return 'Fase 2: Migrar los datos existentes';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Migración por lotes para evitar bloqueos prolongados
+        $connection = $this->connection;
+
+        $totalRows = (int) $connection->fetchOne('SELECT COUNT(*) FROM {table} WHERE {new_column} IS NULL');
+        $processed = 0;
+
+        $this->write("Migrating $totalRows rows...");
+
+        while ($processed < $totalRows) {
+            $this->addSql("
+                UPDATE {table}
+                SET {new_column} = {transformation}
+                WHERE id IN (
+                    SELECT id FROM {table}
+                    WHERE {new_column} IS NULL
+                    LIMIT " . self::BATCH_SIZE . "
+                )
+            ");
+
+            $processed += self::BATCH_SIZE;
+            $this->write("Processed $processed / $totalRows");
+        }
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql("UPDATE {table} SET {new_column} = NULL");
+    }
+}
+```
+
+#### Migración 3: Contract (limpieza)
+
+```php
+<?php
+
+declare(strict_types=1);
+
+namespace DoctrineMigrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+final class Version{TIMESTAMP}_Contract extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return 'Fase 4: Eliminar la antigua estructura (Ejecutar DESPUÉS de la validación completa)';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // Verificar que todos los datos están migrados
+        $count = $this->connection->fetchOne('SELECT COUNT(*) FROM {table} WHERE {new_column} IS NULL');
+        if ($count > 0) {
+            throw new \RuntimeException("Migración incompleta: $count filas no migradas");
+        }
+
+        // Convertir la columna a NOT NULL
+        $this->addSql('ALTER TABLE {table} ALTER COLUMN {new_column} SET NOT NULL');
+
+        // Eliminar la antigua columna
+        $this->addSql('ALTER TABLE {table} DROP COLUMN {old_column}');
+    }
+
+    public function down(Schema $schema): void
+    {
+        $this->addSql('ALTER TABLE {table} ADD COLUMN {old_column} VARCHAR(255)');
+        $this->addSql('UPDATE {table} SET {old_column} = {reverse_transformation}');
+        $this->addSql('ALTER TABLE {table} ALTER COLUMN {new_column} DROP NOT NULL');
+    }
+}
+```
+
+### Paso 4: Plan de Despliegue
+
+```
+══════════════════════════════════════════════════════════════
+📅 PLAN DE DESPLIEGUE
+══════════════════════════════════════════════════════════════
+
+## Prerrequisitos
+
+- [ ] Backup de la base de datos
+- [ ] Test de restauración del backup
+- [ ] Ventana de mantenimiento comunicada
+- [ ] Equipo disponible
+
+## Modo Plan
+
+> El modo plan se activa automáticamente cuando el alcance abarca varios módulos o requiere una investigación transversal.
+
+## D-1: Preparación
+
+- [ ] Mergear las migraciones en main
+- [ ] Desplegar en staging
+- [ ] Ejecutar las migraciones en staging
+- [ ] Pruebas E2E completas
+
+## Día D: Producción
+
+### 09:00 - Fase 1: Expand
+```bash
+# Backup
+docker compose exec db pg_dump -U user db > backup_$(date +%Y%m%d_%H%M%S).sql
+
+# Migración expand
+docker compose exec php php bin/console doctrine:migrations:execute 'DoctrineMigrations\Version{TIMESTAMP}_Expand' --up
+```
+
+### 09:15 - Fase 2: Migración de Datos
+```bash
+# Ejecutar con monitorización
+docker compose exec php php bin/console doctrine:migrations:execute 'DoctrineMigrations\Version{TIMESTAMP}_MigrateData' --up
+```
+
+### 09:30 - Fase 3: Desplegar el Nuevo Código
+```bash
+# Desplegar la aplicación con el nuevo código
+./deploy.sh production
+```
+
+### 10:00 - Validación
+- [ ] Smoke tests
+- [ ] Verificar los logs (sin errores)
+- [ ] Verificar las métricas
+- [ ] Probar las funcionalidades afectadas
+
+### D+7 - Fase 4: Contract (opcional)
+```bash
+# Después de la validación completa
+docker compose exec php php bin/console doctrine:migrations:execute 'DoctrineMigrations\Version{TIMESTAMP}_Contract' --up
+```
+
+══════════════════════════════════════════════════════════════
+🔙 PLAN DE ROLLBACK
+══════════════════════════════════════════════════════════════
+
+### Rollback Fase 1 (Expand)
+```bash
+docker compose exec php php bin/console doctrine:migrations:execute 'DoctrineMigrations\Version{TIMESTAMP}_Expand' --down
+```
+
+### Rollback Fase 2 (Datos)
+```bash
+docker compose exec php php bin/console doctrine:migrations:execute 'DoctrineMigrations\Version{TIMESTAMP}_MigrateData' --down
+```
+
+### Rollback Completo (si es crítico)
+```bash
+# Restaurar el backup
+docker compose exec db psql -U user db < backup_YYYYMMDD_HHMMSS.sql
+
+# Redesplegar la versión anterior
+git checkout {previous_tag}
+./deploy.sh production
+```
+
+══════════════════════════════════════════════════════════════
+✅ CHECKLIST POST-MIGRACIÓN
+══════════════════════════════════════════════════════════════
+
+- [ ] Todas las migraciones ejecutadas con éxito
+- [ ] Sin errores en los logs
+- [ ] Métricas de rendimiento nominales
+- [ ] Tests funcionales OK
+- [ ] Usuarios informados (si el impacto es visible)
+- [ ] Documentación actualizada
+- [ ] Backup eliminado tras la validación (D+30)
+```
 
 ### Comandos Útiles
 
 ```bash
-# Estado de migraciones
+# Estado de las migraciones
 docker compose exec php php bin/console doctrine:migrations:status
 
-# Ver migraciones pendientes
+# Ver las migraciones pendientes
 docker compose exec php php bin/console doctrine:migrations:list
 
 # Ejecutar una migración específica

--- a/Dev/i18n/es/UIUX/commands/a11y-component.md
+++ b/Dev/i18n/es/UIUX/commands/a11y-component.md
@@ -18,7 +18,7 @@ Ejemplo: `/uiux:a11y-component Modal` o `/uiux:a11y-component "Selector de Fecha
 
 ## Modo Plan
 
-> **El modo plan es obligatorio.** Antes de ejecutar, Claude activa el modo plan para analizar el código impactado, proponer un plan de implementación y esperar tu validación antes de realizar cualquier cambio.
+> **El modo plan es obligatorio.** Antes de ejecutar, Claude activa el modo plan para analizar el código afectado, proponer un plan de implementación y esperar tu validación antes de realizar cualquier cambio.
 
 ## MISIÓN
 
@@ -30,7 +30,7 @@ Consultar las ARIA Authoring Practices Guide (APG) para el patrón correspondien
 
 ```
 ══════════════════════════════════════════════════════════════
-♿ ESPECIFICACIÓN ACCESIBILIDAD: {NOMBRE_COMPONENTE}
+♿ ESPECIFICACIÓN DE ACCESIBILIDAD: {NOMBRE_COMPONENTE}
 ══════════════════════════════════════════════════════════════
 
 Tipo: {Button | Input | Dialog | Listbox | Tabs | ...}
@@ -42,14 +42,24 @@ Fecha: {fecha}
 ──────────────────────────────────────────────────────────────
 
 ### Elemento nativo recomendado
+
 ```html
-<!-- Siempre preferir elemento nativo -->
+<!-- Siempre preferir el elemento nativo -->
 <{elemento} ...>
   {contenido}
 </{elemento}>
 ```
 
+### Si se requiere un componente personalizado
+
+```html
+<div role="{role}" ...>
+  {contenido}
+</div>
+```
+
 ### Estructura completa
+
 ```html
 <!-- Ejemplo completo con ARIA -->
 <div
@@ -57,7 +67,8 @@ Fecha: {fecha}
   aria-{atributo}="{valor}"
   tabindex="0"
 >
-  <span id="{id}-label">{Label}</span>
+  <span id="{id}-label">{Etiqueta}</span>
+  <div id="{id}-description">{Descripción}</div>
   {contenido}
 </div>
 ```
@@ -67,55 +78,291 @@ Fecha: {fecha}
 ──────────────────────────────────────────────────────────────
 
 ### Atributos requeridos
+
 | Atributo | Valor | Cuándo | Descripción |
 |----------|-------|--------|-------------|
-| role | {role} | Siempre (si custom) | Define el tipo |
-| aria-label | "{texto}" | Si no hay label visible | Label accesible |
+| role | {role} | Siempre (si personalizado) | Define el tipo |
+| aria-label | "{texto}" | Si no hay etiqueta visible | Etiqueta accesible |
+| aria-labelledby | "{id}" | Si hay etiqueta visible | Referencia a la etiqueta |
 
 ### Atributos condicionales
+
 | Atributo | Valor | Cuándo | Descripción |
 |----------|-------|--------|-------------|
-| aria-expanded | "true"/"false" | Si expandible | Estado abierto/cerrado |
-| aria-disabled | "true" | Si deshabilitado | Estado deshabilitado |
+| aria-describedby | "{id}" | Si hay descripción | Referencia a la descripción |
+| aria-expanded | "true"/"false" | Si es expandible | Estado abierto/cerrado |
+| aria-controls | "{id}" | Si controla otro elemento | ID del elemento controlado |
+| aria-owns | "{id}" | Si está separado en el DOM | Relación de parentesco |
+| aria-haspopup | "dialog"/"menu"/"listbox" | Si tiene popup | Tipo de popup |
+| aria-pressed | "true"/"false" | Si es toggle | Estado presionado |
+| aria-selected | "true"/"false" | Si es seleccionable | Estado seleccionado |
+| aria-checked | "true"/"false"/"mixed" | Si es checkbox | Estado marcado |
+| aria-disabled | "true" | Si está deshabilitado | Estado deshabilitado |
+| aria-invalid | "true" | Si hay error | Estado inválido |
+| aria-required | "true" | Si es obligatorio | Campo requerido |
+| aria-busy | "true" | Si está cargando | En progreso |
+| aria-live | "polite"/"assertive" | Si es dinámico | Anunciar cambio |
+| aria-atomic | "true" | Con aria-live | Anunciar todo |
+
+### Estados por interacción
+
+| Estado | Atributos ARIA |
+|--------|----------------|
+| Por defecto | {atributos base} |
+| Hover | Sin cambio ARIA |
+| Foco | Sin cambio ARIA |
+| Expandido | aria-expanded="true" |
+| Contraído | aria-expanded="false" |
+| Seleccionado | aria-selected="true" |
+| Deshabilitado | aria-disabled="true" |
+| Cargando | aria-busy="true" |
+| Error | aria-invalid="true", aria-errormessage="{id}" |
 
 ──────────────────────────────────────────────────────────────
 ⌨️ NAVEGACIÓN POR TECLADO
 ──────────────────────────────────────────────────────────────
 
+### Teclas principales
+
 | Tecla | Acción | Detalle |
 |-------|--------|---------|
 | Tab | Foco en el componente | Entra al componente |
+| Shift+Tab | Foco anterior | Sale del componente |
 | Enter | Activar | Acción principal |
 | Space | Activar (toggle) | Para botones toggle |
 | Escape | Cerrar/Cancelar | Si popup/modal |
-| Flechas | Navegación interna | En listas |
+| ↑ Flecha arriba | Elemento anterior | Navegación en lista |
+| ↓ Flecha abajo | Elemento siguiente | Navegación en lista |
+| ← Flecha izquierda | Elemento anterior (horizontal) | Pestañas, slider |
+| → Flecha derecha | Elemento siguiente (horizontal) | Pestañas, slider |
+| Home | Primer elemento | Navegación rápida |
+| End | Último elemento | Navegación rápida |
+
+### Gestión del foco
+
+| Situación | Comportamiento |
+|-----------|----------------|
+| Al abrir | Foco en {primer elemento enfocable} |
+| Al cerrar | Foco vuelve a {elemento disparador} |
+| Navegación interna | Roving tabindex O aria-activedescendant |
+| Trampa de foco | {Sí para modal / No para desplegable} |
+
+### Roving tabindex (si aplica)
+
+```html
+<!-- Solo un elemento enfocable a la vez -->
+<div role="tablist">
+  <button role="tab" tabindex="0" aria-selected="true">Pestaña 1</button>
+  <button role="tab" tabindex="-1" aria-selected="false">Pestaña 2</button>
+  <button role="tab" tabindex="-1" aria-selected="false">Pestaña 3</button>
+</div>
+```
+
+──────────────────────────────────────────────────────────────
+🎯 FOCO VISIBLE
+──────────────────────────────────────────────────────────────
+
+### Estilo requerido (WCAG 2.4.11 AAA)
+
+```css
+.{componente}:focus-visible {
+  /* Contorno visible */
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+
+  /* Relación de contraste ≥ 3:1 */
+  /* Área de foco ≥ perímetro visible */
+}
+
+/* Resetear para ratón */
+.{componente}:focus:not(:focus-visible) {
+  outline: none;
+}
+```
+
+### Verificaciones
+
+| Criterio | Valor | Estado |
+|----------|-------|--------|
+| Grosor del contorno | ≥ 2px | ✅ |
+| Contraste del contorno | ≥ 3:1 | ✅ |
+| Área visible | ≥ perímetro | ✅ |
+| Visible sobre todos los fondos | Sí | ✅ |
 
 ──────────────────────────────────────────────────────────────
 🔊 ANUNCIOS DEL LECTOR DE PANTALLA
 ──────────────────────────────────────────────────────────────
 
-### Al entrar (foco)
+### Al recibir el foco
+
 ```
-"{Label}, {rol}, {estado}"
+"{Etiqueta}, {rol}, {estado}"
+
 Ejemplos:
 - "Enviar, botón"
 - "Menú principal, menú, contraído"
+- "Nombre, campo de texto, requerido"
+- "Boletín, casilla de verificación, no marcada"
 ```
 
-### Durante interacción
+### Durante la interacción
+
 | Acción | Anuncio |
 |--------|---------|
 | Expansión | "expandido" / "contraído" |
+| Selección | "seleccionado" |
+| Toggle | "activado" / "desactivado" |
+| Cargando | "Cargando" |
+| Éxito | "{mensaje de éxito}" |
 | Error | "Error: {mensaje}" |
+
+### Contenido dinámico (aria-live)
+
+```html
+<!-- Notificaciones no urgentes (polite) -->
+<div aria-live="polite" aria-atomic="true">
+  {mensaje toast}
+</div>
+
+<!-- Notificaciones urgentes (errores) -->
+<div aria-live="assertive" aria-atomic="true">
+  {mensaje de error}
+</div>
+```
+
+──────────────────────────────────────────────────────────────
+📏 CONTRASTE (WCAG AAA)
+──────────────────────────────────────────────────────────────
+
+### Texto
+
+| Tipo | Relación requerida | Verificación |
+|------|--------------------|--------------|
+| Texto normal (< 18px) | ≥ 7:1 | {color} / {fondo} = {relación} |
+| Texto grande (≥ 18px o 14px negrita) | ≥ 4.5:1 | {color} / {fondo} = {relación} |
+
+### Elementos UI
+
+| Elemento | Relación requerida | Verificación |
+|----------|--------------------|--------------|
+| Bordes | ≥ 3:1 | {color} / {fondo} = {relación} |
+| Iconos | ≥ 3:1 | {color} / {fondo} = {relación} |
+| Contorno de foco | ≥ 3:1 | {color} / {fondo} = {relación} |
+
+### Estados
+
+| Estado | Verificación de contraste |
+|--------|--------------------------|
+| Por defecto | ✅ {relación} |
+| Hover | ✅ {relación} |
+| Foco | ✅ {relación} |
+| Deshabilitado | ⚠️ No requerido pero recomendado |
 
 ──────────────────────────────────────────────────────────────
 📐 OBJETIVOS TÁCTILES (WCAG 2.5.5 AAA)
 ──────────────────────────────────────────────────────────────
 
+### Dimensiones mínimas
+
 | Criterio | Valor | Estado |
 |----------|-------|--------|
 | Tamaño mínimo | 44 × 44 píxeles CSS | ✅/❌ |
 | Espaciado entre objetivos | ≥ 8px | ✅/❌ |
+
+### Implementación
+
+```css
+.{componente} {
+  min-width: 44px;
+  min-height: 44px;
+  /* O padding para alcanzar 44px */
+  padding: 10px 16px; /* si la altura del texto es ~24px */
+}
+
+/* Botones con icono */
+.{componente}-icono {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+──────────────────────────────────────────────────────────────
+🧪 PRUEBAS A REALIZAR
+──────────────────────────────────────────────────────────────
+
+### Automatizadas
+
+- [ ] axe DevTools: 0 violaciones
+- [ ] Lighthouse Accessibility: 100/100
+- [ ] ESLint jsx-a11y: 0 errores
+
+### Manuales
+
+- [ ] Navegación completa por teclado
+- [ ] Foco visible en cada paso
+- [ ] Sin trampa de teclado
+- [ ] Orden de foco lógico
+
+### Lector de pantalla
+
+- [ ] VoiceOver (macOS/iOS): anuncios correctos
+- [ ] NVDA (Windows): navegación en listas/tablas
+- [ ] TalkBack (Android): si es móvil
+
+### Casos límite
+
+- [ ] Zoom al 400%: sin pérdida de contenido
+- [ ] Modo de alto contraste: visible
+- [ ] Movimiento reducido: animaciones respetadas
+
+──────────────────────────────────────────────────────────────
+💻 EJEMPLO DE IMPLEMENTACIÓN
+──────────────────────────────────────────────────────────────
+
+```tsx
+// {Componente}.tsx
+import { forwardRef, useId } from 'react';
+
+interface {Componente}Props {
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  // ...otras props
+}
+
+export const {Componente} = forwardRef<HTML{Elemento}Element, {Componente}Props>(
+  ({ label, description, disabled, ...props }, ref) => {
+    const id = useId();
+    const descriptionId = description ? `${id}-description` : undefined;
+
+    return (
+      <{elemento}
+        ref={ref}
+        id={id}
+        role="{role}"
+        aria-label={label}
+        aria-describedby={descriptionId}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+        {...props}
+      >
+        {/* Contenido */}
+
+        {description && (
+          <span id={descriptionId} className="sr-only">
+            {description}
+          </span>
+        )}
+      </{elemento}>
+    );
+  }
+);
+
+{Componente}.displayName = '{Componente}';
+```
 
 ──────────────────────────────────────────────────────────────
 ✅ CHECKLIST DE VALIDACIÓN
@@ -123,20 +370,31 @@ Ejemplos:
 
 ### Semántica
 - [ ] Elemento HTML nativo usado si es posible
-- [ ] Rol ARIA correcto si es custom
+- [ ] Rol ARIA correcto si es personalizado
 - [ ] Estructura DOM lógica
 
 ### ARIA
 - [ ] Atributos requeridos presentes
-- [ ] Sin sobre-ARIA (nativo > ARIA)
+- [ ] Atributos condicionales correctos
+- [ ] Sin sobrecarga de ARIA (nativo > ARIA)
 
 ### Teclado
-- [ ] Focusable (tabindex apropiado)
-- [ ] Todas las acciones vía teclado
+- [ ] Enfocable (tabindex apropiado)
+- [ ] Todas las acciones disponibles por teclado
 - [ ] Sin trampa de teclado
 - [ ] Foco visible conforme
+
+### Anuncios
+- [ ] Etiqueta anunciada al recibir foco
+- [ ] Estados anunciados al cambiar
+- [ ] Errores con aria-live assertive
 
 ### Contraste
 - [ ] Texto ≥ 7:1 (AAA)
 - [ ] UI ≥ 3:1
+- [ ] Foco ≥ 3:1
+
+### Táctil
+- [ ] Objetivos ≥ 44×44px
+- [ ] Espaciado ≥ 8px
 ```

--- a/Dev/i18n/es/UIUX/commands/design-tokens.md
+++ b/Dev/i18n/es/UIUX/commands/design-tokens.md
@@ -5,7 +5,7 @@ argument-hint: [arguments]
 
 # Definición de Design Tokens
 
-Eres un Lead UI Designer. Debes definir los design tokens para un design system coherente y mantenible.
+Eres un Lead UI Designer. Debes definir los design tokens para un sistema de diseño coherente y mantenible.
 
 ## Argumentos
 $ARGUMENTS
@@ -19,15 +19,15 @@ Ejemplo: `/uiux:design-tokens all #3B82F6 both`
 
 ## Modo Plan
 
-> **El modo plan es obligatorio.** Antes de ejecutar, Claude activa el modo plan para analizar el código impactado, proponer un plan de implementación y esperar tu validación antes de realizar cualquier cambio.
+> **El modo plan es obligatorio.** Antes de ejecutar, Claude activa el modo plan para analizar el código afectado, proponer un plan de implementación y esperar tu validación antes de realizar cualquier cambio.
 
 ## MISIÓN
 
 ### Paso 1: Analizar el contexto
 
 - Stack frontend (React, Vue, Tailwind, CSS vars...)
-- ¿Design system existente?
-- ¿Guía de marca proporcionada?
+- ¿Existe un sistema de diseño previo?
+- ¿Se han proporcionado directrices de marca?
 
 ### Paso 2: Definir los tokens
 
@@ -46,21 +46,54 @@ Formato: CSS Custom Properties
 
 ### Paleta Semántica
 
-#### Primary (Acción principal)
+#### Primario (Acción principal)
 | Token | Light | Dark | Uso |
 |-------|-------|------|-----|
 | --color-primary-50 | #eff6ff | #1e3a5f | Fondo sutil |
+| --color-primary-100 | #dbeafe | #1e40af | Fondo |
+| --color-primary-200 | #bfdbfe | #1d4ed8 | Borde |
+| --color-primary-300 | #93c5fd | #2563eb | Borde hover |
+| --color-primary-400 | #60a5fa | #3b82f6 | Icono |
 | --color-primary-500 | #3b82f6 | #60a5fa | Texto |
 | --color-primary-600 | #2563eb | #93c5fd | Texto hover |
+| --color-primary-700 | #1d4ed8 | #bfdbfe | - |
+| --color-primary-800 | #1e40af | #dbeafe | - |
+| --color-primary-900 | #1e3a5f | #eff6ff | - |
 
-#### Success / Warning / Error
-{Escalas similares}
+#### Éxito
+| Token | Light | Dark |
+|-------|-------|------|
+| --color-success-50 | #f0fdf4 | #14532d |
+| --color-success-500 | #22c55e | #4ade80 |
+| --color-success-700 | #15803d | #86efac |
 
-#### Neutral (Texto, Fondos)
+#### Advertencia
+| Token | Light | Dark |
+|-------|-------|------|
+| --color-warning-50 | #fffbeb | #78350f |
+| --color-warning-500 | #f59e0b | #fbbf24 |
+| --color-warning-700 | #b45309 | #fcd34d |
+
+#### Error
+| Token | Light | Dark |
+|-------|-------|------|
+| --color-error-50 | #fef2f2 | #7f1d1d |
+| --color-error-500 | #ef4444 | #f87171 |
+| --color-error-700 | #b91c1c | #fca5a5 |
+
+#### Neutro (Texto, Fondos)
 | Token | Light | Dark | Uso |
 |-------|-------|------|-----|
 | --color-neutral-0 | #ffffff | #0a0a0a | Fondo |
-| --color-neutral-500 | #737373 | #a3a3a3 | Texto muted |
+| --color-neutral-50 | #fafafa | #171717 | Fondo sutil |
+| --color-neutral-100 | #f5f5f5 | #262626 | Fondo atenuado |
+| --color-neutral-200 | #e5e5e5 | #404040 | Borde |
+| --color-neutral-300 | #d4d4d4 | #525252 | Borde hover |
+| --color-neutral-400 | #a3a3a3 | #737373 | Placeholder |
+| --color-neutral-500 | #737373 | #a3a3a3 | Texto atenuado |
+| --color-neutral-600 | #525252 | #d4d4d4 | Texto secundario |
+| --color-neutral-700 | #404040 | #e5e5e5 | Texto primario |
+| --color-neutral-800 | #262626 | #f5f5f5 | Texto enfatizado |
 | --color-neutral-900 | #171717 | #fafafa | Texto fuerte |
 
 ### Tokens Alias (Semánticos)
@@ -68,14 +101,25 @@ Formato: CSS Custom Properties
 /* Fondos */
 --color-bg-primary: var(--color-neutral-0);
 --color-bg-secondary: var(--color-neutral-50);
+--color-bg-tertiary: var(--color-neutral-100);
+--color-bg-inverse: var(--color-neutral-900);
 
-/* Textos */
+/* Texto */
 --color-text-primary: var(--color-neutral-900);
 --color-text-secondary: var(--color-neutral-600);
+--color-text-muted: var(--color-neutral-500);
+--color-text-inverse: var(--color-neutral-0);
 
 /* Bordes */
 --color-border-default: var(--color-neutral-200);
+--color-border-hover: var(--color-neutral-300);
 --color-border-focus: var(--color-primary-500);
+
+/* Estados */
+--color-state-focus: var(--color-primary-500);
+--color-state-error: var(--color-error-500);
+--color-state-success: var(--color-success-500);
+--color-state-warning: var(--color-warning-500);
 ```
 
 ──────────────────────────────────────────────────────────────
@@ -84,39 +128,159 @@ Formato: CSS Custom Properties
 
 ### Familias
 ```css
---font-family-sans: 'Inter', system-ui, sans-serif;
---font-family-mono: 'JetBrains Mono', monospace;
+--font-family-sans: 'Inter', system-ui, -apple-system, sans-serif;
+--font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
 ```
 
 ### Tamaños (base 16px)
-| Token | Tamaño | Line Height | Uso |
-|-------|--------|-------------|-----|
-| --font-size-xs | 0.75rem | 1rem | Labels |
-| --font-size-base | 1rem | 1.5rem | Body |
-| --font-size-4xl | 2.25rem | 2.5rem | H1 |
+| Token | Tamaño | Altura de línea | Uso |
+|-------|--------|-----------------|-----|
+| --font-size-xs | 0.75rem (12px) | 1rem | Etiquetas, badges |
+| --font-size-sm | 0.875rem (14px) | 1.25rem | Cuerpo pequeño |
+| --font-size-base | 1rem (16px) | 1.5rem | Cuerpo |
+| --font-size-lg | 1.125rem (18px) | 1.75rem | Texto destacado |
+| --font-size-xl | 1.25rem (20px) | 1.75rem | H4 |
+| --font-size-2xl | 1.5rem (24px) | 2rem | H3 |
+| --font-size-3xl | 1.875rem (30px) | 2.25rem | H2 |
+| --font-size-4xl | 2.25rem (36px) | 2.5rem | H1 |
+| --font-size-5xl | 3rem (48px) | 1 | Display |
+
+### Pesos
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --font-weight-normal | 400 | Cuerpo |
+| --font-weight-medium | 500 | Etiquetas, nav |
+| --font-weight-semibold | 600 | Subencabezados |
+| --font-weight-bold | 700 | Encabezados |
+
+### Alturas de línea
+```css
+--line-height-none: 1;
+--line-height-tight: 1.25;
+--line-height-snug: 1.375;
+--line-height-normal: 1.5;
+--line-height-relaxed: 1.625;
+--line-height-loose: 2;
+```
+
+### Espaciado entre letras
+```css
+--letter-spacing-tighter: -0.05em;
+--letter-spacing-tight: -0.025em;
+--letter-spacing-normal: 0;
+--letter-spacing-wide: 0.025em;
+--letter-spacing-wider: 0.05em;
+```
 
 ──────────────────────────────────────────────────────────────
-📐 ESPACIADOS
+📐 ESPACIADO
 ──────────────────────────────────────────────────────────────
 
 ### Escala (base 4px)
 | Token | Valor | Píxeles | Uso |
 |-------|-------|---------|-----|
+| --spacing-0 | 0 | 0px | - |
+| --spacing-px | 1px | 1px | Bordes |
+| --spacing-0.5 | 0.125rem | 2px | Ajustado |
 | --spacing-1 | 0.25rem | 4px | XS |
+| --spacing-1.5 | 0.375rem | 6px | - |
+| --spacing-2 | 0.5rem | 8px | S |
+| --spacing-2.5 | 0.625rem | 10px | - |
+| --spacing-3 | 0.75rem | 12px | - |
 | --spacing-4 | 1rem | 16px | M (base) |
+| --spacing-5 | 1.25rem | 20px | - |
+| --spacing-6 | 1.5rem | 24px | L |
 | --spacing-8 | 2rem | 32px | XL |
+| --spacing-10 | 2.5rem | 40px | - |
+| --spacing-12 | 3rem | 48px | 2XL |
+| --spacing-16 | 4rem | 64px | 3XL |
+| --spacing-20 | 5rem | 80px | - |
+| --spacing-24 | 6rem | 96px | 4XL |
 
 ──────────────────────────────────────────────────────────────
-🌗 SOMBRAS / ⭕ RADIOS / ⏱️ TRANSICIONES
+🌗 SOMBRAS
 ──────────────────────────────────────────────────────────────
 
-{Tablas similares con tokens}
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --shadow-xs | 0 1px 2px 0 rgb(0 0 0 / 0.05) | Sutil |
+| --shadow-sm | 0 1px 3px 0 rgb(0 0 0 / 0.1) | Tarjetas |
+| --shadow-md | 0 4px 6px -1px rgb(0 0 0 / 0.1) | Desplegables |
+| --shadow-lg | 0 10px 15px -3px rgb(0 0 0 / 0.1) | Modales |
+| --shadow-xl | 0 20px 25px -5px rgb(0 0 0 / 0.1) | Diálogos |
+| --shadow-2xl | 0 25px 50px -12px rgb(0 0 0 / 0.25) | Superposiciones |
+| --shadow-inner | inset 0 2px 4px 0 rgb(0 0 0 / 0.05) | Inputs |
+| --shadow-none | none | Resetear |
 
+──────────────────────────────────────────────────────────────
+⭕ RADIOS (Border Radius)
+──────────────────────────────────────────────────────────────
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --radius-none | 0 | Afilado |
+| --radius-sm | 0.125rem (2px) | Sutil |
+| --radius-md | 0.375rem (6px) | Botones, inputs |
+| --radius-lg | 0.5rem (8px) | Tarjetas |
+| --radius-xl | 0.75rem (12px) | Modales |
+| --radius-2xl | 1rem (16px) | Tarjetas grandes |
+| --radius-full | 9999px | Pills, avatares |
+
+──────────────────────────────────────────────────────────────
+⏱️ TRANSICIONES
+──────────────────────────────────────────────────────────────
+
+### Duraciones
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --duration-75 | 75ms | Micro |
+| --duration-100 | 100ms | Rápida |
+| --duration-150 | 150ms | Por defecto |
+| --duration-200 | 200ms | Normal |
+| --duration-300 | 300ms | Lenta |
+| --duration-500 | 500ms | Énfasis |
+
+### Curvas de aceleración
+```css
+--ease-linear: linear;
+--ease-in: cubic-bezier(0.4, 0, 1, 1);
+--ease-out: cubic-bezier(0, 0, 0.2, 1);
+--ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+--ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+```
+
+### Transiciones compuestas
+```css
+--transition-none: none;
+--transition-all: all 150ms ease-out;
+--transition-colors: color, background-color, border-color 150ms ease-out;
+--transition-opacity: opacity 150ms ease-out;
+--transition-shadow: box-shadow 150ms ease-out;
+--transition-transform: transform 150ms ease-out;
+```
+
+──────────────────────────────────────────────────────────────
+📦 Z-INDEX
+──────────────────────────────────────────────────────────────
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --z-0 | 0 | Base |
+| --z-10 | 10 | Elevado |
+| --z-20 | 20 | Desplegables |
+| --z-30 | 30 | Sticky |
+| --z-40 | 40 | Fijo |
+| --z-50 | 50 | Fondo modal |
+| --z-60 | 60 | Modal |
+| --z-70 | 70 | Popover |
+| --z-80 | 80 | Toast |
+| --z-90 | 90 | Tooltip |
+| --z-max | 9999 | Máximo |
 ```
 
 ### Paso 3: Exportar
 
-Generar archivos:
+Generar los archivos:
 - `tokens.css` - CSS Custom Properties
 - `tokens.json` - Formato Style Dictionary
-- `tailwind.config.js` - Extensión Tailwind (si aplica)
+- `tailwind.config.js` - Extensión de Tailwind (si aplica)

--- a/Dev/i18n/es/UIUX/commands/user-flow.md
+++ b/Dev/i18n/es/UIUX/commands/user-flow.md
@@ -5,7 +5,7 @@ argument-hint: [arguments]
 
 # Diseño de Flujo de Usuario
 
-Eres un Experto UX/Ergonomía. Debes diseñar un flujo de usuario (user flow) completo y optimizado.
+Eres un Experto UX/Ergonomía. Debes diseñar un flujo de usuario completo y optimizado.
 
 ## Argumentos
 $ARGUMENTS
@@ -19,7 +19,7 @@ Ejemplo: `/uiux:user-flow "Registro de usuario"` o `/uiux:user-flow "Checkout" p
 
 ## Modo Plan
 
-> **El modo plan es recomendado.** Claude activa el modo plan para estructurar el enfoque, identificar dependencias y presentar una estrategia de generación antes de crear artefactos.
+> **El modo plan es recomendado.** Claude activa el modo plan para estructurar el enfoque, identificar dependencias y presentar una estrategia de generación antes de crear los artefactos.
 
 ## MISIÓN
 
@@ -57,16 +57,44 @@ Versión: 1.0
 > "{Lo que el usuario quiere lograr}"
 
 ### Objetivo de negocio
-> "{Lo que el negocio quiere obtener}"
+> "{Lo que el negocio quiere conseguir}"
+
+### Restricciones
+- Tiempo máximo: {X segundos/minutos}
+- Pasos máximos: {Y}
+- Dispositivo: {restricciones técnicas}
+- Sin conexión: Sí / No
+
+──────────────────────────────────────────────────────────────
+🗺️ RESUMEN GENERAL
+──────────────────────────────────────────────────────────────
+
+```
+┌──────┐    ┌──────┐    ┌──────┐    ┌──────┐    ┌──────┐
+│Inicio│───▶│Paso 1│───▶│Paso 2│───▶│Paso 3│───▶│ Fin  │
+└──────┘    └──────┘    └──────┘    └──────┘    └──────┘
+                │            │
+                ▼            ▼
+           ┌────────┐   ┌────────┐
+           │Error A │   │Error B │
+           └────────┘   └────────┘
+```
 
 ──────────────────────────────────────────────────────────────
 📋 FLUJO DETALLADO
 ──────────────────────────────────────────────────────────────
 
 ### Paso 0: Disparador
+
 **Punto de entrada**: {Cómo llega el usuario}
+- Vía: {menú / enlace / CTA / deep link}
+- Estado previo: {autenticado / anónimo / datos existentes}
+- Precondiciones: {lo que debe ser verdadero}
+
+---
 
 ### Paso 1: {Nombre del paso}
+
 **Pantalla**: {Nombre de pantalla}
 **Objetivo**: {Lo que el usuario debe hacer}
 
@@ -74,40 +102,175 @@ Versión: 1.0
 | Acción | Elemento UI | Resultado |
 |--------|-------------|-----------|
 | Principal | {botón/enlace} | Pasa al paso 2 |
+| Secundaria | {botón/enlace} | {alternativa} |
+| Terciaria | {enlace} | {otra opción} |
+
+#### Datos requeridos
+| Campo | Tipo | Validación | Requerido |
+|-------|------|------------|-----------|
+| {campo} | {tipo} | {reglas} | Sí/No |
 
 #### Feedback del sistema
 | Evento | Feedback | Tipo |
 |--------|----------|------|
-| Error validación | {mensaje} | Inline |
+| Foco en input | {feedback} | Visual |
+| Error de validación | {mensaje} | Inline |
+| Éxito | {feedback} | Toast/inline |
+
+#### Puntos de atención
+- ⚠️ {fricción potencial}
+- 💡 {oportunidad de mejora}
+
+---
+
+### Paso 2: {Nombre del paso}
+
+{Misma estructura...}
+
+---
+
+### Paso N: Confirmación (Fin)
+
+**Pantalla**: {Confirmación / Éxito}
+**Estado final**: {Lo que se ha logrado}
+
+#### Contenido
+- Mensaje de éxito
+- Resumen de la acción
+- Próximos pasos sugeridos
+
+#### Acciones siguientes
+| Acción | Destino |
+|--------|---------|
+| CTA principal | {siguiente flujo} |
+| Volver | {dashboard/lista} |
+| Compartir | {si aplica} |
 
 ──────────────────────────────────────────────────────────────
-📊 MÉTRICAS & KPIs
+⚠️ CAMINOS ALTERNATIVOS
 ──────────────────────────────────────────────────────────────
+
+### Error: {Tipo de error}
+
+**Disparador**: {Qué causa el error}
+**Pantalla**: {Inline / Modal / Página dedicada}
+
+#### Mensaje de error
+```
+Título: {Título claro}
+Descripción: {Explicación del problema}
+Acción: {Cómo resolverlo}
+```
+
+#### Opciones del usuario
+- Reintentar: {comportamiento}
+- Modificar: {volver al paso X}
+- Abandonar: {¿se guarda el estado?}
+
+---
+
+### Abandono: Guardado del estado
+
+**Comportamiento**:
+- Borrador guardado automáticamente
+- Duración de retención: {X días}
+- Notificación de recordatorio: Sí / No
+
+---
+
+### Caso límite: {Descripción}
+
+**Situación**: {Contexto particular}
+**Comportamiento**: {Adaptación del flujo}
+
+──────────────────────────────────────────────────────────────
+📊 MÉTRICAS Y KPIs
+──────────────────────────────────────────────────────────────
+
+### Objetivos cuantitativos
 
 | Métrica | Objetivo | Medición |
 |---------|----------|----------|
 | Tiempo de completación | < {X} seg | Time-on-task |
 | Tasa de completación | > {Y}% | Funnel analytics |
+| Tasa de error | < {Z}% | Error rate |
 | Número de clics | ≤ {N} | Click tracking |
+| Puntuación de satisfacción | > {S}/5 | Encuesta post-tarea |
+
+### Puntos de medición
+
+| Paso | Evento a rastrear |
+|------|-------------------|
+| Entrada | `flow_started` |
+| Paso 1 | `step_1_completed` |
+| Paso 2 | `step_2_completed` |
+| Éxito | `flow_completed` |
+| Abandono | `flow_abandoned` con `last_step` |
+| Error | `flow_error` con `error_type` |
+
+──────────────────────────────────────────────────────────────
+🧠 ERGONOMÍA
+──────────────────────────────────────────────────────────────
+
+### Carga cognitiva
+
+| Paso | Complejidad | Justificación |
+|------|-------------|---------------|
+| 1 | Baja | {1-2 acciones simples} |
+| 2 | Media | {formulario corto} |
+| 3 | Baja | {solo confirmación} |
+
+### Principios aplicados
+
+| Principio | Aplicación |
+|-----------|------------|
+| Divulgación progresiva | {cómo} |
+| Valores por defecto | {cuáles} |
+| Validación inline | {cuándo} |
+| Guardado automático | {frecuencia} |
+
+──────────────────────────────────────────────────────────────
+♿ ACCESIBILIDAD
+──────────────────────────────────────────────────────────────
+
+### Navegación por teclado
+- Orden de tabulación: {secuencia lógica}
+- Skip links: {si hay formulario largo}
+- Gestión del foco: {al cambiar de paso}
+
+### Lector de pantalla
+- Anuncio de paso: "Paso X de Y"
+- Errores: aria-live="assertive"
+- Progreso: aria-describedby
+
+### Tiempo
+- Sin tiempo límite automático
+- Si hay demora: extensible o desactivable
 
 ──────────────────────────────────────────────────────────────
 ✅ CHECKLIST DE VALIDACIÓN
 ──────────────────────────────────────────────────────────────
 
 ### UX
-- [ ] Objetivo de usuario claro
+- [ ] Objetivo del usuario claro
 - [ ] Pasos mínimos necesarios
 - [ ] Feedback en cada acción
 - [ ] Caminos de error documentados
+- [ ] Abandono con guardado
+
+### Medibilidad
+- [ ] KPIs definidos
+- [ ] Eventos de seguimiento listados
+- [ ] Objetivos cuantificados
 
 ### Accesibilidad
 - [ ] Navegación por teclado
-- [ ] Anuncios SR
+- [ ] Anuncios del lector de pantalla
 - [ ] Sin límites de tiempo
 ```
 
 ### Paso 3: Validación
 
-- Revisión con stakeholders
-- Prueba de usuario (5 usuarios mín)
-- Iteración basada en feedback
+- Revisión con las partes interesadas (stakeholders)
+- Prueba de usuario (mínimo 5 usuarios)
+- Iteración basada en el feedback recibido

--- a/Dev/i18n/es/VueJS/commands/check-compliance.md
+++ b/Dev/i18n/es/VueJS/commands/check-compliance.md
@@ -1,128 +1,253 @@
 ---
-description: Audit Vue.js project compliance with coding standards and best practices
+description: Verificar el cumplimiento completo del proyecto Vue.js
+argument-hint: [arguments]
 ---
 
-# Vue.js Compliance Audit
+# Verificar el Cumplimiento Completo de Vue.js
 
-You are an expert Vue.js auditor. Perform a comprehensive compliance check on this project.
+## Argumentos
 
-## MISSION
-
-Audit the project for compliance with Vue.js 3 best practices, Composition API standards, and TypeScript conventions.
+$ARGUMENTS (opcional: ruta al proyecto a analizar)
 
 ## Modo Plan
 
 > El modo plan se activa automáticamente cuando el alcance abarca varios módulos o requiere una investigación transversal.
 
-## AUDIT CHECKLIST
+## MISIÓN
 
-### 1. Project Structure (20 points)
+Realizar una auditoría de cumplimiento completa del proyecto Vue.js orquestando las 4 verificaciones principales: Arquitectura, Calidad de Código, Pruebas y Seguridad. Producir un informe consolidado con una puntuación global sobre 100 puntos.
+
+### Paso 1: Preparación de la Auditoría
+
+Preparar el entorno de auditoría:
+- [ ] Identificar la ruta del proyecto a auditar
+- [ ] Verificar la presencia de los archivos de configuración (package.json, tsconfig.json, vite.config.ts)
+- [ ] Listar los directorios principales (src/, tests/, public/, etc.)
+- [ ] Identificar la estructura del proyecto y la versión de Vue.js
+
+**Nota**: Si se proporciona $ARGUMENTS, usar como ruta del proyecto; en caso contrario, usar el directorio actual.
+
+### Paso 2: Auditoría de Arquitectura (25 puntos)
+
+Ejecutar la verificación completa de arquitectura:
+
+**Comando**: Usar el slash command `/vuejs:check-architecture` o seguir manualmente los pasos de `check-architecture.md`
+
+**Criterios Evaluados**:
+- Organización de componentes y funcionalidades (6 pts)
+- Estructura y reutilización de composables (6 pts)
+- Arquitectura de los stores Pinia (4 pts)
+- Configuración del router y lazy loading (4 pts)
+- Separación del módulo compartido/common (3 pts)
+- Reglas de dependencias y barrel exports (2 pts)
+
+**Referencia**: `check-architecture.md`
+
+### Paso 3: Auditoría de Calidad de Código (25 puntos)
+
+Ejecutar la verificación de calidad de código:
+
+**Comando**: Usar el slash command `/vuejs:check-code-quality` o seguir manualmente los pasos de `check-code-quality.md`
+
+**Criterios Evaluados**:
+- Modo estricto de TypeScript y seguridad de tipos (5 pts)
+- Cumplimiento de ESLint y Prettier (5 pts)
+- Uso de la Composition API y script setup (4 pts)
+- Principios KISS/DRY/YAGNI (4 pts)
+- Convenciones de nomenclatura (4 pts)
+- Gestión de errores (3 pts)
+
+**Referencia**: `check-code-quality.md`
+
+### Paso 4: Auditoría de Pruebas (25 puntos)
+
+Ejecutar la verificación de pruebas:
+
+**Comando**: Usar el slash command `/vuejs:check-testing` o seguir manualmente los pasos de `check-testing.md`
+
+**Criterios Evaluados**:
+- Cobertura de código (7 pts)
+- Pruebas unitarias de composables y stores (6 pts)
+- Pruebas de componentes con Vue Test Utils (4 pts)
+- Pruebas de integración (3 pts)
+- Calidad de las pruebas y patrón AAA (3 pts)
+- Organización de mocks y fixtures (2 pts)
+
+**Referencia**: `check-testing.md`
+
+### Paso 5: Auditoría de Seguridad (25 puntos)
+
+Ejecutar la verificación de seguridad:
+
+**Comando**: Usar el slash command `/vuejs:check-security` o seguir manualmente los pasos de `check-security.md`
+
+**Criterios Evaluados**:
+- Prevención de XSS (uso de v-html) (6 pts)
+- Gestión de secretos y credenciales (5 pts)
+- Validación y saneamiento de entradas (4 pts)
+- Vulnerabilidades en dependencias (4 pts)
+- Autenticación y guards de ruta (3 pts)
+- Comunicación segura con la API (2 pts)
+- Protección CSRF (1 pt)
+
+**Referencia**: `check-security.md`
+
+### Paso 6: Consolidación y Puntuación Global
+
+Calcular la puntuación general y producir el informe consolidado:
+- [ ] Sumar las 4 puntuaciones (máximo 100 puntos)
+- [ ] Identificar categorías críticas (<50%)
+- [ ] Listar todos los problemas transversales críticos
+- [ ] Priorizar acciones por impacto/esfuerzo
+- [ ] Producir el informe consolidado final
+
+**Escala de Calificación**:
+- 90-100: Excelente - Proyecto de referencia
+- 75-89: Muy Bueno - Algunas mejoras menores
+- 60-74: Aceptable - Requiere mejoras
+- 40-59: Insuficiente - Refactorización mayor requerida
+- 0-39: Crítico - Revisión completa necesaria
+
+### Paso 7: Recomendaciones y Plan de Acción
+
+Producir las recomendaciones finales:
+- [ ] Identificar las 3 acciones prioritarias de todas las categorías
+- [ ] Estimar el esfuerzo (Bajo/Medio/Alto) para cada acción
+- [ ] Estimar el impacto (Bajo/Medio/Alto) para cada acción
+- [ ] Proponer el orden de implementación
+- [ ] Sugerir victorias rápidas (alto impacto/bajo esfuerzo)
+
+## FORMATO DE SALIDA
 
 ```
-[ ] src/components/ - Shared components organized
-[ ] src/composables/ - Composition functions present
-[ ] src/stores/ - Pinia stores properly structured
-[ ] src/router/ - Vue Router configuration
-[ ] src/types/ - TypeScript types defined
-[ ] src/services/ - API services separated
+AUDITORÍA DE CUMPLIMIENTO VUE.JS - INFORME COMPLETO
+=====================================================
+
+PUNTUACIÓN GLOBAL: XX/100
+
+NIVEL DE CUMPLIMIENTO: [Excelente/Muy Bueno/Aceptable/Insuficiente/Crítico]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PUNTUACIONES POR CATEGORÍA:
+
+ARQUITECTURA       : XX/25  [██████████░░░░░░░░░░] XX%
+CALIDAD DE CÓDIGO  : XX/25  [██████████░░░░░░░░░░] XX%
+PRUEBAS            : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURIDAD          : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+FORTALEZAS GLOBALES:
+1. [Fortaleza identificada en múltiples categorías]
+2. [Otra fortaleza principal]
+3. [Tercera fortaleza]
+
+MEJORAS GLOBALES:
+1. [Mejora transversal menor]
+2. [Otra mejora recomendada]
+3. [Tercera mejora]
+
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico #1 - categoría afectada]
+2. [Problema crítico #2 - categoría afectada]
+3. [Problema crítico #3 - categoría afectada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALLES POR CATEGORÍA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITECTURA (XX/25)                        │
+└─────────────────────────────────────────────┘
+
+Sub-puntuaciones:
+  • Organización de componentes y funcionalidades : XX/6
+  • Estructura de composables                     : XX/6
+  • Arquitectura de stores Pinia                  : XX/4
+  • Router y lazy loading                         : XX/4
+  • Separación del módulo compartido              : XX/3
+  • Reglas de dependencias                        : XX/2
+
+Fortalezas:
+- [Fortalezas de arquitectura]
+
+Problemas:
+- [Problemas de arquitectura]
+
+[Secciones similares para Calidad de Código, Pruebas y Seguridad...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 ACCIONES PRIORITARIAS (TODAS LAS CATEGORÍAS):
+
+1. CRÍTICO - [Acción #1]
+   Categoría  : [Arquitectura/Calidad/Pruebas/Seguridad]
+   Impacto    : [Alto/Medio/Bajo]
+   Esfuerzo   : [Alto/Medio/Bajo]
+   Prioridad  : INMEDIATA
+
+   Descripción detallada:
+   [Explicación del problema y solución propuesta]
+
+   Archivos afectados:
+   - [archivo:línea]
+
+   Ejemplo de corrección:
+   [Código o comando de corrección]
+
+2. IMPORTANTE - [Acción #2]
+   [Mismo formato...]
+
+3. RECOMENDADO - [Acción #3]
+   [Mismo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+VICTORIAS RÁPIDAS (Alto Impacto / Bajo Esfuerzo):
+
+- [Victoria rápida #1] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+- [Victoria rápida #2] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+- [Victoria rápida #3] - Categoría: [X] - Impacto: [X] - Esfuerzo: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLAN DE ACCIÓN RECOMENDADO:
+
+SEMANA 1 (Inmediato):
+- [ ] [Acción crítica #1]
+- [ ] [Victoria rápida prioritaria]
+
+SEMANAS 2-4 (Corto plazo):
+- [ ] [Acción importante #2]
+- [ ] [Otras victorias rápidas]
+
+MESES 2-3 (Medio plazo):
+- [ ] [Acción recomendada #3]
+- [ ] [Mejoras progresivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMEN EJECUTIVO:
+
+[Párrafo de resumen sobre el estado general del proyecto, las principales
+fortalezas, las principales debilidades y la trayectoria recomendada para
+mejorar el cumplimiento. Indicar si el proyecto está listo para producción,
+requiere correcciones o necesita refactorización.]
+
+Recomendación General: [Listo para producción / Correcciones menores /
+Refactorización mayor / Revisión completa necesaria]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Component Standards (25 points)
+## NOTAS IMPORTANTES
 
-```
-[ ] Using <script setup> syntax
-[ ] TypeScript with lang="ts"
-[ ] Props defined with defineProps<T>()
-[ ] Emits defined with defineEmits<T>()
-[ ] Components are multi-word named
-[ ] Base components use Base prefix
-```
-
-### 3. Composition API (20 points)
-
-```
-[ ] No Options API in new components
-[ ] Composables follow use* naming
-[ ] Reactive state properly typed
-[ ] Computed properties used correctly
-[ ] Watchers cleaned up
-```
-
-### 4. Pinia Stores (15 points)
-
-```
-[ ] Setup syntax stores (composition style)
-[ ] Proper TypeScript typing
-[ ] Actions are async when needed
-[ ] Getters use computed
-[ ] No direct state mutation from components
-```
-
-### 5. TypeScript Integration (20 points)
-
-```
-[ ] Strict mode enabled
-[ ] No implicit any
-[ ] Props and emits fully typed
-[ ] Interfaces for complex types
-[ ] Type-only imports used
-```
-
-## OUTPUT FORMAT
-
-```
-══════════════════════════════════════════════════════════════
-VUE.JS COMPLIANCE AUDIT
-══════════════════════════════════════════════════════════════
-
-📊 SUMMARY
-──────────────────────────────────────────────────────────────
-Total Score: XX/100
-Status: ✅ COMPLIANT | ⚠️ NEEDS WORK | ❌ NON-COMPLIANT
-
-📁 PROJECT STRUCTURE: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Organized component structure
-[✗] Missing composables directory
-    → Create src/composables/ for reusable logic
-
-🧩 COMPONENT STANDARDS: XX/25
-──────────────────────────────────────────────────────────────
-[✓] Using <script setup>
-[✗] Some components use Options API
-    Files: src/components/OldComponent.vue
-    → Migrate to Composition API
-
-🔧 COMPOSITION API: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Composables properly named
-[✗] Missing cleanup in watchers
-    File: src/composables/useData.ts:45
-
-🏪 PINIA STORES: XX/15
-──────────────────────────────────────────────────────────────
-[✓] Setup syntax used
-[✓] Proper typing
-
-📝 TYPESCRIPT: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Strict mode enabled
-[✗] Implicit any found
-    File: src/utils/helpers.ts:12
-
-📋 RECOMMENDATIONS
-──────────────────────────────────────────────────────────────
-1. [HIGH] Migrate remaining Options API components
-2. [MEDIUM] Add missing type definitions
-3. [LOW] Organize composables by feature
-
-══════════════════════════════════════════════════════════════
-```
-
-## PROCESS
-
-1. Scan project structure
-2. Analyze component files for standards
-3. Check composables and stores
-4. Verify TypeScript configuration
-5. Generate compliance report with score
+- Este comando orquesta las 4 auditorías especializadas
+- Usar Docker para todas las herramientas de análisis
+- Proporcionar ejemplos concretos con archivo:línea para cada problema
+- Priorizar acciones según la matriz Impacto/Esfuerzo
+- Los problemas de seguridad son SIEMPRE la prioridad máxima
+- Proponer correcciones automatizables (scripts, hooks pre-commit)
+- El informe debe ser accionable, no meramente descriptivo
+- Adaptar las recomendaciones al contexto de negocio del proyecto

--- a/Dev/i18n/fr/Angular/commands/check-compliance.md
+++ b/Dev/i18n/fr/Angular/commands/check-compliance.md
@@ -1,203 +1,253 @@
 ---
-description: Angular Standards Compliance Check
+description: Vérification Complète de la Conformité Angular
+argument-hint: [arguments]
 ---
 
-# Angular Standards Compliance Check
+# Vérification Complète de la Conformité Angular
 
-Verify that the Angular project follows established coding standards and best practices.
+## Arguments
 
-## What This Command Does
-
-1. **Standards Verification**
-   - Check coding conventions
-   - Verify naming conventions
-   - Validate file organization
-   - Check import order
-   - Verify documentation standards
-
-2. **Angular-Specific Checks**
-   - Standalone components usage
-   - Signals implementation
-   - OnPush change detection
-   - Modern control flow (@if, @for)
-   - Typed forms
-
-3. **Generated Report**
-   - Non-compliant files
-   - Severity levels
-   - Remediation recommendations
-   - Compliance score (/100)
+$ARGUMENTS (optionnel : chemin du projet à analyser)
 
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.
 
-## Compliance Areas
+## MISSION
 
-### 1. Component Standards
+Réaliser un audit complet de conformité du projet Angular en orchestrant les 4 grandes vérifications : Architecture, Qualité du Code, Tests et Sécurité. Produire un rapport consolidé avec un score global sur 100 points.
 
-```typescript
-// ✅ Compliant
-@Component({
-  selector: 'app-user-profile',
-  standalone: true,
-  imports: [CommonModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `...`
-})
-export class UserProfileComponent {}
+### Étape 1 : Préparation de l'audit
 
-// ❌ Non-compliant
-@Component({
-  selector: 'user-profile',     // Missing app- prefix
-  // standalone: missing       // Not standalone
-  // changeDetection: missing  // Not OnPush
-})
-export class UserProfile {}    // Missing Component suffix
+Préparer l'environnement d'audit :
+- [ ] Identifier le chemin du projet à auditer
+- [ ] Vérifier la présence des fichiers de configuration (angular.json, tsconfig.json, package.json)
+- [ ] Lister les répertoires principaux (src/app/, e2e/, etc.)
+- [ ] Identifier la structure du projet et la version Angular
+
+**Note** : Si $ARGUMENTS est fourni, l'utiliser comme chemin du projet, sinon utiliser le répertoire courant.
+
+### Étape 2 : Audit Architecture (25 points)
+
+Exécuter la vérification complète de l'architecture :
+
+**Commande** : Utiliser la commande slash `/angular:check-architecture` ou suivre manuellement les étapes dans `check-architecture.md`
+
+**Critères évalués** :
+- Structure des modules pilotée par le domaine (6 pts)
+- Utilisation des composants standalone (6 pts)
+- Lazy loading et routage (4 pts)
+- Séparation Core/Shared/Feature (4 pts)
+- Organisation de la couche service (3 pts)
+- Patterns d'injection de dépendances (2 pts)
+
+**Référence** : `check-architecture.md`
+
+### Étape 3 : Audit Qualité du Code (25 points)
+
+Exécuter la vérification de la qualité du code :
+
+**Commande** : Utiliser la commande slash `/angular:check-code-quality` ou suivre manuellement les étapes dans `check-code-quality.md`
+
+**Critères évalués** :
+- Mode strict TypeScript et sûreté des types (5 pts)
+- Conformité ESLint (5 pts)
+- Signals et patterns Angular modernes (4 pts)
+- Principes KISS/DRY/YAGNI (4 pts)
+- Conventions de nommage et structure des fichiers (4 pts)
+- Détection de changement OnPush (3 pts)
+
+**Référence** : `check-code-quality.md`
+
+### Étape 4 : Audit Tests (25 points)
+
+Exécuter la vérification des tests :
+
+**Commande** : Utiliser la commande slash `/angular:check-testing` ou suivre manuellement les étapes dans `check-testing.md`
+
+**Critères évalués** :
+- Couverture du code (7 pts)
+- Tests unitaires pour les services et pipes (6 pts)
+- Tests de composants avec TestBed (4 pts)
+- Tests d'intégration (3 pts)
+- Tests E2E (3 pts)
+- Isolation des tests et mocks (2 pts)
+
+**Référence** : `check-testing.md`
+
+### Étape 5 : Audit Sécurité (25 points)
+
+Exécuter la vérification de sécurité :
+
+**Commande** : Utiliser la commande slash `/angular:check-security` ou suivre manuellement les étapes dans `check-security.md`
+
+**Critères évalués** :
+- Prévention XSS et DomSanitizer (6 pts)
+- Gestion des secrets et des identifiants (5 pts)
+- Validation et assainissement des entrées (4 pts)
+- Vulnérabilités des dépendances (4 pts)
+- Authentification et route guards (3 pts)
+- CSRF et intercepteurs HTTP (2 pts)
+- Content Security Policy (1 pt)
+
+**Référence** : `check-security.md`
+
+### Étape 6 : Consolidation et Score Global
+
+Calculer le score global et produire le rapport consolidé :
+- [ ] Additionner les 4 scores (max 100 points)
+- [ ] Identifier les catégories critiques (<50%)
+- [ ] Lister tous les problèmes transversaux critiques
+- [ ] Prioriser les actions par impact/effort
+- [ ] Produire le rapport final consolidé
+
+**Échelle de notation** :
+- 90-100 : Excellent - Projet de référence
+- 75-89 : Très bien - Quelques améliorations mineures
+- 60-74 : Acceptable - Des améliorations sont nécessaires
+- 40-59 : Insuffisant - Refactoring majeur requis
+- 0-39 : Critique - Refonte complète nécessaire
+
+### Étape 7 : Recommandations et Plan d'Action
+
+Produire les recommandations finales :
+- [ ] Identifier les 3 actions prioritaires dans toutes les catégories
+- [ ] Estimer l'effort (Faible/Moyen/Élevé) pour chaque action
+- [ ] Estimer l'impact (Faible/Moyen/Élevé) pour chaque action
+- [ ] Proposer un ordre d'implémentation
+- [ ] Suggérer des gains rapides (ratio impact/effort élevé)
+
+## FORMAT DE SORTIE
+
+```
+AUDIT DE CONFORMITÉ ANGULAR - RAPPORT COMPLET
+=============================================
+
+SCORE GLOBAL : XX/100
+
+NIVEAU DE CONFORMITÉ : [Excellent/Très bien/Acceptable/Insuffisant/Critique]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SCORES PAR CATÉGORIE :
+
+ARCHITECTURE       : XX/25  [██████████░░░░░░░░░░] XX%
+QUALITÉ DU CODE    : XX/25  [██████████░░░░░░░░░░] XX%
+TESTS              : XX/25  [██████████░░░░░░░░░░] XX%
+SÉCURITÉ           : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+POINTS FORTS GLOBAUX :
+1. [Point fort identifié dans plusieurs catégories]
+2. [Autre point fort majeur]
+3. [Troisième point fort]
+
+AMÉLIORATIONS GLOBALES :
+1. [Amélioration transversale mineure]
+2. [Autre amélioration recommandée]
+3. [Troisième amélioration]
+
+PROBLÈMES CRITIQUES :
+1. [Problème critique #1 - catégorie concernée]
+2. [Problème critique #2 - catégorie concernée]
+3. [Problème critique #3 - catégorie concernée]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DÉTAILS PAR CATÉGORIE :
+
+┌─────────────────────────────────────────────┐
+│ ARCHITECTURE (XX/25)                        │
+└─────────────────────────────────────────────┘
+
+Sous-scores :
+  • Modules pilotés par le domaine    : XX/6
+  • Composants standalone             : XX/6
+  • Lazy loading et routage           : XX/4
+  • Core/Shared/Feature               : XX/4
+  • Couche service                    : XX/3
+  • Injection de dépendances          : XX/2
+
+Points forts :
+- [Points forts d'architecture]
+
+Problèmes :
+- [Problèmes d'architecture]
+
+[Sections similaires pour Qualité du Code, Tests et Sécurité...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 DES ACTIONS PRIORITAIRES (TOUTES CATÉGORIES) :
+
+1. CRITIQUE - [Action #1]
+   Catégorie  : [Architecture/Qualité/Tests/Sécurité]
+   Impact     : [Élevé/Moyen/Faible]
+   Effort     : [Élevé/Moyen/Faible]
+   Priorité   : IMMÉDIATE
+
+   Description détaillée :
+   [Explication du problème et solution proposée]
+
+   Fichiers concernés :
+   - [fichier:ligne]
+
+   Exemple de correction :
+   [Code ou commande de correction]
+
+2. IMPORTANT - [Action #2]
+   [Même format...]
+
+3. RECOMMANDÉ - [Action #3]
+   [Même format...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GAINS RAPIDES (Impact Élevé / Effort Faible) :
+
+- [Gain rapide #1] - Catégorie : [X] - Impact : [X] - Effort : [X]
+- [Gain rapide #2] - Catégorie : [X] - Impact : [X] - Effort : [X]
+- [Gain rapide #3] - Catégorie : [X] - Impact : [X] - Effort : [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLAN D'ACTION RECOMMANDÉ :
+
+SEMAINE 1 (Immédiat) :
+- [ ] [Action critique #1]
+- [ ] [Gain rapide prioritaire]
+
+SEMAINES 2-4 (Court terme) :
+- [ ] [Action importante #2]
+- [ ] [Autres gains rapides]
+
+MOIS 2-3 (Moyen terme) :
+- [ ] [Action recommandée #3]
+- [ ] [Améliorations progressives]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RÉSUMÉ EXÉCUTIF :
+
+[Paragraphe de synthèse sur l'état global du projet, les principaux
+points forts, les principales faiblesses et la trajectoire recommandée
+pour améliorer la conformité. Mentionner si le projet est prêt pour
+la production, nécessite des corrections ou un refactoring.]
+
+Recommandation générale : [Prêt pour la production / Corrections mineures /
+Refactoring majeur / Refonte nécessaire]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Signal Usage
+## NOTES IMPORTANTES
 
-```typescript
-// ✅ Compliant - Using signals
-export class CounterComponent {
-  count = signal(0);
-  doubleCount = computed(() => this.count() * 2);
-}
-
-// ❌ Non-compliant - Using observables for local state
-export class CounterComponent {
-  count$ = new BehaviorSubject(0);
-}
-```
-
-### 3. Template Syntax
-
-```html
-<!-- ✅ Compliant - Modern control flow -->
-@if (loading()) {
-  <app-spinner />
-}
-
-@for (item of items(); track item.id) {
-  <app-item [data]="item" />
-}
-
-<!-- ❌ Non-compliant - Legacy syntax -->
-<app-spinner *ngIf="loading"></app-spinner>
-<app-item *ngFor="let item of items" [data]="item"></app-item>
-```
-
-### 4. Dependency Injection
-
-```typescript
-// ✅ Compliant - inject() function
-export class MyComponent {
-  private readonly userService = inject(UserService);
-}
-
-// ⚠️ Warning - Constructor injection (valid but verbose)
-export class MyComponent {
-  constructor(private userService: UserService) {}
-}
-```
-
-### 5. File Naming
-
-```
-✅ Compliant:
-- user-profile.component.ts
-- auth.service.ts
-- auth.guard.ts
-- date-format.pipe.ts
-
-❌ Non-compliant:
-- UserProfile.component.ts (PascalCase)
-- authService.ts (missing suffix)
-- AuthGuard.ts (PascalCase)
-```
-
-## Scoring Criteria
-
-| Category | Weight | Criteria |
-|----------|--------|----------|
-| Standalone Components | 20% | All components are standalone |
-| Signals Usage | 15% | Local state uses signals |
-| OnPush Strategy | 15% | All components use OnPush |
-| Modern Control Flow | 10% | @if/@for instead of *ngIf/*ngFor |
-| Typed Forms | 10% | Forms are strongly typed |
-| Naming Conventions | 10% | Correct file/class naming |
-| Import Organization | 10% | Imports properly ordered |
-| Documentation | 10% | Key components documented |
-
-## Output Format
-
-```
-══════════════════════════════════════════════════════════════
-ANGULAR COMPLIANCE REPORT
-══════════════════════════════════════════════════════════════
-
-📊 SCORE: 85/100
-
-✅ PASSING (6)
-──────────────────────────────────────────────────────────────
-• Standalone components: 100% (24/24 components)
-• OnPush strategy: 100% (24/24 components)
-• Typed forms: 100% (8/8 forms)
-• Import organization: 100%
-• File naming: 100%
-• Documentation: 90%
-
-⚠️ WARNINGS (2)
-──────────────────────────────────────────────────────────────
-• Modern control flow: 75% (18/24 templates)
-  - src/app/features/users/user-list.component.html:15 - Uses *ngFor
-  - src/app/shared/modal/modal.component.html:8 - Uses *ngIf
-
-• Signals usage: 80% (16/20 components with local state)
-  - src/app/features/auth/login.component.ts - Uses BehaviorSubject
-
-❌ ERRORS (1)
-──────────────────────────────────────────────────────────────
-• Constructor injection detected (prefer inject()):
-  - src/app/core/services/api.service.ts:15
-
-📋 RECOMMENDATIONS
-──────────────────────────────────────────────────────────────
-1. Migrate remaining *ngFor to @for with track
-2. Replace BehaviorSubject with signal() for local state
-3. Use inject() function instead of constructor injection
-
-══════════════════════════════════════════════════════════════
-```
-
-## Automated Checks
-
-Run these commands to verify compliance:
-
-```bash
-# Lint check
-ng lint
-
-# Type check
-npx tsc --noEmit
-
-# Test coverage
-npm run test:ci
-
-# Build check
-ng build --configuration=production
-```
-
-## Checklist
-
-- [ ] All components are standalone
-- [ ] All components use OnPush change detection
-- [ ] Local state uses signals (not BehaviorSubject)
-- [ ] Templates use @if/@for/@switch
-- [ ] Forms are typed (FormGroup<T>)
-- [ ] inject() used for dependency injection
-- [ ] File naming follows conventions
-- [ ] Imports are organized
-- [ ] Public API documented
-- [ ] Tests pass with >80% coverage
+- Cette commande orchestre les 4 audits spécialisés
+- Utiliser Docker pour tous les outils d'analyse
+- Fournir des exemples concrets avec fichier:ligne pour chaque problème
+- Prioriser les actions selon la matrice Impact/Effort
+- Les problèmes de sécurité sont TOUJOURS prioritaires
+- Proposer des corrections automatisables (scripts, hooks pre-commit)
+- Le rapport doit être actionnable, pas seulement descriptif
+- Adapter les recommandations au contexte métier du projet

--- a/Dev/i18n/fr/Common/commands/ralph-run.md
+++ b/Dev/i18n/fr/Common/commands/ralph-run.md
@@ -1,55 +1,55 @@
 ---
-description: Executer Claude en boucle continue jusqu'a completion de la tache (Ralph Wiggum v2.0)
+description: Exécuter Claude en boucle continue jusqu'à la complétion de la tâche (Ralph Wiggum v2.0)
 argument-hint: <description-tache> [--auto-detect|--init|--interactive]
 ---
 
 # Ralph Run - Boucle Continue d'Agent IA v2.0
 
-Execute Claude en boucle continue jusqu'a ce que la tache soit terminee ou que les criteres Definition of Done (DoD) soient satisfaits.
+Exécuter Claude en boucle continue jusqu'à ce que la tâche soit terminée ou que les critères de Définition of Done (DoD) soient satisfaits.
 
 ## Arguments
 
 **$ARGUMENTS**
 
-- `<description-tache>`: La tache a accomplir par Claude
-- `--auto-detect`: Detection automatique du type de projet et configuration DoD
-- `--init`: Generer la configuration sans executer
-- `--interactive`: Assistant de configuration interactif
+- `<description-tache>` : La tâche à accomplir par Claude
+- `--auto-detect` : Détection automatique du type de projet et configuration DoD
+- `--init` : Générer la configuration sans exécuter
+- `--interactive` : Assistant de configuration interactif
 
 ## Mode Plan
 
 > **Le mode plan est obligatoire.** Avant l'exécution, Claude active le mode plan pour analyser le code impacté, proposer un plan d'implémentation et attendre votre validation avant toute modification.
 
-## Nouvelles fonctionnalites v2.0
+## Nouvelles fonctionnalités v2.0
 
-| Fonctionnalite | Description |
+| Fonctionnalité | Description |
 |----------------|-------------|
-| **Integration Hooks** | Integration bidirectionnelle avec Claude Code 2.1.23+ |
-| **Auto-Detection** | Detection automatique du type de projet (Symfony, Flutter, React, etc.) |
-| **Dashboard** | Affichage temps reel avec barre de progression |
-| **Export Metriques** | Metriques au format JSON et Prometheus |
-| **Circuit Breaker Adaptatif** | 5 profils avec apprentissage historique |
-| **Moniteur de Sante** | Detection blocage, spirale d'erreurs, gonflement contexte |
-| **Templates DoD** | Templates preconfigures pour 8 technologies |
+| **Intégration Hooks** | Intégration bidirectionnelle avec Claude Code 2.1.23+ |
+| **Auto-Détection** | Détection automatique du type de projet (Symfony, Flutter, React, etc.) |
+| **Dashboard** | Affichage temps réel avec barre de progression |
+| **Export Métriques** | Métriques au format JSON et Prometheus |
+| **Circuit Breaker Adaptatif** | 5 profils avec apprentissage de l'historique |
+| **Moniteur de Santé** | Détection de blocage, spirale d'erreurs et gonflement du contexte |
+| **Templates DoD** | Templates préconfigurés pour 8 technologies |
 
 ## Processus
 
 ### 1. Initialisation de session
 
-1. **Verifier prerequis**:
-   - Verifier disponibilite de Claude
-   - Chercher configuration `ralph.yml`
-   - Initialiser repertoire session (`.ralph/`)
+1. **Vérifier les prérequis** :
+   - Vérifier la disponibilité de Claude
+   - Rechercher la configuration `ralph.yml`
+   - Initialiser le répertoire de session (`.ralph/`)
 
-2. **Detection automatique** (si `--auto-detect`):
-   - Detecter type de projet (Symfony, Flutter, React, Python, .NET, Go, Rust)
-   - Charger template DoD approprie
-   - Configurer commandes test et lint
+2. **Détection automatique du projet** (si `--auto-detect`) :
+   - Détecter le type de projet (Symfony, Flutter, React, Python, .NET, Go, Rust)
+   - Charger le template DoD approprié
+   - Configurer les commandes de test et de lint
 
-3. **Charger configuration**:
+3. **Charger la configuration** :
    - Lire `ralph.yml` ou `.claude/ralph.yml`
-   - Definir iterations max, timeouts, criteres DoD
-   - Initialiser hooks si actives
+   - Définir les itérations max, les timeouts, les critères DoD
+   - Initialiser les hooks si activés
 
 ### 2. Boucle principale avec Dashboard
 
@@ -57,30 +57,30 @@ Execute Claude en boucle continue jusqu'a ce que la tache soit terminee ou que l
 ╔═══════════════════════════════════════════════════════════════╗
 ║  RALPH WIGGUM - Session: ralph-xxx           PHASE: GREEN     ║
 ╠═══════════════════════════════════════════════════════════════╣
-║  ITERATION 8/25              ECOULE: 12:34                    ║
-║  PROGRES ████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░  32%   ║
+║  ITERATION 8/25              ÉCOULÉ: 12:34                    ║
+║  PROGRÈS ████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░  32%   ║
 ║                                                               ║
 ║  Circuit Breaker: ░░ (0/4)    Contexte: ████████░░ 78%       ║
 ╚═══════════════════════════════════════════════════════════════╝
 ```
 
-### 3. Validation Definition of Done
+### 3. Validation de la Définition of Done
 
-Le systeme DoD valide la completion via plusieurs criteres:
+Le système DoD valide la complétion à travers plusieurs critères :
 
 | Validateur | Description |
 |------------|-------------|
-| `command` | Executer commande shell (tests, lint, build) |
-| `output_contains` | Verifier pattern dans sortie Claude |
-| `file_changed` | Verifier modification fichiers |
-| `hook` | Executer hook Claude existant |
+| `command` | Exécuter une commande shell (tests, lint, build) |
+| `output_contains` | Vérifier la présence d'un pattern dans la sortie Claude |
+| `file_changed` | Vérifier que des fichiers ont été modifiés |
+| `hook` | Exécuter un hook Claude existant |
 | `human` | Validation humaine interactive |
 
 ### 4. Circuit Breaker Adaptatif (v2.0)
 
-Selection automatique du profil selon mots-cles:
+Sélection automatique du profil selon les mots-clés de la tâche :
 
-| Profil | Mots-cles | Sans Modif | Erreurs | Max Iter |
+| Profil | Mots-clés | Sans Modif | Erreurs | Max Iter |
 |--------|-----------|------------|---------|----------|
 | `quick_fix` | fix, bug, typo | 2 | 3 | 10 |
 | `small_feature` | add, implement | 3 | 4 | 15 |
@@ -88,25 +88,25 @@ Selection automatique du profil selon mots-cles:
 | `large_feature` | refactor, migrate | 5 | 8 | 50 |
 | `exploration` | explore, investigate | 10 | 15 | 100 |
 
-### 5. Integration Hooks (Claude Code 2.1.23+)
+### 5. Intégration Hooks (Claude Code 2.1.23+)
 
 ```
-SessionStart → session-restore.sh → Injecter contexte Ralph
+SessionStart → session-restore.sh → Injecter le contexte Ralph
      ↓
-PreToolUse (once) → status-injector.sh → Injecter statut DoD
+PreToolUse (once) → status-injector.sh → Injecter le statut DoD
      ↓
 Claude travaille...
      ↓
 Stop → stop-dod-gate.sh → Bloquer si DoD non satisfait (exit 2)
 ```
 
-## Exemples rapides
+## Exemples de démarrage rapide
 
 ```bash
 # Utilisation basique
-ralph.sh "Implementer authentification utilisateur"
+ralph.sh "Implémenter l'authentification utilisateur"
 
-# Detection auto et generation config
+# Détection automatique du projet et génération de la config
 ralph.sh --auto-detect --init
 
 # Assistant de configuration interactif
@@ -115,7 +115,7 @@ ralph.sh --interactive
 # Avec fichier de configuration
 ralph.sh --config=ralph.yml "Corriger le bug de connexion"
 
-# Reprendre session
+# Reprendre une session
 ralph.sh --continue=ralph-1704067200-a1b2
 ```
 
@@ -124,27 +124,27 @@ ralph.sh --continue=ralph-1704067200-a1b2
 ```yaml
 version: "2.0"
 
-# Integration hooks
+# Intégration hooks
 hooks:
   enabled: true
   mode: "advanced"  # simple ou advanced
 
-# Auto-detection
+# Auto-détection
 auto_detect:
   enabled: true
   interactive: false
 
-# Dashboard temps reel
+# Dashboard temps réel
 dashboard:
   enabled: true
   mode: "full"  # simple, full, headless
 
-# Export metriques
+# Export métriques
 metrics:
   enabled: true
   format: "both"  # json, prometheus, both
 
-# Monitoring sante
+# Monitoring de santé
 health_monitor:
   enabled: true
   patterns:
@@ -160,12 +160,12 @@ circuit_breaker:
     enabled: true
     min_samples: 5
 
-# Definition of Done
+# Définition of Done
 definition_of_done:
   checklist:
     - id: tests
       type: command
-      command: "docker compose exec app vendor/bin/phpunit"
+      command: "docker compose exec app npm test"
       required: true
     - id: completion
       type: output_contains
@@ -175,8 +175,8 @@ definition_of_done:
 
 ## Templates DoD par technologie
 
-| Technologie | Commande Test | Commande Lint |
-|-------------|---------------|---------------|
+| Technologie | Commande de test | Commande de lint |
+|-------------|------------------|------------------|
 | Symfony | `vendor/bin/phpunit` | `vendor/bin/phpstan analyse` |
 | Flutter | `flutter test` | `flutter analyze` |
 | React | `npm test` | `npm run lint` |
@@ -185,16 +185,94 @@ definition_of_done:
 | Go | `go test ./...` | `golangci-lint run` |
 | Rust | `cargo test` | `cargo clippy` |
 
+## Sortie
+
+```
+╔════════════════════════════════════════════════════════════╗
+║     🔁 Ralph Wiggum - Continuous AI Agent Loop v2.0        ║
+╚════════════════════════════════════════════════════════════╝
+
+✓ Détecté : react-typescript (confiance ÉLEVÉE)
+✓ Session créée : ralph-1704067200-a1b2
+✓ Hooks initialisés (mode advanced)
+
+ℹ Démarrage de la boucle Ralph...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Itération 1 sur 25 (Profil : medium_feature)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ℹ Invocation de Claude...
+ℹ Vérification des critères DoD...
+  ✓ [tests] Tous les tests passent - OK
+  ✓ [lint] Aucune erreur de lint - OK
+  ✓ [completion] Claude signale la complétion - OK
+
+  Tous les critères requis sont satisfaits !
+
+✓ DoD VALIDÉ
+
+╔════════════════════════════════════════════════════════════╗
+║     📊 Résumé de session                                    ║
+╚════════════════════════════════════════════════════════════╝
+
+  ID de session :       ralph-1704067200-a1b2
+  Profil :              medium_feature
+  Itérations totales :  3
+  Durée :               45s
+  Statut DoD :          VALIDÉ
+  Raison de sortie :    dod_complete
+  Métriques exportées : .ralph/sessions/.../metrics-export.json
+```
+
+## Modes d'échec et récupération
+
+### Échecs des validateurs DoD
+
+Lorsque les validateurs DoD échouent de manière répétée, Ralph applique une récupération progressive :
+
+| Échecs consécutifs | Action |
+|--------------------|--------|
+| 1-2 | Nouvelle tentative avec contexte — Ralph inclut la sortie d'erreur précédente |
+| 3 | Déclenchement de la vérification du circuit breaker — évaluer si la tâche est bloquée |
+| 4+ | Circuit breaker déclenché — la session s'arrête avec `exit_reason: circuit_breaker` |
+
+### Gestion des timeouts
+
+| Type de timeout | Valeur par défaut | Configuration |
+|-----------------|-------------------|---------------|
+| Par itération | 5 min | `circuit_breaker.iteration_timeout` |
+| Session totale | 30 min | `circuit_breaker.session_timeout` |
+| Commande DoD | 60 sec | `definition_of_done.timeout` |
+
+Lorsqu'un timeout se déclenche :
+1. L'itération en cours est annulée
+2. La progression partielle est conservée dans l'état de session
+3. Le compteur du circuit breaker s'incrémente
+4. Reprendre avec `--continue=<session-id>` pour réessayer
+
+### Raisons de sortie courantes
+
+| Raison de sortie | Signification | Récupération |
+|------------------|---------------|--------------|
+| `dod_complete` | Tous les critères DoD sont satisfaits | Succès — aucune action requise |
+| `circuit_breaker` | Trop d'échecs | Revoir le périmètre de la tâche, simplifier le DoD |
+| `max_iterations` | Limite d'itérations atteinte | Augmenter la limite ou découper en sous-tâches |
+| `timeout` | Timeout de session expiré | Reprendre ou augmenter le timeout |
+| `user_abort` | Annulation utilisateur (Ctrl+C) | Reprendre avec `--continue` |
+
 ## Bonnes pratiques
 
-1. **Utiliser auto-detect**: Laisser Ralph configurer DoD pour votre stack
-2. **Description claire**: Fournir des taches specifiques et actionnables
-3. **Utiliser TDD**: Ecrire les tests d'abord, laisser Ralph implementer
-4. **Surveiller dashboard**: Observer la progression en temps reel
-5. **Analyser metriques**: Examiner les metriques pour optimisation
+1. **Utiliser auto-detect** : Laisser Ralph configurer le DoD pour votre stack
+2. **Description de tâche claire** : Fournir des tâches spécifiques et actionnables
+3. **Utiliser TDD** : Écrire les tests en premier, laisser Ralph implémenter
+4. **Surveiller le dashboard** : Observer la progression en temps réel
+5. **Analyser les métriques** : Examiner les métriques de session pour optimiser
+6. **Définir des timeouts réalistes** : Adapter les timeouts à la complexité de la tâche
+7. **Utiliser les profils du circuit breaker** : Adapter le profil au type de tâche (quick_fix vs large_feature)
 
 ## Liens
 
-- `@ralph-conductor` - Agent pour orchestration Ralph
-- `/qa:tdd` - Correction de bug en TDD
-- `/sprint:dev` - Developpement sprint avec TDD
+- `@ralph-conductor` - Agent pour l'orchestration Ralph
+- `/qa:tdd` - Correction de bugs basée sur le TDD
+- `/sprint:dev` - Développement de sprint avec TDD

--- a/Dev/i18n/fr/Laravel/commands/check-compliance.md
+++ b/Dev/i18n/fr/Laravel/commands/check-compliance.md
@@ -1,145 +1,253 @@
 ---
-description: Check Laravel project compliance with coding standards
+description: Vérification Complète de la Conformité Laravel
+argument-hint: [arguments]
 ---
 
-# Laravel Compliance Check
+# Vérification Complète de la Conformité Laravel
 
-You are a Laravel expert auditor. Your mission is to verify that the project follows Laravel best practices and coding standards.
+## Arguments
 
-## Audit Process
-
-### 1. Project Structure Analysis
-
-Check if the project follows the recommended architecture:
-
-```
-app/
-├── Domain/           # Business logic (if using Clean Architecture)
-├── Application/      # Use cases, Actions, DTOs
-├── Infrastructure/   # External services, Repositories
-├── Http/
-│   ├── Controllers/  # Thin controllers
-│   ├── Requests/     # Form Requests for validation
-│   ├── Resources/    # API Resources
-│   └── Middleware/
-├── Models/           # Eloquent models
-├── Services/         # Business services
-├── Jobs/             # Queue jobs
-├── Events/           # Domain events
-├── Listeners/        # Event listeners
-├── Policies/         # Authorization policies
-└── Providers/        # Service providers
-```
-
-### 2. Code Standards Verification
-
-#### Naming Conventions
-- [ ] Controllers: Singular, PascalCase (`OrderController`)
-- [ ] Models: Singular, PascalCase (`Order`, `OrderItem`)
-- [ ] Tables: Plural, snake_case (`orders`, `order_items`)
-- [ ] Columns: snake_case (`created_at`, `customer_id`)
-- [ ] Methods: camelCase (`getUserOrders()`)
-- [ ] Variables: camelCase (`$orderTotal`)
-
-#### Modern PHP Features (8.3+)
-- [ ] Constructor property promotion used
-- [ ] Readonly properties/classes where appropriate
-- [ ] Enums for status/type fields
-- [ ] Match expressions instead of switch
-- [ ] Named arguments for clarity
-- [ ] Type declarations on all methods
-- [ ] Return types specified
-
-#### Laravel Conventions
-- [ ] Form Requests for validation (not validation in controllers)
-- [ ] API Resources for response transformation
-- [ ] Policies for authorization
-- [ ] Eloquent casts for type conversion
-- [ ] Scopes for reusable queries
-- [ ] Events for cross-cutting concerns
-
-### 3. Architecture Compliance
-
-#### Layer Dependencies
-- Domain layer has NO external dependencies
-- Application layer only depends on Domain
-- Infrastructure implements Domain interfaces
-- Controllers are thin (delegate to Actions/Services)
-
-#### Repository Pattern (if applicable)
-- [ ] Interfaces defined in Domain/Contracts
-- [ ] Implementations in Infrastructure
-- [ ] Bindings in Service Providers
-
-### 4. Configuration Check
-
-- [ ] No hardcoded values (use config files)
-- [ ] Environment variables via config(), not env()
-- [ ] Sensitive data in .env (not committed)
-- [ ] Config caching compatible
-
-### 5. Generate Report
-
-After analysis, provide:
-
-1. **Compliance Score**: X/100
-2. **Critical Issues**: Must-fix problems
-3. **Warnings**: Recommended improvements
-4. **Good Practices**: What's done well
-5. **Action Items**: Prioritized list of fixes
+$ARGUMENTS (optionnel : chemin du projet à analyser)
 
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.
 
-## Commands to Run
+## MISSION
 
-```bash
-# Check code style
-./vendor/bin/pint --test
+Réaliser un audit complet de conformité du projet Laravel en orchestrant les 4 grandes vérifications : Architecture, Qualité du Code, Tests et Sécurité. Produire un rapport consolidé avec un score global sur 100 points.
 
-# Static analysis
-./vendor/bin/phpstan analyse
+### Étape 1 : Préparation de l'audit
 
-# Run tests
-php artisan test
+Préparer l'environnement d'audit :
+- [ ] Identifier le chemin du projet à auditer
+- [ ] Vérifier la présence des fichiers de configuration (composer.json avec laravel/*, .env.example)
+- [ ] Lister les répertoires principaux (app/, tests/, config/, routes/, etc.)
+- [ ] Identifier la structure du projet et la version Laravel
 
-# Check for security vulnerabilities
-composer audit
+**Note** : Si $ARGUMENTS est fourni, l'utiliser comme chemin du projet, sinon utiliser le répertoire courant.
+
+### Étape 2 : Audit Architecture (25 points)
+
+Exécuter la vérification complète de l'architecture :
+
+**Commande** : Utiliser la commande slash `/laravel:check-architecture` ou suivre manuellement les étapes dans `check-architecture.md`
+
+**Critères évalués** :
+- Séparation des couches en Clean Architecture (6 pts)
+- Structure Domain/Application/Infrastructure (6 pts)
+- Pattern Actions et contrôleurs fins (4 pts)
+- Bindings des Service Providers (4 pts)
+- Pattern Repository et interfaces (3 pts)
+- Règles de dépendances (2 pts)
+
+**Référence** : `check-architecture.md`
+
+### Étape 3 : Audit Qualité du Code (25 points)
+
+Exécuter la vérification de la qualité du code :
+
+**Commande** : Utiliser la commande slash `/laravel:check-code-quality` ou suivre manuellement les étapes dans `check-code-quality.md`
+
+**Critères évalués** :
+- Conformité PSR-12 et Laravel Pint (5 pts)
+- Analyse statique PHPStan (5 pts)
+- Fonctionnalités PHP modernes (enums, readonly, typed properties) (4 pts)
+- Principes KISS/DRY/YAGNI (4 pts)
+- Conventions de nommage (standards Laravel) (4 pts)
+- Gestion des erreurs et logging (3 pts)
+
+**Référence** : `check-code-quality.md`
+
+### Étape 4 : Audit Tests (25 points)
+
+Exécuter la vérification des tests :
+
+**Commande** : Utiliser la commande slash `/laravel:check-testing` ou suivre manuellement les étapes dans `check-testing.md`
+
+**Critères évalués** :
+- Couverture du code (7 pts)
+- Tests unitaires pour la logique Domain (6 pts)
+- Tests de fonctionnalité pour les endpoints HTTP (4 pts)
+- Utilisation de Pest PHP et qualité des tests (3 pts)
+- Factories et seeders de base de données (3 pts)
+- Isolation des tests et mocking (2 pts)
+
+**Référence** : `check-testing.md`
+
+### Étape 5 : Audit Sécurité (25 points)
+
+Exécuter la vérification de sécurité :
+
+**Commande** : Utiliser la commande slash `/laravel:check-security` ou suivre manuellement les étapes dans `check-security.md`
+
+**Critères évalués** :
+- Protections OWASP Top 10 (6 pts)
+- Gestion des secrets et des identifiants (5 pts)
+- Validation par Form Request (4 pts)
+- Vulnérabilités des dépendances (composer audit) (4 pts)
+- Authentification et Autorisation (Policies) (3 pts)
+- Configuration CSRF et middleware (2 pts)
+- Prévention de l'injection SQL (1 pt)
+
+**Référence** : `check-security.md`
+
+### Étape 6 : Consolidation et Score Global
+
+Calculer le score global et produire le rapport consolidé :
+- [ ] Additionner les 4 scores (max 100 points)
+- [ ] Identifier les catégories critiques (<50%)
+- [ ] Lister tous les problèmes transversaux critiques
+- [ ] Prioriser les actions par impact/effort
+- [ ] Produire le rapport final consolidé
+
+**Échelle de notation** :
+- 90-100 : Excellent - Projet de référence
+- 75-89 : Très bien - Quelques améliorations mineures
+- 60-74 : Acceptable - Des améliorations sont nécessaires
+- 40-59 : Insuffisant - Refactoring majeur requis
+- 0-39 : Critique - Refonte complète nécessaire
+
+### Étape 7 : Recommandations et Plan d'Action
+
+Produire les recommandations finales :
+- [ ] Identifier les 3 actions prioritaires dans toutes les catégories
+- [ ] Estimer l'effort (Faible/Moyen/Élevé) pour chaque action
+- [ ] Estimer l'impact (Faible/Moyen/Élevé) pour chaque action
+- [ ] Proposer un ordre d'implémentation
+- [ ] Suggérer des gains rapides (ratio impact/effort élevé)
+
+## FORMAT DE SORTIE
+
+```
+AUDIT DE CONFORMITÉ LARAVEL - RAPPORT COMPLET
+=============================================
+
+SCORE GLOBAL : XX/100
+
+NIVEAU DE CONFORMITÉ : [Excellent/Très bien/Acceptable/Insuffisant/Critique]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SCORES PAR CATÉGORIE :
+
+ARCHITECTURE       : XX/25  [██████████░░░░░░░░░░] XX%
+QUALITÉ DU CODE    : XX/25  [██████████░░░░░░░░░░] XX%
+TESTS              : XX/25  [██████████░░░░░░░░░░] XX%
+SÉCURITÉ           : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+POINTS FORTS GLOBAUX :
+1. [Point fort identifié dans plusieurs catégories]
+2. [Autre point fort majeur]
+3. [Troisième point fort]
+
+AMÉLIORATIONS GLOBALES :
+1. [Amélioration transversale mineure]
+2. [Autre amélioration recommandée]
+3. [Troisième amélioration]
+
+PROBLÈMES CRITIQUES :
+1. [Problème critique #1 - catégorie concernée]
+2. [Problème critique #2 - catégorie concernée]
+3. [Problème critique #3 - catégorie concernée]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DÉTAILS PAR CATÉGORIE :
+
+┌─────────────────────────────────────────────┐
+│ ARCHITECTURE (XX/25)                        │
+└─────────────────────────────────────────────┘
+
+Sous-scores :
+  • Couches Clean Architecture        : XX/6
+  • Structure Domain/App/Infra        : XX/6
+  • Actions et contrôleurs fins       : XX/4
+  • Bindings Service Provider         : XX/4
+  • Pattern Repository                : XX/3
+  • Règles de dépendances             : XX/2
+
+Points forts :
+- [Points forts d'architecture]
+
+Problèmes :
+- [Problèmes d'architecture]
+
+[Sections similaires pour Qualité du Code, Tests et Sécurité...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 DES ACTIONS PRIORITAIRES (TOUTES CATÉGORIES) :
+
+1. CRITIQUE - [Action #1]
+   Catégorie  : [Architecture/Qualité/Tests/Sécurité]
+   Impact     : [Élevé/Moyen/Faible]
+   Effort     : [Élevé/Moyen/Faible]
+   Priorité   : IMMÉDIATE
+
+   Description détaillée :
+   [Explication du problème et solution proposée]
+
+   Fichiers concernés :
+   - [fichier:ligne]
+
+   Exemple de correction :
+   [Code ou commande de correction]
+
+2. IMPORTANT - [Action #2]
+   [Même format...]
+
+3. RECOMMANDÉ - [Action #3]
+   [Même format...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GAINS RAPIDES (Impact Élevé / Effort Faible) :
+
+- [Gain rapide #1] - Catégorie : [X] - Impact : [X] - Effort : [X]
+- [Gain rapide #2] - Catégorie : [X] - Impact : [X] - Effort : [X]
+- [Gain rapide #3] - Catégorie : [X] - Impact : [X] - Effort : [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLAN D'ACTION RECOMMANDÉ :
+
+SEMAINE 1 (Immédiat) :
+- [ ] [Action critique #1]
+- [ ] [Gain rapide prioritaire]
+
+SEMAINES 2-4 (Court terme) :
+- [ ] [Action importante #2]
+- [ ] [Autres gains rapides]
+
+MOIS 2-3 (Moyen terme) :
+- [ ] [Action recommandée #3]
+- [ ] [Améliorations progressives]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RÉSUMÉ EXÉCUTIF :
+
+[Paragraphe de synthèse sur l'état global du projet, les principaux
+points forts, les principales faiblesses et la trajectoire recommandée
+pour améliorer la conformité. Mentionner si le projet est prêt pour
+la production, nécessite des corrections ou un refactoring.]
+
+Recommandation générale : [Prêt pour la production / Corrections mineures /
+Refactoring majeur / Refonte nécessaire]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-## Output Format
+## NOTES IMPORTANTES
 
-```markdown
-# Laravel Compliance Report
-
-## Summary
-- **Score**: 85/100
-- **Critical Issues**: 2
-- **Warnings**: 5
-- **Files Analyzed**: 150
-
-## Critical Issues
-
-### 1. Missing Form Request Validation
-**File**: `app/Http/Controllers/OrderController.php:45`
-**Issue**: Validation done in controller instead of Form Request
-**Fix**: Create `StoreOrderRequest` and move validation rules
-
-### 2. [Issue description]
-
-## Warnings
-
-### 1. [Warning description]
-
-## Recommendations
-
-1. [Recommendation 1]
-2. [Recommendation 2]
-
-## Good Practices Observed
-
-- Using Eloquent casts for type conversion
-- Proper use of API Resources
-- Events for decoupling
-```
+- Cette commande orchestre les 4 audits spécialisés
+- Utiliser Docker pour tous les outils d'analyse
+- Fournir des exemples concrets avec fichier:ligne pour chaque problème
+- Prioriser les actions selon la matrice Impact/Effort
+- Les problèmes de sécurité sont TOUJOURS prioritaires
+- Proposer des corrections automatisables (scripts, hooks pre-commit)
+- Le rapport doit être actionnable, pas seulement descriptif
+- Adapter les recommandations au contexte métier du projet

--- a/Dev/i18n/fr/React/commands/check-architecture.md
+++ b/Dev/i18n/fr/React/commands/check-architecture.md
@@ -1,74 +1,352 @@
 ---
-description: Vérification de lArchitecture React
-argument-hint: [arguments]
+description: Vérification de la Conformité Architecturale
 ---
 
-# Vérification de l'Architecture React
+# Vérification de la Conformité Architecturale
 
-## Arguments
+Vérifie que le projet suit les patterns architecturaux établis et les meilleures pratiques.
 
-$ARGUMENTS
+## Ce que fait cette commande
+
+1. **Analyse Architecturale**
+   - Vérifier la structure des dossiers
+   - Contrôler la séparation des responsabilités
+   - Valider l'organisation des composants
+   - Vérifier les directions de dépendance
+   - Vérifier les patterns de conception
+
+2. **Points de Vérification**
+   - Structure orientée fonctionnalités (feature-based)
+   - Hiérarchie des composants
+   - Gestion d'état
+   - Séparation de la couche API
+   - Définitions de types
+
+3. **Rapport Généré**
+   - Violations architecturales
+   - Recommandations
+   - Opportunités de refactoring
+   - Score de conformité
 
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.
 
-## MISSION
+## Architecture Attendue
 
-Tu es un expert en architecture React chargé d'auditer la conformité architecturale d'un projet React.
+### Structure des Dossiers
 
-### Étape 1 : Analyse du contexte
-- Identifier le répertoire du projet à auditer ($ARGUMENTS ou répertoire courant)
-- Lire les règles architecturales depuis `/home/fmetivier/Documents/Company/TheBeardedCTO/Tools/Claude/Dev/React/rules/02-architecture.md`
-- Comprendre la structure attendue (Feature-based, Atomic Design)
+```
+src/
+├── app/                    # Configuration de l'application
+│   ├── App.tsx
+│   ├── routes.tsx
+│   └── providers.tsx
+│
+├── features/              # Fonctionnalités (logique métier)
+│   └── users/
+│       ├── components/    # Composants spécifiques à la feature
+│       ├── hooks/         # Hooks spécifiques à la feature
+│       ├── services/      # Appels API
+│       ├── stores/        # Gestion d'état
+│       ├── types/         # Types TypeScript
+│       └── utils/         # Fonctions utilitaires
+│
+├── components/            # Composants partagés
+│   ├── ui/               # Primitives UI (Button, Input)
+│   ├── layout/           # Composants de mise en page
+│   └── common/           # Composants communs
+│
+├── hooks/                 # Hooks partagés
+├── services/             # Services partagés
+├── stores/               # État global
+├── types/                # Types globaux
+├── utils/                # Fonctions utilitaires
+├── constants/            # Constantes
+└── config/               # Configuration
+```
 
-### Étape 2 : Vérification de la structure du projet
+## Ce qu'il faut Vérifier
 
-Examiner et vérifier :
+### 1. Organisation des Composants
 
-**Organisation des dossiers (8 points)**
-- [ ] Structure feature-based ou modulaire présente
-- [ ] Séparation claire features/shared/core
-- [ ] Dossiers par domaine métier identifiables
-- [ ] Pas de code métier dans `/src/components` racine
+```typescript
+// ❌ Mauvais - Tout dans un seul fichier
+src/components/UserList.tsx (1000 lignes)
 
-**Atomic Design (7 points)**
-- [ ] Hiérarchie atoms/molecules/organisms/templates/pages
-- [ ] Composants atomiques réutilisables
-- [ ] Composition progressive respectée
-- [ ] Pas de logique métier dans les atoms
+// ✅ Bon - Organisation appropriée
+src/features/users/
+  ├── components/
+  │   ├── UserList/
+  │   │   ├── UserList.tsx
+  │   │   ├── UserList.test.tsx
+  │   │   ├── UserListItem.tsx
+  │   │   └── index.ts
+  │   └── UserForm/
+  │       ├── UserForm.tsx
+  │       └── UserForm.test.tsx
+  ├── hooks/
+  │   └── useUsers.ts
+  └── services/
+      └── user.service.ts
+```
 
-**Structure des features (5 points)**
-- [ ] Chaque feature contient : components, hooks, services, types
-- [ ] Index.ts avec exports publics
-- [ ] API interne encapsulée
-- [ ] Tests co-localisés avec le code
+### 2. Séparation des Responsabilités
 
-**Gestion d'état (5 points)**
-- [ ] State management centralisé (Context/Zustand/Redux)
-- [ ] Pas de prop drilling excessif (>3 niveaux)
-- [ ] State local vs global clairement séparé
-- [ ] Hooks personnalisés pour la logique réutilisable
+```typescript
+// ❌ Mauvais - Responsabilités mélangées
+export const UserList: FC = () => {
+  const [users, setUsers] = useState([]);
 
-### Étape 3 : Analyse approfondie
+  useEffect(() => {
+    fetch('/api/users')
+      .then(res => res.json())
+      .then(setUsers);
+  }, []);
 
-Pour chaque feature/module identifié :
-- Vérifier la cohésion interne
-- Identifier les dépendances circulaires
-- Vérifier l'encapsulation des API
-- Mesurer le couplage inter-features
+  return (
+    <div>
+      {users.map(user => (
+        <div key={user.id}>
+          <h3>{user.name}</h3>
+          <p>{user.email}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
 
-### Étape 4 : Calcul du score
+// ✅ Bon - Responsabilités séparées
+// hooks/useUsers.ts
+export const useUsers = () => {
+  return useQuery({
+    queryKey: ['users'],
+    queryFn: () => userService.getAll()
+  });
+};
 
-**Score sur 25 points :**
-- Organisation des dossiers : 8 points
-- Atomic Design : 7 points
-- Structure des features : 5 points
-- Gestion d'état : 5 points
+// services/user.service.ts
+export const userService = {
+  getAll: () => apiClient.get<User[]>('/users')
+};
 
-### Étape 5 : Rapport de conformité
+// components/UserList.tsx
+export const UserList: FC = () => {
+  const { data: users, isLoading } = useUsers();
 
-Générer un rapport structuré :
+  if (isLoading) return <Spinner />;
+
+  return (
+    <ul>
+      {users?.map(user => (
+        <UserListItem key={user.id} user={user} />
+      ))}
+    </ul>
+  );
+};
+```
+
+### 3. Direction des Dépendances
+
+```typescript
+// ✅ Bon - Les dépendances vont vers l'intérieur
+features/users/
+  └── components/     → Peut utiliser hooks/
+      └── hooks/      → Peut utiliser services/
+          └── services/ → Peut utiliser utils/
+
+// ❌ Mauvais - Dépendances circulaires
+services/user.service.ts importe depuis components/
+```
+
+### 4. Types de Composants
+
+```typescript
+// Composants de Présentation (UI uniquement)
+export const Button: FC<ButtonProps> = ({ children, ...props }) => {
+  return <button {...props}>{children}</button>;
+};
+
+// Composants Conteneurs (logique)
+export const UserListContainer: FC = () => {
+  const { data: users } = useUsers();
+  const deleteUser = useDeleteUser();
+
+  return <UserListPresenter users={users} onDelete={deleteUser} />;
+};
+
+// Composants de Page (routage)
+export const UsersPage: FC = () => {
+  return (
+    <MainLayout>
+      <PageHeader title="Users" />
+      <UserListContainer />
+    </MainLayout>
+  );
+};
+```
+
+### 5. Gestion d'État
+
+```typescript
+// ❌ Mauvais - État dupliqué en plusieurs endroits
+const [users, setUsers] = useState([]);
+// Mêmes données dans 5 composants différents
+
+// ✅ Bon - État centralisé
+// stores/userStore.ts
+export const useUserStore = create<UserStore>((set) => ({
+  users: [],
+  setUsers: (users) => set({ users })
+}));
+
+// Ou React Query pour l'état serveur
+export const useUsers = () => {
+  return useQuery({
+    queryKey: ['users'],
+    queryFn: () => userService.getAll()
+  });
+};
+```
+
+## Patterns Architecturaux
+
+### 1. Structure Orientée Fonctionnalités
+
+```
+src/features/
+├── auth/
+│   ├── components/
+│   ├── hooks/
+│   ├── services/
+│   └── stores/
+├── users/
+└── products/
+```
+
+### 2. Couches de Clean Architecture
+
+```
+Couche Présentation (Composants)
+    ↓
+Couche Logique Métier (Hooks, Services)
+    ↓
+Couche Données (API, Store)
+```
+
+### 3. Atomic Design
+
+```
+src/components/
+├── atoms/        # Button, Input, Label
+├── molecules/    # FormField, SearchBar
+├── organisms/    # UserForm, Header
+├── templates/    # PageLayout, DashboardLayout
+└── pages/        # HomePage, UsersPage
+```
+
+## Règles de Validation
+
+### Règle 1 : Pas de Logique Métier dans les Composants
+
+```typescript
+// ❌ Mauvais
+export const UserForm: FC = () => {
+  const [email, setEmail] = useState('');
+
+  const validate = () => {
+    return email.includes('@') && email.length > 5;
+  };
+
+  // ... logique de validation complexe
+};
+
+// ✅ Bon
+export const UserForm: FC = () => {
+  const form = useForm({
+    resolver: zodResolver(userSchema)
+  });
+
+  // Validation dans le schéma, logique dans le hook
+};
+```
+
+### Règle 2 : Appels API via les Services
+
+```typescript
+// ❌ Mauvais - fetch direct dans le composant
+const response = await fetch('/api/users');
+
+// ✅ Bon - Via le service
+const users = await userService.getAll();
+```
+
+### Règle 3 : Types Centralisés
+
+```typescript
+// ✅ Bonne structure
+src/features/users/types/
+  ├── user.types.ts
+  ├── dto.types.ts
+  └── index.ts
+```
+
+## Vérifications Automatisées
+
+### Règles ESLint pour l'Architecture
+
+```json
+// .eslintrc.json
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["../**/features/*"],
+            "message": "Les features ne doivent pas importer d'autres features"
+          },
+          {
+            "group": ["**/components/**/services/*"],
+            "message": "Les composants ne doivent pas importer les services directement"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Script Personnalisé
+
+```typescript
+// scripts/check-architecture.ts
+import { glob } from 'glob';
+import { readFile } from 'fs/promises';
+
+const checkImports = async () => {
+  const files = await glob('src/**/*.{ts,tsx}');
+  const violations = [];
+
+  for (const file of files) {
+    const content = await readFile(file, 'utf-8');
+
+    // Vérifier les violations
+    if (file.includes('/components/') && content.includes('fetch(')) {
+      violations.push({
+        file,
+        rule: 'Pas d\'appels API directs dans les composants',
+        line: content.split('\n').findIndex(l => l.includes('fetch('))
+      });
+    }
+  }
+
+  return violations;
+};
+```
+
+## Rapport de Conformité
 
 ```
 ═══════════════════════════════════════════════════
@@ -125,10 +403,49 @@ Générer un rapport structuré :
 • rules/03-coding-standards.md - Conventions de code
 ```
 
-### Étape 6 : Recommandations détaillées
+## Bonnes Pratiques
 
-Pour chaque problème identifié :
-- Expliquer l'impact
-- Proposer une solution concrète
-- Fournir un exemple de code si pertinent
-- Indiquer le niveau d'effort (Low/Medium/High)
+1. **Isolation des features** : Chaque feature est autonome
+2. **Frontières claires** : Couches présentation, logique, données
+3. **Injection de dépendances** : Services via hooks/context
+4. **Sécurité des types** : TypeScript partout
+5. **Nommage cohérent** : Respecter les conventions
+6. **Responsabilité unique** : Un composant, une tâche
+7. **Composition plutôt qu'héritage** : Utiliser la composition
+8. **Documentation** : Documenter les décisions architecturales
+
+## Violations Courantes
+
+### Violation 1 : Composants Dieux
+
+**Problème** : Le composant fait trop de choses
+**Solution** : Décomposer en composants plus petits
+
+### Violation 2 : Dépendances Circulaires
+
+**Problème** : A importe B, B importe A
+**Solution** : Extraire le code commun ou repenser la structure
+
+### Violation 3 : Prop Drilling
+
+**Problème** : Passage de props à travers de nombreux niveaux
+**Solution** : Utiliser le Context ou la gestion d'état
+
+### Violation 4 : Responsabilités Mélangées
+
+**Problème** : UI et logique métier mélangées
+**Solution** : Séparer en composant présentateur et conteneur
+
+## Outils
+
+- ESLint avec règles personnalisées
+- Dependency cruiser
+- Madge (graphe de dépendances)
+- SonarQube
+- Scripts personnalisés
+
+## Ressources
+
+- [React Architecture Best Practices](https://react.dev/learn/thinking-in-react)
+- [Feature-Sliced Design](https://feature-sliced.design/)
+- [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)

--- a/Dev/i18n/fr/React/commands/check-code-quality.md
+++ b/Dev/i18n/fr/React/commands/check-code-quality.md
@@ -1,94 +1,421 @@
 ---
-description: Vérification de la Qualité du Code React
-argument-hint: [arguments]
+description: Vérification de la Qualité du Code
 ---
 
-# Vérification de la Qualité du Code React
+# Vérification de la Qualité du Code
 
-## Arguments
+Effectue une analyse complète de la qualité du code de l'application React.
 
-$ARGUMENTS
+## Ce que fait cette commande
+
+1. **Analyse de Qualité**
+   - Lancer le linting (ESLint)
+   - Vérification des types (TypeScript)
+   - Formatage du code (Prettier)
+   - Analyse de la complexité
+   - Détection des odeurs de code
+   - Vérification de la couverture de tests
+
+2. **Métriques Mesurées**
+   - Complexité cyclomatique
+   - Duplication de code
+   - Couverture de tests
+   - Dette technique
+   - Indice de maintenabilité
+
+3. **Rapport Généré**
+   - Score de qualité
+   - Problèmes par sévérité
+   - Recommandations de refactoring
+   - Tendances dans le temps
+
+## Comment Utiliser
+
+```bash
+# Vérification complète de qualité
+npm run quality
+
+# Vérifications individuelles
+npm run lint
+npm run type-check
+npm run format:check
+npm run test:coverage
+```
 
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.
 
-## MISSION
+## Vérifications de Qualité
 
-Tu es un expert en qualité de code React chargé d'auditer les standards de code d'un projet React.
+### 1. Linting (ESLint)
 
-### Étape 1 : Analyse du contexte
-- Identifier le répertoire du projet à auditer ($ARGUMENTS ou répertoire courant)
-- Lire les règles de qualité depuis :
-  - `/home/fmetivier/Documents/Company/TheBeardedCTO/Tools/Claude/Dev/React/rules/03-coding-standards.md`
-  - `/home/fmetivier/Documents/Company/TheBeardedCTO/Tools/Claude/Dev/React/rules/04-solid-principles.md`
-  - `/home/fmetivier/Documents/Company/TheBeardedCTO/Tools/Claude/Dev/React/rules/05-kiss-dry-yagni.md`
-  - `/home/fmetivier/Documents/Company/TheBeardedCTO/Tools/Claude/Dev/React/rules/08-quality-tools.md`
+```bash
+# Vérifier les erreurs
+npm run lint
 
-### Étape 2 : Vérification TypeScript et typage
+# Corriger automatiquement les erreurs
+npm run lint:fix
+```
 
-Examiner et vérifier :
+**Configuration** :
+```json
+// .eslintrc.json
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "rules": {
+    "no-console": "warn",
+    "no-debugger": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
+  }
+}
+```
 
-**Configuration TypeScript (6 points)**
-- [ ] tsconfig.json avec strict: true
-- [ ] noImplicitAny, strictNullChecks activés
-- [ ] Pas de @ts-ignore ou @ts-expect-error sans justification
-- [ ] Types exportés depuis des fichiers .types.ts ou .d.ts
+### 2. Vérification des Types (TypeScript)
 
-**Qualité du typage (7 points)**
-- [ ] Props des composants typées avec interfaces
-- [ ] Hooks personnalisés retournent des types explicites
-- [ ] Pas d'usage excessif de 'any' (<5% des types)
-- [ ] Types génériques utilisés correctement
-- [ ] Enums ou union types pour les constantes
-- [ ] Type guards pour les narrowing
-- [ ] Discriminated unions pour les variants
+```bash
+# Vérifier les types
+npm run type-check
 
-### Étape 3 : Vérification ESLint et formatting
+# Mode watch
+npm run type-check:watch
+```
 
-**Configuration ESLint (4 points)**
-- [ ] ESLint configuré avec règles React recommandées
-- [ ] Plugin @typescript-eslint actif
-- [ ] Règles react-hooks activées
-- [ ] Pas de violations non justifiées (eslint-disable)
-
-**Code style (4 points)**
-- [ ] Prettier configuré et appliqué
-- [ ] Conventions de nommage cohérentes
-- [ ] Imports organisés (absolus vs relatifs)
-- [ ] Pas de code mort ou commentaires inutiles
-
-### Étape 4 : Vérification des conventions de nommage
-
-**Nommage des composants (4 points)**
-- [ ] PascalCase pour les composants React
-- [ ] camelCase pour les fonctions utilitaires
-- [ ] UPPER_CASE pour les constantes
-- [ ] Noms descriptifs et auto-documentés
-- [ ] Préfixes cohérents (use pour hooks, is/has pour booléens)
-
-### Étape 5 : Analyse des principes SOLID et bonnes pratiques
-
-Pour un échantillon représentatif de composants :
-- Vérifier le principe de responsabilité unique (SRP)
-- Identifier les composants trop complexes (>300 lignes)
-- Vérifier la composition vs l'héritage
-- Analyser le couplage et la cohésion
-- Vérifier DRY (pas de duplication de code)
-- Vérifier KISS (simplicité des solutions)
-
-### Étape 6 : Calcul du score
+**Configuration TypeScript** :
 
 **Score sur 25 points :**
-- Configuration TypeScript : 6 points
-- Qualité du typage : 7 points
+- Configuration TypeScript : 6 points (tsconfig strict, noImplicitAny, strictNullChecks)
+- Qualité du typage : 7 points (interfaces, génériques, discriminated unions)
 - Configuration ESLint : 4 points
 - Code style : 4 points
 - Conventions de nommage : 4 points
 
-### Étape 7 : Rapport de conformité
+**Problèmes Courants** :
+```typescript
+// ❌ Mauvais - Type any
+const data: any = fetchData();
 
-Générer un rapport structuré :
+// ✅ Bon - Types appropriés
+interface User {
+  id: string;
+  name: string;
+}
+const data: User = fetchData();
+
+// ❌ Mauvais - any implicite
+const handleClick = (event) => {};
+
+// ✅ Bon - Types explicites
+const handleClick = (event: React.MouseEvent) => {};
+```
+
+### 3. Formatage du Code (Prettier)
+
+```bash
+# Vérifier le formatage
+npm run format:check
+
+# Formater tous les fichiers
+npm run format
+```
+
+**Configuration** :
+```json
+// .prettierrc
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2
+}
+```
+
+### 4. Analyse de Complexité
+
+```typescript
+// ❌ Mauvais - Complexité élevée (10+)
+function processUser(user, options) {
+  if (user.isActive) {
+    if (user.role === 'admin') {
+      if (options.includeStats) {
+        if (user.lastLogin) {
+          // ... logique imbriquée
+        }
+      }
+    }
+  }
+  // Complexité : 15
+}
+
+// ✅ Bon - Faible complexité
+function processUser(user, options) {
+  if (!user.isActive) return null;
+  if (user.role !== 'admin') return formatBasicUser(user);
+  if (!options.includeStats) return formatAdminUser(user);
+  return formatAdminUserWithStats(user);
+  // Complexité : 4
+}
+```
+
+### 5. Duplication de Code
+
+```typescript
+// ❌ Mauvais - Code dupliqué
+export const UserList = () => {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch('/api/users')
+      .then(res => res.json())
+      .then(setUsers)
+      .finally(() => setLoading(false));
+  }, []);
+};
+
+export const ProductList = () => {
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch('/api/products')
+      .then(res => res.json())
+      .then(setProducts)
+      .finally(() => setLoading(false));
+  }, []);
+};
+
+// ✅ Bon - Hook réutilisable
+export const useFetch = <T>(url: string) => {
+  const [data, setData] = useState<T[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(url)
+      .then(res => res.json())
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, [url]);
+
+  return { data, loading };
+};
+```
+
+## Métriques de Qualité du Code
+
+### Complexité Cyclomatique
+
+**Objectif** : < 10 par fonction
+
+```bash
+# Installer le vérificateur de complexité
+npm install -D eslint-plugin-complexity
+
+# Ajouter à la config ESLint
+{
+  "rules": {
+    "complexity": ["error", 10]
+  }
+}
+```
+
+### Couverture de Tests
+
+**Objectifs** :
+- Lignes : > 80%
+- Fonctions : > 80%
+- Branches : > 75%
+- Instructions : > 80%
+
+```bash
+# Générer le rapport de couverture
+npm run test:coverage
+```
+
+```json
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      lines: 80,
+      functions: 80,
+      branches: 75,
+      statements: 80
+    }
+  }
+});
+```
+
+### Duplication de Code
+
+**Objectif** : < 3% de duplication
+
+```bash
+# Installer jscpd
+npm install -D jscpd
+
+# Lancer la vérification de duplication
+npx jscpd src/
+```
+
+## Portes de Qualité
+
+### Vérifications Pré-Commit
+
+```json
+// package.json
+{
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write",
+      "vitest related --run --passWithNoTests"
+    ]
+  }
+}
+```
+
+### Portes de Qualité CI/CD
+
+```yaml
+# .github/workflows/quality.yml
+name: Quality Check
+
+on: [pull_request]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Format check
+        run: npm run format:check
+
+      - name: Test with coverage
+        run: npm run test:coverage
+
+      - name: Check coverage
+        uses: codecov/codecov-action@v3
+```
+
+## Odeurs de Code
+
+### 1. Longues Listes de Paramètres
+
+```typescript
+// ❌ Mauvais - Trop de paramètres
+function createUser(
+  name: string,
+  email: string,
+  age: number,
+  address: string,
+  phone: string,
+  role: string
+) {}
+
+// ✅ Bon - Utiliser un paramètre objet
+interface CreateUserParams {
+  name: string;
+  email: string;
+  age: number;
+  address: string;
+  phone: string;
+  role: string;
+}
+
+function createUser(params: CreateUserParams) {}
+```
+
+### 2. Grandes Fonctions
+
+```typescript
+// ❌ Mauvais - Fonction trop longue (100+ lignes)
+function handleSubmit() {
+  // ... 100 lignes de code
+}
+
+// ✅ Bon - Décomposer en fonctions plus petites
+function handleSubmit() {
+  validateForm();
+  processData();
+  submitToAPI();
+}
+```
+
+### 3. Nombres Magiques
+
+```typescript
+// ❌ Mauvais - Nombres magiques
+if (user.age > 18 && cart.total > 100) {}
+
+// ✅ Bon - Constantes nommées
+const ADULT_AGE = 18;
+const FREE_SHIPPING_THRESHOLD = 100;
+
+if (user.age > ADULT_AGE && cart.total > FREE_SHIPPING_THRESHOLD) {}
+```
+
+### 4. Imbrication Profonde
+
+```typescript
+// ❌ Mauvais - Imbrication profonde
+if (user) {
+  if (user.isActive) {
+    if (user.role === 'admin') {
+      if (hasPermission) {
+        // ...
+      }
+    }
+  }
+}
+
+// ✅ Bon - Guard clauses
+if (!user) return;
+if (!user.isActive) return;
+if (user.role !== 'admin') return;
+if (!hasPermission) return;
+// ...
+```
+
+## Intégration SonarQube
+
+```bash
+# Installer SonarScanner
+npm install -D sonarqube-scanner
+
+# Lancer l'analyse
+npx sonar-scanner \
+  -Dsonar.projectKey=my-project \
+  -Dsonar.sources=src \
+  -Dsonar.host.url=http://localhost:9000 \
+  -Dsonar.login=your-token
+```
+
+## Rapport de Conformité
 
 ```
 ═══════════════════════════════════════════════════
@@ -165,12 +492,75 @@ Exemples de violations :
 • rules/08-quality-tools.md - Outils de qualité
 ```
 
-### Étape 8 : Métriques de qualité
+## Amélioration Continue
+
+### Suivi des Métriques dans le Temps
+
+```json
+// .qualityrc
+{
+  "metrics": {
+    "complexity": {
+      "current": 8,
+      "target": 10,
+      "trend": "improving"
+    },
+    "coverage": {
+      "current": 85,
+      "target": 80,
+      "trend": "stable"
+    },
+    "duplication": {
+      "current": 2,
+      "target": 3,
+      "trend": "improving"
+    }
+  }
+}
+```
+
+### Tableau de Bord Qualité
+
+Créer un tableau de bord pour visualiser :
+- Tendances de la couverture de code
+- Tendances de la complexité
+- Nombre de problèmes par sévérité
+- Estimation de la dette technique
+
+## Métriques de Qualité Calculées
 
 Calculer et afficher :
 - Pourcentage de fichiers avec strict mode TypeScript
-- Nombre de any détectés vs types explicites
+- Nombre de `any` détectés vs types explicites
 - Taux de conformité ESLint
 - Nombre de fichiers non formatés par Prettier
 - Complexité cyclomatique moyenne
 - Dette technique estimée (en heures de refactoring)
+
+## Outils
+
+- **ESLint** : Linting du code
+- **TypeScript** : Vérification des types
+- **Prettier** : Formatage du code
+- **Vitest** : Couverture de tests
+- **SonarQube** : Plateforme de qualité du code
+- **jscpd** : Détection de duplication
+- **Lighthouse** : Audit de performance
+
+## Bonnes Pratiques
+
+1. **Lancer les vérifications localement** avant de pousser
+2. **Automatiser en CI/CD** pour appliquer les standards
+3. **Définir des portes de qualité** qui doivent passer
+4. **Surveiller les tendances** dans le temps
+5. **Refactoriser régulièrement** pour réduire la dette technique
+6. **Documenter les standards** pour l'équipe
+7. **Revoir les métriques** en réunion d'équipe
+8. **Célébrer les améliorations**
+
+## Ressources
+
+- [ESLint Rules](https://eslint.org/docs/rules/)
+- [TypeScript Handbook](https://www.typescriptlang.org/docs/handbook/intro.html)
+- [Clean Code Principles](https://github.com/ryanmcdermott/clean-code-javascript)
+- [Refactoring Guru](https://refactoring.guru/)

--- a/Dev/i18n/fr/React/commands/check-testing.md
+++ b/Dev/i18n/fr/React/commands/check-testing.md
@@ -1,115 +1,439 @@
 ---
-description: Vérification des Tests React
-argument-hint: [arguments]
+description: Vérification de la Stratégie de Tests
 ---
 
-# Vérification des Tests React
+# Vérification de la Stratégie de Tests
 
-## Arguments
+Vérifie que l'application React dispose d'une couverture de tests complète et suit les meilleures pratiques de test.
 
-$ARGUMENTS
+## Ce que fait cette commande
+
+1. **Analyse des Tests**
+   - Vérifier la couverture de tests
+   - Valider la qualité des tests
+   - Contrôler les patterns de test
+   - Vérifier l'organisation des tests
+   - Analyser les performances des tests
+
+2. **Métriques Mesurées**
+   - Couverture du code (lignes, fonctions, branches)
+   - Nombre de tests par type (unitaire, intégration, e2e)
+   - Temps d'exécution des tests
+   - Détection des tests instables (flaky)
+   - Chemins critiques non testés
+
+3. **Rapport Généré**
+   - Rapport de couverture
+   - Tests manquants
+   - Score de qualité des tests
+   - Recommandations
+
+## Comment Utiliser
+
+```bash
+# Lancer tous les tests avec couverture
+npm run test:coverage
+
+# Mode watch
+npm run test:watch
+
+# Mode UI
+npm run test:ui
+
+# Tests E2E
+npm run test:e2e
+```
 
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.
 
-## MISSION
+## Analyse de la Couverture de Tests
 
-Tu es un expert en testing React chargé d'auditer la stratégie de tests d'un projet React.
+### Objectifs de Couverture
 
-### Étape 1 : Analyse du contexte
-- Identifier le répertoire du projet à auditer ($ARGUMENTS ou répertoire courant)
-- Lire les règles de testing depuis :
-  - `/home/fmetivier/Documents/Company/TheBeardedCTO/Tools/Claude/Dev/React/rules/07-testing.md`
-  - `/home/fmetivier/Documents/Company/TheBeardedCTO/Tools/Claude/Dev/React/rules/06-tooling.md`
-
-### Étape 2 : Vérification de la configuration des tests
-
-Examiner et vérifier :
-
-**Infrastructure de test (5 points)**
-- [ ] Vitest ou Jest configuré
-- [ ] React Testing Library installé et configuré
-- [ ] Configuration de coverage (vitest.config.ts ou jest.config.js)
-- [ ] Scripts npm pour test, test:watch, test:coverage
-- [ ] Environment jsdom ou happy-dom configuré
-
-**Configuration du coverage (4 points)**
-- [ ] Seuils de coverage définis (statements, branches, functions, lines)
-- [ ] Objectif minimum 80% global
-- [ ] Exclusions justifiées (.config, .test, .spec)
-- [ ] Rapports de coverage générés (lcov, html)
-
-### Étape 3 : Analyse de la couverture de tests
-
-**Coverage global (7 points)**
-- [ ] Coverage statements ≥ 80%
-- [ ] Coverage branches ≥ 75%
-- [ ] Coverage functions ≥ 80%
-- [ ] Coverage lines ≥ 80%
-- [ ] Fichiers critiques couverts à >90%
-- [ ] Pas de fichiers importants non testés
-- [ ] Tendance d'amélioration du coverage
-
-**Qualité des tests unitaires (5 points)**
-- [ ] Tests co-localisés avec le code (__tests__ ou .test.tsx)
-- [ ] Un fichier de test par composant/hook/utilitaire
-- [ ] Conventions de nommage : *.test.tsx, *.spec.tsx
-- [ ] Tests isolés et indépendants
-- [ ] Pas de tests flaky ou skip sans raison
-
-### Étape 4 : Vérification des bonnes pratiques de test
-
-**React Testing Library (4 points)**
-- [ ] Tests basés sur le comportement utilisateur (not implementation)
-- [ ] Queries prioritaires : getByRole, getByLabelText, getByText
-- [ ] Pas d'usage excessif de getByTestId
-- [ ] userEvent utilisé pour les interactions
-- [ ] Assertions sur les éléments accessibles
-- [ ] waitFor pour les opérations asynchrones
-
-### Étape 5 : Analyse des types de tests
-
-Pour un échantillon représentatif :
-- Identifier tests unitaires vs tests d'intégration
-- Vérifier présence de tests pour :
-  - Composants UI (rendu, props, events)
-  - Hooks personnalisés
-  - Fonctions utilitaires
-  - Services/API calls (mocks)
-  - Formulaires et validation
-  - Gestion d'erreurs
-- Évaluer la qualité des assertions
-- Vérifier les mocks et stubs (MSW recommandé)
-
-### Étape 6 : Calcul du score
-
-**Score sur 25 points :**
-- Infrastructure de test : 5 points
-- Configuration du coverage : 4 points
-- Coverage global : 7 points
-- Qualité des tests unitaires : 5 points
-- React Testing Library : 4 points
-
-### Étape 7 : Exécution des tests et analyse
-
-Exécuter les commandes :
-```bash
-# Lancer les tests avec coverage
-npm run test:coverage || yarn test:coverage
-
-# Analyser les résultats
+```json
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      lines: 80,
+      functions: 80,
+      branches: 75,
+      statements: 80,
+      exclude: [
+        'node_modules/',
+        'src/test/',
+        '**/*.test.{ts,tsx}',
+        '**/*.spec.{ts,tsx}',
+        '**/*.d.ts',
+        'vite.config.ts'
+      ]
+    }
+  }
+});
 ```
 
-Extraire les métriques :
-- Coverage actuel par catégorie
-- Nombre de tests total
-- Temps d'exécution des tests
-- Tests en échec ou skipped
+### Vérifier la Couverture
 
-### Étape 8 : Rapport de conformité
+```bash
+# Générer le rapport de couverture
+npm run test:coverage
 
-Générer un rapport structuré :
+# Visualiser le rapport HTML
+open coverage/index.html
+
+# Vérifier un seuil spécifique
+npm run test:coverage -- --coverage.lines=90
+```
+
+## Types de Tests
+
+### 1. Tests Unitaires (70% des tests)
+
+```typescript
+// Button.test.tsx
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('should render with text', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByRole('button')).toHaveTextContent('Click me');
+  });
+
+  it('should call onClick when clicked', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Button onClick={handleClick}>Click me</Button>);
+    await user.click(screen.getByRole('button'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('should be disabled when disabled prop is true', () => {
+    render(<Button disabled>Click me</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});
+```
+
+### 2. Tests d'Intégration (20% des tests)
+
+```typescript
+// UserManagement.integration.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { UserManagement } from './UserManagement';
+
+describe('UserManagement Integration', () => {
+  it('should complete full user creation flow', async () => {
+    const user = userEvent.setup();
+    render(<UserManagement />);
+
+    // Attendre le chargement
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    // Cliquer sur le bouton d'ajout
+    await user.click(screen.getByRole('button', { name: /add user/i }));
+
+    // Remplir le formulaire
+    await user.type(screen.getByLabelText(/name/i), 'New User');
+    await user.type(screen.getByLabelText(/email/i), 'new@example.com');
+
+    // Soumettre
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    // Vérifier
+    await waitFor(() => {
+      expect(screen.getByText('New User')).toBeInTheDocument();
+    });
+  });
+});
+```
+
+### 3. Tests E2E (10% des tests)
+
+```typescript
+// auth.spec.ts (Playwright)
+import { test, expect } from '@playwright/test';
+
+test.describe('Authentication', () => {
+  test('should login successfully', async ({ page }) => {
+    await page.goto('/');
+    await page.click('text=Login');
+
+    await page.fill('input[name="email"]', 'user@example.com');
+    await page.fill('input[name="password"]', 'password123');
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL('/dashboard');
+    await expect(page.locator('text=Welcome')).toBeVisible();
+  });
+});
+```
+
+## Vérifications de Qualité des Tests
+
+### 1. Pattern AAA
+
+```typescript
+// ✅ BON - Arrange, Act, Assert
+it('should increment counter', async () => {
+  // Arrange
+  const user = userEvent.setup();
+  render(<Counter initialCount={0} />);
+
+  // Act
+  await user.click(screen.getByRole('button', { name: /increment/i }));
+
+  // Assert
+  expect(screen.getByText('Count: 1')).toBeInTheDocument();
+});
+```
+
+### 2. Tester le Comportement, pas l'Implémentation
+
+```typescript
+// ❌ MAUVAIS - Tester l'implémentation
+it('should call setState', () => {
+  const setStateSpy = vi.spyOn(React, 'useState');
+  // ...
+});
+
+// ✅ BON - Tester le comportement
+it('should display incremented count', async () => {
+  const user = userEvent.setup();
+  render(<Counter />);
+
+  await user.click(screen.getByRole('button', { name: /increment/i }));
+
+  expect(screen.getByText('Count: 1')).toBeInTheDocument();
+});
+```
+
+### 3. Noms de Tests Descriptifs
+
+```typescript
+// ❌ MAUVAIS - Noms vagues
+it('works');
+it('test 1');
+it('should render');
+
+// ✅ BON - Noms descriptifs
+it('should display user name when user data is loaded');
+it('should show error message when email is invalid');
+it('should disable submit button while form is submitting');
+```
+
+### 4. Priorité des Requêtes
+
+```typescript
+// ✅ BON - Requêtes accessibles (meilleures)
+screen.getByRole('button', { name: /submit/i });
+screen.getByLabelText(/email/i);
+screen.getByText(/welcome/i);
+
+// ⚠️ ACCEPTABLE - Requêtes sémantiques
+screen.getByAltText(/profile/i);
+screen.getByTitle(/close/i);
+
+// ❌ ÉVITER - Test IDs (en dernier recours)
+screen.getByTestId('custom-element');
+```
+
+## Organisation des Tests
+
+### Structure des Dossiers
+
+```
+src/
+├── components/
+│   └── Button/
+│       ├── Button.tsx
+│       ├── Button.test.tsx       # Tests unitaires
+│       └── Button.stories.tsx    # Storybook
+│
+├── features/
+│   └── users/
+│       ├── components/
+│       │   └── UserList/
+│       │       ├── UserList.tsx
+│       │       └── UserList.test.tsx
+│       ├── hooks/
+│       │   └── useUsers.test.ts
+│       └── UserManagement.integration.test.tsx  # Intégration
+│
+├── test/
+│   ├── setup.ts                  # Configuration des tests
+│   ├── mocks/
+│   │   └── handlers.ts           # Handlers MSW
+│   └── utils/
+│       └── test-utils.tsx        # Utilitaires de test
+│
+└── e2e/                          # Tests E2E
+    ├── auth.spec.ts
+    └── users.spec.ts
+```
+
+### Utilitaires de Test
+
+```typescript
+// test/utils/test-utils.tsx
+import { render, RenderOptions } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+
+const AllProviders = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>{children}</BrowserRouter>
+    </QueryClientProvider>
+  );
+};
+
+export const renderWithProviders = (
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) => render(ui, { wrapper: AllProviders, ...options });
+
+export * from '@testing-library/react';
+```
+
+## Problèmes de Test Courants
+
+### Problème 1 : Tests Instables (Flaky)
+
+```typescript
+// ❌ MAUVAIS - Condition de course
+it('should load data', () => {
+  render(<DataComponent />);
+  expect(screen.getByText('Data loaded')).toBeInTheDocument();
+  // Échoue de façon aléatoire si les données chargent lentement
+});
+
+// ✅ BON - Attendre les données
+it('should load data', async () => {
+  render(<DataComponent />);
+  await waitFor(() => {
+    expect(screen.getByText('Data loaded')).toBeInTheDocument();
+  });
+});
+```
+
+### Problème 2 : Avertissements Act Manquants
+
+```typescript
+// ❌ MAUVAIS - Mise à jour d'état en dehors de act
+it('should update count', () => {
+  const { result } = renderHook(() => useCounter());
+  result.current.increment(); // Avertissement !
+});
+
+// ✅ BON - Envelopper dans act
+it('should update count', () => {
+  const { result } = renderHook(() => useCounter());
+  act(() => {
+    result.current.increment();
+  });
+});
+```
+
+### Problème 3 : Nettoyage Non Effectué
+
+```typescript
+// ✅ BON - Nettoyage automatique
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});
+```
+
+## MSW (Mock Service Worker)
+
+### Configuration
+
+```typescript
+// test/mocks/handlers.ts
+import { http, HttpResponse } from 'msw';
+
+export const handlers = [
+  http.get('/api/users', () => {
+    return HttpResponse.json([
+      { id: '1', name: 'John Doe' },
+      { id: '2', name: 'Jane Smith' }
+    ]);
+  }),
+
+  http.post('/api/users', async ({ request }) => {
+    const newUser = await request.json();
+    return HttpResponse.json({ id: '3', ...newUser }, { status: 201 });
+  })
+];
+
+// test/mocks/server.ts
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);
+```
+
+### Utilisation
+
+```typescript
+// test/setup.ts
+import { beforeAll, afterEach, afterAll } from 'vitest';
+import { server } from './mocks/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+## Tests de Performance
+
+```typescript
+// Vérifier les performances de rendu
+it('should render list efficiently', () => {
+  const start = performance.now();
+
+  render(<LargeList items={items} />);
+
+  const duration = performance.now() - start;
+  expect(duration).toBeLessThan(100); // ms
+});
+```
+
+## Rapports de Tests
+
+### Rapport de Couverture
+
+```bash
+# Générer le rapport HTML
+npm run test:coverage
+
+# Visualiser le rapport
+open coverage/index.html
+
+# CI : Upload vers Codecov
+bash <(curl -s https://codecov.io/bash)
+```
+
+### Rapport de Conformité
 
 ```
 ═══════════════════════════════════════════════════
@@ -212,10 +536,60 @@ Anti-patterns détectés :
 • https://testing-library.com/docs/queries/about/#priority
 ```
 
-### Étape 9 : Recommandations détaillées
+### Résultats de Tests en CI
 
-Pour chaque gap de coverage identifié :
-- Lister les fichiers/fonctions non testés
-- Proposer des cas de test à ajouter
-- Fournir des exemples de tests manquants
-- Estimer l'effort de mise en conformité
+```yaml
+# .github/workflows/test.yml
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm run test:coverage
+
+      - name: Upload coverage
+        uses: codecov/codecov-action@v3
+```
+
+## Checklist de Tests
+
+- [ ] Tests unitaires pour tous les composants
+- [ ] Tests unitaires pour tous les hooks
+- [ ] Tests unitaires pour tous les utilitaires
+- [ ] Tests d'intégration pour les features
+- [ ] Tests E2E pour les parcours critiques
+- [ ] Couverture > 80%
+- [ ] Pas de tests instables (flaky)
+- [ ] Tests rapides (< 1s chacun)
+- [ ] MSW pour le mocking des API
+- [ ] Utilitaires de test extraits
+- [ ] Tests suivent le pattern AAA
+- [ ] Tests ont des noms descriptifs
+- [ ] Tests utilisent les requêtes accessibles
+
+## Outils
+
+- **Vitest** : Exécuteur de tests unitaires
+- **React Testing Library** : Test de composants
+- **Playwright** : Tests E2E
+- **MSW** : Mocking des API
+- **Testing Library User Event** : Interactions utilisateur
+- **Codecov** : Rapport de couverture
+
+## Ressources
+
+- [React Testing Library](https://testing-library.com/react)
+- [Vitest Documentation](https://vitest.dev/)
+- [Playwright Documentation](https://playwright.dev/)
+- [MSW Documentation](https://mswjs.io/)
+- [Testing Best Practices](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)

--- a/Dev/i18n/fr/Symfony/commands/check-compliance.md
+++ b/Dev/i18n/fr/Symfony/commands/check-compliance.md
@@ -1,13 +1,13 @@
 ---
-description: Audit Complet de Conformité Symfony
+description: Vérification Complète de la Conformité Symfony
 argument-hint: [arguments]
 ---
 
-# Audit Complet de Conformité Symfony
+# Vérification Complète de la Conformité Symfony
 
 ## Arguments
 
-$ARGUMENTS : Chemin du projet Symfony à auditer (optionnel, par défaut : répertoire courant)
+$ARGUMENTS (optionnel : chemin du projet à analyser)
 
 ## Mode Plan
 
@@ -15,167 +15,239 @@ $ARGUMENTS : Chemin du projet Symfony à auditer (optionnel, par défaut : répe
 
 ## MISSION
 
-Tu es un auditeur expert Symfony chargé de réaliser un audit complet de conformité d'un projet Symfony.
+Réaliser un audit complet de conformité du projet Symfony en orchestrant les 4 grandes vérifications : Architecture, Qualité du Code, Tests et Sécurité. Produire un rapport consolidé avec un score global sur 100 points.
 
-### Étape 1 : Vérification du projet
+### Étape 1 : Préparation de l'audit
 
-1. Identifie le répertoire du projet à auditer
-2. Vérifie qu'il s'agit bien d'un projet Symfony (présence de composer.json avec symfony/*)
-3. Vérifie la version de Symfony utilisée
+Préparer l'environnement d'audit :
+- [ ] Identifier le chemin du projet à auditer
+- [ ] Vérifier la présence des fichiers de configuration (composer.json avec symfony/*, .env)
+- [ ] Lister les répertoires principaux (src/, tests/, config/, etc.)
+- [ ] Identifier la structure du projet et la version Symfony
+
+**Note** : Si $ARGUMENTS est fourni, l'utiliser comme chemin du projet, sinon utiliser le répertoire courant.
 
 ### Étape 2 : Audit Architecture (25 points)
 
-Exécute l'audit d'architecture en vérifiant :
+Exécuter la vérification complète de l'architecture :
 
-**Référence aux règles** : `.claude/rules/symfony-architecture.md`
+**Commande** : Utiliser la commande slash `/symfony:check-architecture` ou suivre manuellement les étapes dans `check-architecture.md`
 
-- [ ] Structure des dossiers respecte Clean Architecture
-- [ ] Séparation Domain / Application / Infrastructure
-- [ ] Respect des principes DDD (Entities, Value Objects, Aggregates)
-- [ ] Architecture Hexagonale (Ports & Adapters)
-- [ ] Utilisation de Deptrac pour vérifier les dépendances
-- [ ] Absence de couplage entre les couches
-- [ ] Interfaces correctement définies pour les ports
-- [ ] Use Cases / Application Services bien définis
-- [ ] Repositories avec interfaces dans le domain
-- [ ] DTOs pour les transferts de données
+**Critères évalués** :
+- Structure Clean Architecture (6 pts)
+- Séparation Domain/Application/Infrastructure (6 pts)
+- Architecture Hexagonale / Ports & Adapters (4 pts)
+- Modélisation DDD (Entités, Value Objects, Agrégats) (4 pts)
+- Use Cases et Application Services (3 pts)
+- Règles de dépendances et Deptrac (2 pts)
 
-**Score Architecture** : ___/25 points
+**Référence** : `check-architecture.md`
 
 ### Étape 3 : Audit Qualité du Code (25 points)
 
-Exécute l'audit de qualité du code en vérifiant :
+Exécuter la vérification de la qualité du code :
 
-**Référence aux règles** : `.claude/rules/symfony-code-quality.md`
+**Commande** : Utiliser la commande slash `/symfony:check-code-quality` ou suivre manuellement les étapes dans `check-code-quality.md`
 
-- [ ] Respect de PSR-12
-- [ ] PHPStan niveau 9 sans erreur
-- [ ] Type hints strict sur tous les paramètres et retours
-- [ ] Déclaration `declare(strict_types=1)` dans tous les fichiers
-- [ ] Pas de code mort (détecté par PHPStan)
-- [ ] Pas de dépendances inutilisées
-- [ ] Complexité cyclomatique < 10 par méthode
-- [ ] Longueur des méthodes < 20 lignes
-- [ ] Classes single responsibility
-- [ ] Documentation PHPDoc complète et à jour
+**Critères évalués** :
+- Conformité PSR-12 (5 pts)
+- PHPStan niveau 9 (5 pts)
+- Type hints stricts et declare(strict_types=1) (4 pts)
+- Principes KISS/DRY/YAGNI (4 pts)
+- Documentation et PHPDoc (4 pts)
+- Gestion des erreurs (3 pts)
 
-**Score Qualité du Code** : ___/25 points
+**Référence** : `check-code-quality.md`
 
-### Étape 4 : Audit Testing (25 points)
+### Étape 4 : Audit Tests (25 points)
 
-Exécute l'audit des tests en vérifiant :
+Exécuter la vérification des tests :
 
-**Référence aux règles** : `.claude/rules/symfony-testing.md`
+**Commande** : Utiliser la commande slash `/symfony:check-testing` ou suivre manuellement les étapes dans `check-testing.md`
 
-- [ ] Couverture de code ≥ 80%
-- [ ] Tests unitaires pour le Domain
-- [ ] Tests d'intégration pour l'Infrastructure
-- [ ] Tests fonctionnels avec Behat ou Symfony WebTestCase
-- [ ] Tests de mutation avec Infection (MSI ≥ 70%)
-- [ ] Fixtures pour les tests
-- [ ] Tests isolés (pas de dépendances entre tests)
-- [ ] Base de données de test séparée
-- [ ] Mocks et Stubs appropriés
-- [ ] CI/CD avec exécution automatique des tests
+**Critères évalués** :
+- Couverture du code (7 pts)
+- Tests unitaires pour le Domain (6 pts)
+- Tests d'intégration pour l'Infrastructure (4 pts)
+- Tests fonctionnels (WebTestCase/Behat) (3 pts)
+- Tests de mutation avec Infection (3 pts)
+- Isolation des tests et fixtures (2 pts)
 
-**Score Testing** : ___/25 points
+**Référence** : `check-testing.md`
 
 ### Étape 5 : Audit Sécurité (25 points)
 
-Exécute l'audit de sécurité en vérifiant :
+Exécuter la vérification de sécurité :
 
-**Référence aux règles** : `.claude/rules/symfony-security.md`
+**Commande** : Utiliser la commande slash `/symfony:check-security` ou suivre manuellement les étapes dans `check-security.md`
 
-- [ ] Symfony Security Bundle correctement configuré
-- [ ] OWASP Top 10 : Protection contre injection SQL
-- [ ] OWASP Top 10 : Protection XSS
-- [ ] OWASP Top 10 : Protection CSRF
-- [ ] OWASP Top 10 : Authentification sécurisée
-- [ ] OWASP Top 10 : Contrôle d'accès (Voters, ACL)
-- [ ] RGPD : Consentement utilisateur
-- [ ] RGPD : Droit à l'oubli implémenté
-- [ ] RGPD : Export des données personnelles
-- [ ] Secrets externalisés (pas dans le code)
+**Critères évalués** :
+- Configuration du Symfony Security Bundle (6 pts)
+- Protections OWASP Top 10 (5 pts)
+- Gestion des secrets et des identifiants (4 pts)
+- Validation des entrées et CSRF (4 pts)
+- Authentification et Autorisation (Voters) (3 pts)
+- Vulnérabilités des dépendances (2 pts)
+- Conformité RGPD (1 pt)
 
-**Score Sécurité** : ___/25 points
+**Référence** : `check-security.md`
 
-### Étape 6 : Calcul du Score Global
+### Étape 6 : Consolidation et Score Global
 
-**SCORE GLOBAL** : ___/100 points
+Calculer le score global et produire le rapport consolidé :
+- [ ] Additionner les 4 scores (max 100 points)
+- [ ] Identifier les catégories critiques (<50%)
+- [ ] Lister tous les problèmes transversaux critiques
+- [ ] Prioriser les actions par impact/effort
+- [ ] Produire le rapport final consolidé
 
-Interprétation :
-- ✅ 90-100 : Excellent - Conformité exemplaire
-- ✅ 75-89 : Bon - Quelques améliorations mineures
-- ⚠️ 60-74 : Moyen - Améliorations nécessaires
-- ⚠️ 40-59 : Insuffisant - Refactoring important requis
-- ❌ 0-39 : Critique - Refonte complète nécessaire
+**Échelle de notation** :
+- 90-100 : Excellent - Projet de référence
+- 75-89 : Très bien - Quelques améliorations mineures
+- 60-74 : Acceptable - Des améliorations sont nécessaires
+- 40-59 : Insuffisant - Refactoring majeur requis
+- 0-39 : Critique - Refonte complète nécessaire
 
-### Étape 7 : Rapport Détaillé
+### Étape 7 : Recommandations et Plan d'Action
 
-Génère un rapport structuré avec :
+Produire les recommandations finales :
+- [ ] Identifier les 3 actions prioritaires dans toutes les catégories
+- [ ] Estimer l'effort (Faible/Moyen/Élevé) pour chaque action
+- [ ] Estimer l'impact (Faible/Moyen/Élevé) pour chaque action
+- [ ] Proposer un ordre d'implémentation
+- [ ] Suggérer des gains rapides (ratio impact/effort élevé)
+
+## FORMAT DE SORTIE
 
 ```
-=================================================
-   AUDIT DE CONFORMITÉ SYMFONY
-=================================================
+AUDIT DE CONFORMITÉ SYMFONY - RAPPORT COMPLET
+=============================================
 
-📊 SCORE GLOBAL : ___/100
+SCORE GLOBAL : XX/100
 
-📐 Architecture        : ___/25 [✅|⚠️|❌]
-🎯 Qualité du Code    : ___/25 [✅|⚠️|❌]
-🧪 Testing            : ___/25 [✅|⚠️|❌]
-🔒 Sécurité           : ___/25 [✅|⚠️|❌]
+NIVEAU DE CONFORMITÉ : [Excellent/Très bien/Acceptable/Insuffisant/Critique]
 
-=================================================
-   DÉTAILS PAR CATÉGORIE
-=================================================
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-[Insérer les détails de chaque audit]
+SCORES PAR CATÉGORIE :
 
-=================================================
-   TOP 3 ACTIONS PRIORITAIRES
-=================================================
+ARCHITECTURE       : XX/25  [██████████░░░░░░░░░░] XX%
+QUALITÉ DU CODE    : XX/25  [██████████░░░░░░░░░░] XX%
+TESTS              : XX/25  [██████████░░░░░░░░░░] XX%
+SÉCURITÉ           : XX/25  [██████████░░░░░░░░░░] XX%
 
-1. [Action prioritaire #1 avec impact estimé]
-2. [Action prioritaire #2 avec impact estimé]
-3. [Action prioritaire #3 avec impact estimé]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-=================================================
-   RECOMMANDATIONS TECHNIQUES
-=================================================
+POINTS FORTS GLOBAUX :
+1. [Point fort identifié dans plusieurs catégories]
+2. [Autre point fort majeur]
+3. [Troisième point fort]
 
-- [Recommandation technique spécifique]
-- [Recommandation technique spécifique]
-- [Recommandation technique spécifique]
+AMÉLIORATIONS GLOBALES :
+1. [Amélioration transversale mineure]
+2. [Autre amélioration recommandée]
+3. [Troisième amélioration]
 
-=================================================
+PROBLÈMES CRITIQUES :
+1. [Problème critique #1 - catégorie concernée]
+2. [Problème critique #2 - catégorie concernée]
+3. [Problème critique #3 - catégorie concernée]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DÉTAILS PAR CATÉGORIE :
+
+┌─────────────────────────────────────────────┐
+│ ARCHITECTURE (XX/25)                        │
+└─────────────────────────────────────────────┘
+
+Sous-scores :
+  • Structure Clean Architecture      : XX/6
+  • Séparation des couches            : XX/6
+  • Hexagonal / Ports & Adapters      : XX/4
+  • Modélisation DDD                  : XX/4
+  • Use Cases                         : XX/3
+  • Règles de dépendances             : XX/2
+
+Points forts :
+- [Points forts d'architecture]
+
+Problèmes :
+- [Problèmes d'architecture]
+
+[Sections similaires pour Qualité du Code, Tests et Sécurité...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 DES ACTIONS PRIORITAIRES (TOUTES CATÉGORIES) :
+
+1. CRITIQUE - [Action #1]
+   Catégorie  : [Architecture/Qualité/Tests/Sécurité]
+   Impact     : [Élevé/Moyen/Faible]
+   Effort     : [Élevé/Moyen/Faible]
+   Priorité   : IMMÉDIATE
+
+   Description détaillée :
+   [Explication du problème et solution proposée]
+
+   Fichiers concernés :
+   - [fichier:ligne]
+
+   Exemple de correction :
+   [Code ou commande de correction]
+
+2. IMPORTANT - [Action #2]
+   [Même format...]
+
+3. RECOMMANDÉ - [Action #3]
+   [Même format...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GAINS RAPIDES (Impact Élevé / Effort Faible) :
+
+- [Gain rapide #1] - Catégorie : [X] - Impact : [X] - Effort : [X]
+- [Gain rapide #2] - Catégorie : [X] - Impact : [X] - Effort : [X]
+- [Gain rapide #3] - Catégorie : [X] - Impact : [X] - Effort : [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLAN D'ACTION RECOMMANDÉ :
+
+SEMAINE 1 (Immédiat) :
+- [ ] [Action critique #1]
+- [ ] [Gain rapide prioritaire]
+
+SEMAINES 2-4 (Court terme) :
+- [ ] [Action importante #2]
+- [ ] [Autres gains rapides]
+
+MOIS 2-3 (Moyen terme) :
+- [ ] [Action recommandée #3]
+- [ ] [Améliorations progressives]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RÉSUMÉ EXÉCUTIF :
+
+[Paragraphe de synthèse sur l'état global du projet, les principaux
+points forts, les principales faiblesses et la trajectoire recommandée
+pour améliorer la conformité. Mentionner si le projet est prêt pour
+la production, nécessite des corrections ou un refactoring.]
+
+Recommandation générale : [Prêt pour la production / Corrections mineures /
+Refactoring majeur / Refonte nécessaire]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### Étape 8 : Commandes Docker pour Vérifications
+## NOTES IMPORTANTES
 
-Pour chaque vérification, utilise Docker pour s'abstraire de l'environnement local :
-
-```bash
-# PHPStan
-docker run --rm -v $(pwd):/app phpstan/phpstan analyse src --level=9
-
-# PHP_CodeSniffer (PSR-12)
-docker run --rm -v $(pwd):/project php:8.2-cli vendor/bin/phpcs --standard=PSR12 src/
-
-# PHPUnit avec couverture
-docker run --rm -v $(pwd):/app php:8.2-cli vendor/bin/phpunit --coverage-text --coverage-html=coverage
-
-# Infection (mutation testing)
-docker run --rm -v $(pwd):/app infection/infection --min-msi=70
-
-# Deptrac
-docker run --rm -v $(pwd):/app qossmic/deptrac analyse
-```
-
-## IMPORTANT
-
-- Utilise TOUJOURS Docker pour les commandes afin de s'abstraire de l'environnement local
-- Ne stocke JAMAIS de fichiers dans /tmp
-- Fournis des exemples concrets de problèmes détectés
-- Priorise les actions selon l'impact et l'effort
-- Sois factuel et objectif dans l'évaluation
+- Cette commande orchestre les 4 audits spécialisés
+- Utiliser Docker pour tous les outils d'analyse
+- Fournir des exemples concrets avec fichier:ligne pour chaque problème
+- Prioriser les actions selon la matrice Impact/Effort
+- Les problèmes de sécurité sont TOUJOURS prioritaires
+- Proposer des corrections automatisables (scripts, hooks pre-commit)
+- Le rapport doit être actionnable, pas seulement descriptif
+- Adapter les recommandations au contexte métier du projet

--- a/Dev/i18n/fr/VueJS/commands/check-compliance.md
+++ b/Dev/i18n/fr/VueJS/commands/check-compliance.md
@@ -1,128 +1,253 @@
 ---
-description: Audit Vue.js project compliance with coding standards and best practices
+description: Vérification Complète de la Conformité Vue.js
+argument-hint: [arguments]
 ---
 
-# Vue.js Compliance Audit
+# Vérification Complète de la Conformité Vue.js
 
-You are an expert Vue.js auditor. Perform a comprehensive compliance check on this project.
+## Arguments
 
-## MISSION
-
-Audit the project for compliance with Vue.js 3 best practices, Composition API standards, and TypeScript conventions.
+$ARGUMENTS (optionnel : chemin du projet à analyser)
 
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.
 
-## AUDIT CHECKLIST
+## MISSION
 
-### 1. Project Structure (20 points)
+Réaliser un audit complet de conformité du projet Vue.js en orchestrant les 4 grandes vérifications : Architecture, Qualité du Code, Tests et Sécurité. Produire un rapport consolidé avec un score global sur 100 points.
+
+### Étape 1 : Préparation de l'audit
+
+Préparer l'environnement d'audit :
+- [ ] Identifier le chemin du projet à auditer
+- [ ] Vérifier la présence des fichiers de configuration (package.json, tsconfig.json, vite.config.ts)
+- [ ] Lister les répertoires principaux (src/, tests/, public/, etc.)
+- [ ] Identifier la structure du projet et la version Vue.js
+
+**Note** : Si $ARGUMENTS est fourni, l'utiliser comme chemin du projet, sinon utiliser le répertoire courant.
+
+### Étape 2 : Audit Architecture (25 points)
+
+Exécuter la vérification complète de l'architecture :
+
+**Commande** : Utiliser la commande slash `/vuejs:check-architecture` ou suivre manuellement les étapes dans `check-architecture.md`
+
+**Critères évalués** :
+- Organisation des composants et des fonctionnalités (6 pts)
+- Structure et réutilisation des composables (6 pts)
+- Architecture du store Pinia (4 pts)
+- Configuration du routeur et lazy loading (4 pts)
+- Séparation des modules partagés/communs (3 pts)
+- Règles de dépendances et exports barrel (2 pts)
+
+**Référence** : `check-architecture.md`
+
+### Étape 3 : Audit Qualité du Code (25 points)
+
+Exécuter la vérification de la qualité du code :
+
+**Commande** : Utiliser la commande slash `/vuejs:check-code-quality` ou suivre manuellement les étapes dans `check-code-quality.md`
+
+**Critères évalués** :
+- Mode strict TypeScript et sûreté des types (5 pts)
+- Conformité ESLint et Prettier (5 pts)
+- Utilisation de la Composition API et de script setup (4 pts)
+- Principes KISS/DRY/YAGNI (4 pts)
+- Conventions de nommage (4 pts)
+- Gestion des erreurs (3 pts)
+
+**Référence** : `check-code-quality.md`
+
+### Étape 4 : Audit Tests (25 points)
+
+Exécuter la vérification des tests :
+
+**Commande** : Utiliser la commande slash `/vuejs:check-testing` ou suivre manuellement les étapes dans `check-testing.md`
+
+**Critères évalués** :
+- Couverture du code (7 pts)
+- Tests unitaires pour les composables et les stores (6 pts)
+- Tests de composants avec Vue Test Utils (4 pts)
+- Tests d'intégration (3 pts)
+- Qualité des tests et pattern AAA (3 pts)
+- Organisation des mocks et des fixtures (2 pts)
+
+**Référence** : `check-testing.md`
+
+### Étape 5 : Audit Sécurité (25 points)
+
+Exécuter la vérification de sécurité :
+
+**Commande** : Utiliser la commande slash `/vuejs:check-security` ou suivre manuellement les étapes dans `check-security.md`
+
+**Critères évalués** :
+- Prévention XSS (utilisation de v-html) (6 pts)
+- Gestion des secrets et des identifiants (5 pts)
+- Validation et assainissement des entrées (4 pts)
+- Vulnérabilités des dépendances (4 pts)
+- Authentification et route guards (3 pts)
+- Communication API sécurisée (2 pts)
+- Protection CSRF (1 pt)
+
+**Référence** : `check-security.md`
+
+### Étape 6 : Consolidation et Score Global
+
+Calculer le score global et produire le rapport consolidé :
+- [ ] Additionner les 4 scores (max 100 points)
+- [ ] Identifier les catégories critiques (<50%)
+- [ ] Lister tous les problèmes transversaux critiques
+- [ ] Prioriser les actions par impact/effort
+- [ ] Produire le rapport final consolidé
+
+**Échelle de notation** :
+- 90-100 : Excellent - Projet de référence
+- 75-89 : Très bien - Quelques améliorations mineures
+- 60-74 : Acceptable - Des améliorations sont nécessaires
+- 40-59 : Insuffisant - Refactoring majeur requis
+- 0-39 : Critique - Refonte complète nécessaire
+
+### Étape 7 : Recommandations et Plan d'Action
+
+Produire les recommandations finales :
+- [ ] Identifier les 3 actions prioritaires dans toutes les catégories
+- [ ] Estimer l'effort (Faible/Moyen/Élevé) pour chaque action
+- [ ] Estimer l'impact (Faible/Moyen/Élevé) pour chaque action
+- [ ] Proposer un ordre d'implémentation
+- [ ] Suggérer des gains rapides (ratio impact/effort élevé)
+
+## FORMAT DE SORTIE
 
 ```
-[ ] src/components/ - Shared components organized
-[ ] src/composables/ - Composition functions present
-[ ] src/stores/ - Pinia stores properly structured
-[ ] src/router/ - Vue Router configuration
-[ ] src/types/ - TypeScript types defined
-[ ] src/services/ - API services separated
+AUDIT DE CONFORMITÉ VUE.JS - RAPPORT COMPLET
+=============================================
+
+SCORE GLOBAL : XX/100
+
+NIVEAU DE CONFORMITÉ : [Excellent/Très bien/Acceptable/Insuffisant/Critique]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+SCORES PAR CATÉGORIE :
+
+ARCHITECTURE       : XX/25  [██████████░░░░░░░░░░] XX%
+QUALITÉ DU CODE    : XX/25  [██████████░░░░░░░░░░] XX%
+TESTS              : XX/25  [██████████░░░░░░░░░░] XX%
+SÉCURITÉ           : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+POINTS FORTS GLOBAUX :
+1. [Point fort identifié dans plusieurs catégories]
+2. [Autre point fort majeur]
+3. [Troisième point fort]
+
+AMÉLIORATIONS GLOBALES :
+1. [Amélioration transversale mineure]
+2. [Autre amélioration recommandée]
+3. [Troisième amélioration]
+
+PROBLÈMES CRITIQUES :
+1. [Problème critique #1 - catégorie concernée]
+2. [Problème critique #2 - catégorie concernée]
+3. [Problème critique #3 - catégorie concernée]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DÉTAILS PAR CATÉGORIE :
+
+┌─────────────────────────────────────────────┐
+│ ARCHITECTURE (XX/25)                        │
+└─────────────────────────────────────────────┘
+
+Sous-scores :
+  • Organisation composants/fonctionnalités   : XX/6
+  • Structure des composables                 : XX/6
+  • Architecture store Pinia                  : XX/4
+  • Routeur et lazy loading                   : XX/4
+  • Séparation des modules partagés           : XX/3
+  • Règles de dépendances                     : XX/2
+
+Points forts :
+- [Points forts d'architecture]
+
+Problèmes :
+- [Problèmes d'architecture]
+
+[Sections similaires pour Qualité du Code, Tests et Sécurité...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 DES ACTIONS PRIORITAIRES (TOUTES CATÉGORIES) :
+
+1. CRITIQUE - [Action #1]
+   Catégorie  : [Architecture/Qualité/Tests/Sécurité]
+   Impact     : [Élevé/Moyen/Faible]
+   Effort     : [Élevé/Moyen/Faible]
+   Priorité   : IMMÉDIATE
+
+   Description détaillée :
+   [Explication du problème et solution proposée]
+
+   Fichiers concernés :
+   - [fichier:ligne]
+
+   Exemple de correction :
+   [Code ou commande de correction]
+
+2. IMPORTANT - [Action #2]
+   [Même format...]
+
+3. RECOMMANDÉ - [Action #3]
+   [Même format...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GAINS RAPIDES (Impact Élevé / Effort Faible) :
+
+- [Gain rapide #1] - Catégorie : [X] - Impact : [X] - Effort : [X]
+- [Gain rapide #2] - Catégorie : [X] - Impact : [X] - Effort : [X]
+- [Gain rapide #3] - Catégorie : [X] - Impact : [X] - Effort : [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLAN D'ACTION RECOMMANDÉ :
+
+SEMAINE 1 (Immédiat) :
+- [ ] [Action critique #1]
+- [ ] [Gain rapide prioritaire]
+
+SEMAINES 2-4 (Court terme) :
+- [ ] [Action importante #2]
+- [ ] [Autres gains rapides]
+
+MOIS 2-3 (Moyen terme) :
+- [ ] [Action recommandée #3]
+- [ ] [Améliorations progressives]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RÉSUMÉ EXÉCUTIF :
+
+[Paragraphe de synthèse sur l'état global du projet, les principaux
+points forts, les principales faiblesses et la trajectoire recommandée
+pour améliorer la conformité. Mentionner si le projet est prêt pour
+la production, nécessite des corrections ou un refactoring.]
+
+Recommandation générale : [Prêt pour la production / Corrections mineures /
+Refactoring majeur / Refonte nécessaire]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Component Standards (25 points)
+## NOTES IMPORTANTES
 
-```
-[ ] Using <script setup> syntax
-[ ] TypeScript with lang="ts"
-[ ] Props defined with defineProps<T>()
-[ ] Emits defined with defineEmits<T>()
-[ ] Components are multi-word named
-[ ] Base components use Base prefix
-```
-
-### 3. Composition API (20 points)
-
-```
-[ ] No Options API in new components
-[ ] Composables follow use* naming
-[ ] Reactive state properly typed
-[ ] Computed properties used correctly
-[ ] Watchers cleaned up
-```
-
-### 4. Pinia Stores (15 points)
-
-```
-[ ] Setup syntax stores (composition style)
-[ ] Proper TypeScript typing
-[ ] Actions are async when needed
-[ ] Getters use computed
-[ ] No direct state mutation from components
-```
-
-### 5. TypeScript Integration (20 points)
-
-```
-[ ] Strict mode enabled
-[ ] No implicit any
-[ ] Props and emits fully typed
-[ ] Interfaces for complex types
-[ ] Type-only imports used
-```
-
-## OUTPUT FORMAT
-
-```
-══════════════════════════════════════════════════════════════
-VUE.JS COMPLIANCE AUDIT
-══════════════════════════════════════════════════════════════
-
-📊 SUMMARY
-──────────────────────────────────────────────────────────────
-Total Score: XX/100
-Status: ✅ COMPLIANT | ⚠️ NEEDS WORK | ❌ NON-COMPLIANT
-
-📁 PROJECT STRUCTURE: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Organized component structure
-[✗] Missing composables directory
-    → Create src/composables/ for reusable logic
-
-🧩 COMPONENT STANDARDS: XX/25
-──────────────────────────────────────────────────────────────
-[✓] Using <script setup>
-[✗] Some components use Options API
-    Files: src/components/OldComponent.vue
-    → Migrate to Composition API
-
-🔧 COMPOSITION API: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Composables properly named
-[✗] Missing cleanup in watchers
-    File: src/composables/useData.ts:45
-
-🏪 PINIA STORES: XX/15
-──────────────────────────────────────────────────────────────
-[✓] Setup syntax used
-[✓] Proper typing
-
-📝 TYPESCRIPT: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Strict mode enabled
-[✗] Implicit any found
-    File: src/utils/helpers.ts:12
-
-📋 RECOMMENDATIONS
-──────────────────────────────────────────────────────────────
-1. [HIGH] Migrate remaining Options API components
-2. [MEDIUM] Add missing type definitions
-3. [LOW] Organize composables by feature
-
-══════════════════════════════════════════════════════════════
-```
-
-## PROCESS
-
-1. Scan project structure
-2. Analyze component files for standards
-3. Check composables and stores
-4. Verify TypeScript configuration
-5. Generate compliance report with score
+- Cette commande orchestre les 4 audits spécialisés
+- Utiliser Docker pour tous les outils d'analyse
+- Fournir des exemples concrets avec fichier:ligne pour chaque problème
+- Prioriser les actions selon la matrice Impact/Effort
+- Les problèmes de sécurité sont TOUJOURS prioritaires
+- Proposer des corrections automatisables (scripts, hooks pre-commit)
+- Le rapport doit être actionnable, pas seulement descriptif
+- Adapter les recommandations au contexte métier du projet

--- a/Dev/i18n/pt/Angular/commands/check-compliance.md
+++ b/Dev/i18n/pt/Angular/commands/check-compliance.md
@@ -1,203 +1,253 @@
 ---
-description: Angular Standards Compliance Check
+description: Verificar Conformidade Completa do Angular
+argument-hint: [arguments]
 ---
 
-# Angular Standards Compliance Check
+# Verificar Conformidade Completa do Angular
 
-Verify that the Angular project follows established coding standards and best practices.
+## Argumentos
 
-## What This Command Does
+$ARGUMENTS (opcional: caminho para o projeto a analisar)
 
-1. **Standards Verification**
-   - Check coding conventions
-   - Verify naming conventions
-   - Validate file organization
-   - Check import order
-   - Verify documentation standards
+## Modo de Planejamento
 
-2. **Angular-Specific Checks**
-   - Standalone components usage
-   - Signals implementation
-   - OnPush change detection
-   - Modern control flow (@if, @for)
-   - Typed forms
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
-3. **Generated Report**
-   - Non-compliant files
-   - Severity levels
-   - Remediation recommendations
-   - Compliance score (/100)
+## MISSÃO
 
-## Modo Plano
+Realizar uma auditoria de conformidade completa do projeto Angular orquestrando as 4 verificações principais: Arquitetura, Qualidade de Código, Testes e Segurança. Produzir um relatório consolidado com uma pontuação geral de 100 pontos.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+### Etapa 1: Preparação da Auditoria
 
-## Compliance Areas
+Preparar o ambiente de auditoria:
+- [ ] Identificar o caminho do projeto a auditar
+- [ ] Verificar a presença de arquivos de configuração (angular.json, tsconfig.json, package.json)
+- [ ] Listar os diretórios principais (src/app/, e2e/, etc.)
+- [ ] Identificar a estrutura do projeto e a versão do Angular
 
-### 1. Component Standards
+**Nota**: Se $ARGUMENTS for fornecido, utilizá-lo como caminho do projeto; caso contrário, usar o diretório atual.
 
-```typescript
-// ✅ Compliant
-@Component({
-  selector: 'app-user-profile',
-  standalone: true,
-  imports: [CommonModule],
-  changeDetection: ChangeDetectionStrategy.OnPush,
-  template: `...`
-})
-export class UserProfileComponent {}
+### Etapa 2: Auditoria de Arquitetura (25 pontos)
 
-// ❌ Non-compliant
-@Component({
-  selector: 'user-profile',     // Missing app- prefix
-  // standalone: missing       // Not standalone
-  // changeDetection: missing  // Not OnPush
-})
-export class UserProfile {}    // Missing Component suffix
-```
+Executar a verificação completa de arquitetura:
 
-### 2. Signal Usage
+**Comando**: Usar o slash command `/angular:check-architecture` ou seguir manualmente os passos em `check-architecture.md`
 
-```typescript
-// ✅ Compliant - Using signals
-export class CounterComponent {
-  count = signal(0);
-  doubleCount = computed(() => this.count() * 2);
-}
+**Critérios Avaliados**:
+- Estrutura de módulos orientada a domínio (6 pts)
+- Uso de componentes standalone (6 pts)
+- Lazy loading e roteamento (4 pts)
+- Separação Core/Shared/Feature (4 pts)
+- Organização da camada de serviços (3 pts)
+- Padrões de injeção de dependência (2 pts)
 
-// ❌ Non-compliant - Using observables for local state
-export class CounterComponent {
-  count$ = new BehaviorSubject(0);
-}
-```
+**Referência**: `check-architecture.md`
 
-### 3. Template Syntax
+### Etapa 3: Auditoria de Qualidade de Código (25 pontos)
 
-```html
-<!-- ✅ Compliant - Modern control flow -->
-@if (loading()) {
-  <app-spinner />
-}
+Executar a verificação de qualidade de código:
 
-@for (item of items(); track item.id) {
-  <app-item [data]="item" />
-}
+**Comando**: Usar o slash command `/angular:check-code-quality` ou seguir manualmente os passos em `check-code-quality.md`
 
-<!-- ❌ Non-compliant - Legacy syntax -->
-<app-spinner *ngIf="loading"></app-spinner>
-<app-item *ngFor="let item of items" [data]="item"></app-item>
-```
+**Critérios Avaliados**:
+- Modo estrito do TypeScript e segurança de tipos (5 pts)
+- Conformidade com ESLint (5 pts)
+- Signals e padrões modernos do Angular (4 pts)
+- Princípios KISS/DRY/YAGNI (4 pts)
+- Convenções de nomenclatura e estrutura de arquivos (4 pts)
+- Detecção de mudanças OnPush (3 pts)
 
-### 4. Dependency Injection
+**Referência**: `check-code-quality.md`
 
-```typescript
-// ✅ Compliant - inject() function
-export class MyComponent {
-  private readonly userService = inject(UserService);
-}
+### Etapa 4: Auditoria de Testes (25 pontos)
 
-// ⚠️ Warning - Constructor injection (valid but verbose)
-export class MyComponent {
-  constructor(private userService: UserService) {}
-}
-```
+Executar a verificação de testes:
 
-### 5. File Naming
+**Comando**: Usar o slash command `/angular:check-testing` ou seguir manualmente os passos em `check-testing.md`
 
-```
-✅ Compliant:
-- user-profile.component.ts
-- auth.service.ts
-- auth.guard.ts
-- date-format.pipe.ts
+**Critérios Avaliados**:
+- Cobertura de código (7 pts)
+- Testes unitários para serviços e pipes (6 pts)
+- Testes de componentes com TestBed (4 pts)
+- Testes de integração (3 pts)
+- Testes E2E (3 pts)
+- Isolamento de testes e mocks (2 pts)
 
-❌ Non-compliant:
-- UserProfile.component.ts (PascalCase)
-- authService.ts (missing suffix)
-- AuthGuard.ts (PascalCase)
-```
+**Referência**: `check-testing.md`
 
-## Scoring Criteria
+### Etapa 5: Auditoria de Segurança (25 pontos)
 
-| Category | Weight | Criteria |
-|----------|--------|----------|
-| Standalone Components | 20% | All components are standalone |
-| Signals Usage | 15% | Local state uses signals |
-| OnPush Strategy | 15% | All components use OnPush |
-| Modern Control Flow | 10% | @if/@for instead of *ngIf/*ngFor |
-| Typed Forms | 10% | Forms are strongly typed |
-| Naming Conventions | 10% | Correct file/class naming |
-| Import Organization | 10% | Imports properly ordered |
-| Documentation | 10% | Key components documented |
+Executar a verificação de segurança:
 
-## Output Format
+**Comando**: Usar o slash command `/angular:check-security` ou seguir manualmente os passos em `check-security.md`
+
+**Critérios Avaliados**:
+- Prevenção de XSS e DomSanitizer (6 pts)
+- Gestão de segredos e credenciais (5 pts)
+- Validação e sanitização de entradas (4 pts)
+- Vulnerabilidades de dependências (4 pts)
+- Autenticação e guardas de rota (3 pts)
+- CSRF e interceptadores HTTP (2 pts)
+- Política de Segurança de Conteúdo (1 pt)
+
+**Referência**: `check-security.md`
+
+### Etapa 6: Consolidação e Pontuação Global
+
+Calcular a pontuação geral e produzir o relatório consolidado:
+- [ ] Somar as 4 pontuações (máximo de 100 pontos)
+- [ ] Identificar categorias críticas (<50%)
+- [ ] Listar todos os problemas transversais críticos
+- [ ] Priorizar ações por impacto/esforço
+- [ ] Produzir o relatório consolidado final
+
+**Escala de Avaliação**:
+- 90-100: Excelente — Projeto de referência
+- 75-89: Muito Bom — Algumas melhorias menores
+- 60-74: Aceitável — Requer melhorias
+- 40-59: Insuficiente — Refatoração significativa necessária
+- 0-39: Crítico — Revisão completa necessária
+
+### Etapa 7: Recomendações e Plano de Ação
+
+Produzir as recomendações finais:
+- [ ] Identificar as 3 ações prioritárias em todas as categorias
+- [ ] Estimar o esforço (Baixo/Médio/Alto) para cada ação
+- [ ] Estimar o impacto (Baixo/Médio/Alto) para cada ação
+- [ ] Propor a ordem de implementação
+- [ ] Sugerir ganhos rápidos (alta relação impacto/esforço)
+
+## FORMATO DE SAÍDA
 
 ```
-══════════════════════════════════════════════════════════════
-ANGULAR COMPLIANCE REPORT
-══════════════════════════════════════════════════════════════
+AUDITORIA DE CONFORMIDADE ANGULAR - RELATÓRIO COMPLETO
+=======================================================
 
-📊 SCORE: 85/100
+PONTUAÇÃO GERAL: XX/100
 
-✅ PASSING (6)
-──────────────────────────────────────────────────────────────
-• Standalone components: 100% (24/24 components)
-• OnPush strategy: 100% (24/24 components)
-• Typed forms: 100% (8/8 forms)
-• Import organization: 100%
-• File naming: 100%
-• Documentation: 90%
+NÍVEL DE CONFORMIDADE: [Excelente/Muito Bom/Aceitável/Insuficiente/Crítico]
 
-⚠️ WARNINGS (2)
-──────────────────────────────────────────────────────────────
-• Modern control flow: 75% (18/24 templates)
-  - src/app/features/users/user-list.component.html:15 - Uses *ngFor
-  - src/app/shared/modal/modal.component.html:8 - Uses *ngIf
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-• Signals usage: 80% (16/20 components with local state)
-  - src/app/features/auth/login.component.ts - Uses BehaviorSubject
+PONTUAÇÕES POR CATEGORIA:
 
-❌ ERRORS (1)
-──────────────────────────────────────────────────────────────
-• Constructor injection detected (prefer inject()):
-  - src/app/core/services/api.service.ts:15
+ARQUITETURA        : XX/25  [██████████░░░░░░░░░░] XX%
+QUALIDADE DE CÓDIGO: XX/25  [██████████░░░░░░░░░░] XX%
+TESTES             : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURANÇA          : XX/25  [██████████░░░░░░░░░░] XX%
 
-📋 RECOMMENDATIONS
-──────────────────────────────────────────────────────────────
-1. Migrate remaining *ngFor to @for with track
-2. Replace BehaviorSubject with signal() for local state
-3. Use inject() function instead of constructor injection
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-══════════════════════════════════════════════════════════════
+PONTOS FORTES GERAIS:
+1. [Ponto forte identificado em múltiplas categorias]
+2. [Outro ponto forte principal]
+3. [Terceiro ponto forte]
+
+MELHORIAS GERAIS:
+1. [Melhoria transversal menor]
+2. [Outra melhoria recomendada]
+3. [Terceira melhoria]
+
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico nº 1 - categoria afetada]
+2. [Problema crítico nº 2 - categoria afetada]
+3. [Problema crítico nº 3 - categoria afetada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALHES POR CATEGORIA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITETURA (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Sub-pontuações:
+  • Módulos orientados a domínio  : XX/6
+  • Componentes standalone        : XX/6
+  • Lazy loading e roteamento     : XX/4
+  • Core/Shared/Feature           : XX/4
+  • Camada de serviços            : XX/3
+  • Injeção de dependência        : XX/2
+
+Pontos Fortes:
+- [Pontos fortes de arquitetura]
+
+Problemas:
+- [Problemas de arquitetura]
+
+[Seções semelhantes para Qualidade de Código, Testes e Segurança...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 AÇÕES PRIORITÁRIAS (TODAS AS CATEGORIAS):
+
+1. CRÍTICO - [Ação nº 1]
+   Categoria : [Arquitetura/Qualidade/Testes/Segurança]
+   Impacto   : [Alto/Médio/Baixo]
+   Esforço   : [Alto/Médio/Baixo]
+   Prioridade: IMEDIATA
+
+   Descrição detalhada:
+   [Explicação do problema e solução proposta]
+
+   Arquivos afetados:
+   - [arquivo:linha]
+
+   Exemplo de correção:
+   [Código ou comando de correção]
+
+2. IMPORTANTE - [Ação nº 2]
+   [Mesmo formato...]
+
+3. RECOMENDADO - [Ação nº 3]
+   [Mesmo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GANHOS RÁPIDOS (Alto Impacto / Baixo Esforço):
+
+- [Ganho rápido nº 1] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Ganho rápido nº 2] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Ganho rápido nº 3] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLANO DE AÇÃO RECOMENDADO:
+
+SEMANA 1 (Imediato):
+- [ ] [Ação crítica nº 1]
+- [ ] [Ganho rápido prioritário]
+
+SEMANAS 2-4 (Curto prazo):
+- [ ] [Ação importante nº 2]
+- [ ] [Outros ganhos rápidos]
+
+MESES 2-3 (Médio prazo):
+- [ ] [Ação recomendada nº 3]
+- [ ] [Melhorias progressivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMO EXECUTIVO:
+
+[Parágrafo de síntese sobre o estado geral do projeto, principais pontos
+fortes, principais pontos fracos e a trajetória recomendada para melhorar
+a conformidade. Indicar se o projeto está pronto para produção,
+requer correções ou necessita de refatoração.]
+
+Recomendação Geral: [Pronto para produção / Correções menores /
+Refatoração significativa / Revisão completa necessária]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-## Automated Checks
+## NOTAS IMPORTANTES
 
-Run these commands to verify compliance:
-
-```bash
-# Lint check
-ng lint
-
-# Type check
-npx tsc --noEmit
-
-# Test coverage
-npm run test:ci
-
-# Build check
-ng build --configuration=production
-```
-
-## Checklist
-
-- [ ] All components are standalone
-- [ ] All components use OnPush change detection
-- [ ] Local state uses signals (not BehaviorSubject)
-- [ ] Templates use @if/@for/@switch
-- [ ] Forms are typed (FormGroup<T>)
-- [ ] inject() used for dependency injection
-- [ ] File naming follows conventions
-- [ ] Imports are organized
-- [ ] Public API documented
-- [ ] Tests pass with >80% coverage
+- Este comando orquestra as 4 auditorias especializadas
+- Usar Docker para todas as ferramentas de análise
+- Fornecer exemplos concretos com arquivo:linha para cada problema
+- Priorizar ações com base na matriz Impacto/Esforço
+- Problemas de segurança são SEMPRE a prioridade máxima
+- Propor correções automatizáveis (scripts, hooks de pré-commit)
+- O relatório deve ser acionável, não apenas descritivo
+- Adaptar as recomendações ao contexto de negócio do projeto

--- a/Dev/i18n/pt/Common/agents/ralph-conductor.md
+++ b/Dev/i18n/pt/Common/agents/ralph-conductor.md
@@ -1,54 +1,98 @@
 ---
 name: ralph-conductor
-description: Orquestra sessoes Ralph Wiggum v2.0 com validacao DoD adaptativa
+description: Orquestra sessões de loop contínuo do Ralph Wiggum v2.0 com validação adaptativa de DoD
 model: opus
 effort: xhigh
 maxTurns: 10
 memory: user
-tools: [Read, Glob, Grep, Edit, Write, Bash, Task, WebFetch, WebSearch]
-permissionMode: default
 ---
 
 # Agente Ralph Conductor v2.0
 
-Voce e um agente especializado para orquestrar sessoes de loop continuo Ralph Wiggum v2.0. Seu papel e guiar tarefas atraves da execucao iterativa do Claude ate que os criterios Definition of Done (DoD) sejam atendidos.
+Você é um agente especializado na orquestração de sessões de loop contínuo do Ralph Wiggum v2.0. Seu papel é guiar tarefas por meio de execução iterativa do Claude até que os critérios da Definição de Pronto (DoD) sejam atendidos.
 
-## Responsabilidades principais
+## Responsabilidades Principais
 
-### 1. Gerenciamento de sessao
-- Inicializar sessoes Ralph com configuracao apropriada
-- Rastrear progresso e metricas
-- Gerenciar estado de sessao e recuperacao
+### 1. Gerenciamento de Sessão
+- Inicializar sessões Ralph com a configuração adequada
+- Acompanhar o progresso das iterações e as métricas
+- Gerenciar o estado da sessão e a recuperação
+- Monitorar o painel em tempo real
+- Exportar métricas da sessão (JSON/Prometheus)
 
-### 2. Validacao Definition of Done
-- Avaliar criterios DoD em cada iteracao
-- Usar templates DoD especificos por tecnologia
+### 2. Validação da Definição de Pronto
+- Avaliar os critérios de DoD a cada iteração
+- Utilizar templates de DoD específicos por tecnologia
+- Fornecer feedback sobre quais critérios estão passando/falhando
+- Sugerir ações corretivas quando os critérios falham
 
 ### 3. Circuit Breaker Adaptativo (v2.0)
-- Detectar perfil de tarefa a partir de palavras-chave
-- Aplicar limiares especificos ao perfil
+- Detectar o perfil da tarefa a partir de palavras-chave do prompt
+- Aplicar limites específicos por perfil
+- Aprender com os resultados históricos das sessões
+- Monitorar condições de estagnação
 
-### 4. Monitoramento de Saude (v2.0)
-- Detectar padroes de estagnacao
-- Identificar espirais de erros
+### 4. Monitoramento de Saúde (v2.0)
+- Detectar padrões de estagnação (sem progresso)
+- Identificar espirais de erro
+- Monitorar inchaço de contexto
+- Recomendar ações preventivas
 
-### 5. Integracao Hooks (v2.0)
-- Gerenciar hooks Claude Code 2.1.23+
+### 5. Integração de Hooks (v2.0)
+- Gerenciar hooks do Claude Code 2.1.23+
+- Injetar contexto Ralph no SessionStart
+- Injetar status do DoD no PreToolUse
+- Bloquear Stop na satisfação do DoD
 
 ## Perfis Adaptativos v2.0
 
 | Perfil | Palavras-chave | Comportamento |
 |--------|----------------|---------------|
-| `quick_fix` | fix, bug, typo | Limiares agressivos |
+| `quick_fix` | fix, bug, typo | Limites agressivos, parada rápida |
 | `small_feature` | add, implement | Abordagem equilibrada |
-| `medium_feature` | feature, create | Limiares padrao |
-| `large_feature` | refactor, migrate | Limiares tolerantes |
-| `exploration` | explore, investigate | Muito tolerante |
+| `medium_feature` | feature, create | Limites padrão |
+| `large_feature` | refactor, migrate | Limites permissivos |
+| `exploration` | explore, investigate | Muito permissivo, alta iteração |
 
-## Templates DoD por tecnologia
+## Modo de Trabalho
 
-| Tecnologia | Framework Teste | Ferramenta Lint |
-|------------|-----------------|-----------------|
+Ao orquestrar uma sessão Ralph v2.0:
+
+1. **Avaliação Inicial**
+   - Compreender os requisitos da tarefa
+   - Detectar o tipo de projeto (Symfony, Flutter, React, etc.)
+   - Carregar o template de DoD adequado
+   - Identificar o perfil adaptativo a partir das palavras-chave
+   - Configurar hooks se habilitados
+
+2. **Orientação das Iterações**
+   - Fornecer prompts claros e acionáveis
+   - Focar em um objetivo de cada vez
+   - Construir incrementalmente sobre o progresso anterior
+   - Monitorar o painel para status em tempo real
+
+3. **Portões de Qualidade**
+   - Verificar se os testes passam antes de prosseguir
+   - Verificar métricas de qualidade do código
+   - Validar atualizações de documentação
+   - Utilizar validadores específicos por tecnologia
+
+4. **Monitoramento de Saúde**
+   - Observar indicadores de estagnação
+   - Detectar espirais de erro precocemente
+   - Monitorar o uso do contexto
+   - Recomendar compactação quando necessário
+
+5. **Sinais de Conclusão**
+   - Indicar claramente quando o DoD é atendido
+   - Utilizar o marcador de conclusão: `<promise>COMPLETE</promise>`
+   - Resumir o que foi realizado
+   - Exportar métricas finais
+
+## Templates de DoD por Tecnologia
+
+| Tecnologia | Framework de Testes | Ferramenta de Lint |
+|------------|---------------------|--------------------|
 | Symfony | PHPUnit | PHPStan |
 | Flutter | flutter_test | flutter_lints |
 | React | Jest/Vitest | ESLint |
@@ -57,8 +101,145 @@ Voce e um agente especializado para orquestrar sessoes de loop continuo Ralph Wi
 | Go | go test | golangci-lint |
 | Rust | cargo test | clippy |
 
-## Pontos de integracao
+## Boas Práticas
 
-- Funciona com `/common:ralph-run`
-- Integra com hooks Claude Code 2.1.23+
-- Compativel com `/sprint:dev`
+### Decomposição de Tarefas
+Dividir tarefas complexas em etapas menores e verificáveis:
+1. Escrever o teste que falha primeiro (RED)
+2. Implementar o código mínimo para passar (GREEN)
+3. Refatorar mantendo os testes passando (REFACTOR)
+4. Atualizar a documentação
+5. Sinalizar a conclusão
+
+### Indicadores de Progresso
+Incluir marcadores de progresso claros na saída:
+- `[PROGRESS]` - Avançando
+- `[BLOCKED]` - Obstáculo encontrado
+- `[TESTING]` - Executando verificação
+- `[HEALTH]` - Status de verificação de saúde
+- `[COMPLETE]` - Tarefa finalizada
+
+### Comportamento Adaptativo
+Ajustar com base no perfil:
+- **quick_fix**: Mover rápido, iteração mínima
+- **exploration**: Ser paciente, permitir mais exploração
+- **large_feature**: Esperar sessões mais longas, mais compactações
+
+## Fluxo de Sessão de Exemplo (v2.0)
+
+```
+Session: ralph-1704067200-a1b2
+Profile: medium_feature (detected from "Implement user authentication")
+Technology: Symfony (auto-detected)
+
+╔═══════════════════════════════════════════════════════════════╗
+║  RALPH WIGGUM v2.0 - Session: ralph-xxx      PHASE: GREEN     ║
+╠═══════════════════════════════════════════════════════════════╣
+║  ITERATION 3/25              ELAPSED: 05:23                   ║
+║  PROGRESS ████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░  24%    ║
+║  Circuit Breaker: ░░ (0/4)    Context: ████░░░░░░ 42%        ║
+╚═══════════════════════════════════════════════════════════════╝
+
+Iteration 1:
+[PROGRESS] Analyzing existing code structure
+[HEALTH] Status: HEALTHY
+- Found existing User entity
+- Authentication service needs creation
+- DoD template loaded: Symfony (PHPUnit + PHPStan)
+
+Iteration 2:
+[TESTING] Writing authentication tests
+- Created AuthServiceTest.php
+- 3 test cases: login, logout, validateToken
+- Tests currently FAILING (expected - RED phase)
+
+Iteration 3:
+[PROGRESS] Implementing AuthService
+- Created AuthService.php
+- Implemented JWT token generation
+- Tests now PASSING (GREEN phase)
+
+DoD Validation:
+  ✓ [tests] PHPUnit passes
+  ✓ [phpstan] PHPStan level max
+  ✓ [completion] Completion marker found
+
+<promise>COMPLETE</promise>
+
+Summary:
+- Profile: medium_feature
+- Iterations: 3
+- DoD: 3/3 checks passing
+- Metrics exported: .ralph/sessions/.../metrics-export.json
+```
+
+## Modo de Coordenação de Equipes de Agentes
+
+Ao operar no modo Agent Teams (ativado via `--ralph-mode` em `/team:sprint`), o conductor assume o papel de **líder de equipe** e coordena um colega de desenvolvimento por meio da API Claude Code Agent Teams em vez do gerenciamento de processos bash.
+
+### Pré-requisitos
+
+- Variável de ambiente `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`
+- Claude Code v2.1.32+
+- Biblioteca adaptadora: `Tools/AgentTeams/lib/ralph-teams-adapter.sh`
+
+### Coordenação via Sistema de Tarefas
+
+No modo Agent Teams, o conductor substitui o rastreamento baseado em PID pelo sistema de tarefas compartilhado:
+
+| Modo Bash (atual) | Modo Agent Teams |
+|-------------------|-----------------|
+| `spawn_ralph_for_story()` com `&` bash | `TaskCreate` + `SendMessage` para o colega dev |
+| Polling `kill -0 $pid` | `TaskList` / hook `TaskCompleted` |
+| Detecção de conclusão baseada em PID | `TaskUpdate(status=completed)` pelo dev |
+| `kill -9` para processos travados | `SendMessage(type=shutdown_request)` + watchdog de fallback |
+| Escritas `yq` em `batch-queue.yaml` | `TaskList` compartilhado (coordenação integrada) |
+
+### Fluxo de Processamento de Histórias
+
+1. **Reivindicar história**: Conductor lê `sprint-status.yaml`, reivindica a próxima história `ready-for-dev`
+2. **Criar tarefa**: `TaskCreate` com detalhes da história, critérios de aceitação e instruções TDD
+3. **Atribuir ao dev**: `SendMessage(type=message, recipient=dev-1)` com o prompt da história
+4. **Monitorar progresso**: Consultar `TaskList` para atualizações de status do colega dev
+5. **Tratar conclusão**: Quando o dev marca a tarefa como `completed`, o conductor faz a transição da história para `review`
+6. **Tratar falha**: Se o dev reporta falha ou o watchdog detecta estagnação, o conductor aplica a estratégia de recuperação
+7. **Próxima história**: Atribuir a próxima história pronta ou enviar `shutdown_request` se o sprint estiver completo
+
+### Integração do Watchdog
+
+O conductor executa verificações de saúde periódicas através do `teams_watchdog()` do adaptador:
+
+- **Intervalo de verificação**: A cada 60 segundos (configurável via `TEAMS_WATCHDOG_INTERVAL`)
+- **Limite de timeout**: 5 minutos sem atividade (configurável via `TEAMS_WATCHDOG_TIMEOUT`)
+- **Ação em estagnação**: Marcar colega como estagnado, acionar `teams_fallback_sequential()`, reprocessar a história por meio do `execute_story_with_ralph()` existente
+
+### Manter o Modo Bash Intacto
+
+Toda a orquestração existente no modo bash permanece inalterada. O modo Agent Teams é ativado apenas quando:
+1. O flag `--ralph-mode` é passado para `/team:sprint`
+2. A variável de ambiente `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` está definida
+3. A biblioteca adaptadora está disponível
+
+Sem essas condições, o conductor opera exatamente como antes.
+
+## Pontos de Integração
+
+- Funciona com o comando `/common:ralph-run`
+- Integra-se com hooks do Claude Code 2.1.23+
+- Compatível com o fluxo de trabalho `/sprint:dev`
+- Usa os princípios de `@tdd-coach`
+- Modo Agent Teams via `/team:sprint --ralph-mode`
+
+## Quando Parar
+
+Sinalizar conclusão e parar de iterar quando:
+1. Todos os critérios de DoD obrigatórios passam
+2. Os objetivos da tarefa são totalmente atendidos
+3. Os testes verificam a funcionalidade
+4. A documentação está atualizada
+
+NÃO continuar se:
+- Limites do circuit breaker foram atingidos
+- O monitor de saúde detecta problemas críticos
+- Falhas repetidas indicam problema fundamental
+- Intervenção humana é necessária

--- a/Dev/i18n/pt/Common/commands/add-technology.md
+++ b/Dev/i18n/pt/Common/commands/add-technology.md
@@ -1,28 +1,28 @@
 ---
-description: Adicionar uma nova tecnologia ao claude-craft com best practices do Context7 e pesquisa web
-argument-hint: <nome-tecnologia>
+description: Adicionar uma nova tecnologia ao claude-craft com boas práticas do Context7 e pesquisa web
+argument-hint: <technology-name>
 ---
 
 # Adicionar Tecnologia
 
-Você é um especialista integrador de tecnologias para claude-craft. Sua missão é adicionar uma nova stack tecnológica:
-1. Pesquisando best practices usando Context7 MCP e pesquisa web
-2. Gerando todos os arquivos necessários (rules, commands, templates, skills, agents)
+Você é um integrador de tecnologia especialista para o claude-craft. Sua missão é adicionar uma nova stack de tecnologia:
+1. Pesquisando boas práticas usando o Context7 MCP e pesquisa web
+2. Gerando todos os arquivos necessários (regras, comandos, templates, skills, agentes)
 3. Criando o script de instalação
-4. Atualizando documentação e página de apresentação
+4. Atualizando a documentação e a landing page
 
 ## Argumentos
 $ARGUMENTS
 
 Argumentos:
-- `nome-tecnologia`: Nome da tecnologia a adicionar (ex: "nextjs", "nestjs", "golang", "laravel")
-- (Opcional) `categoria`: Categoria da tecnologia (frontend, backend, mobile, devops, fullstack)
+- `technology-name`: Nome da tecnologia a ser adicionada (ex.: "nextjs", "nestjs", "golang", "laravel")
+- (Opcional) `category`: Categoria da tecnologia (frontend, backend, mobile, devops, fullstack)
 
 Exemplo: `/common:add-technology "nestjs"` ou `/common:add-technology "golang" backend`
 
-## Modo Plano
+## Modo de Planejamento
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de fazer qualquer alteração.
 
 ## MISSÃO
 
@@ -32,50 +32,50 @@ Identificar:
 - Nome oficial e aliases comuns
 - Tipo: framework, biblioteca, linguagem, ferramenta
 - Categoria: frontend, backend, mobile, devops, fullstack
-- Ecossistema: ferramentas relacionadas, frameworks de teste, opções de deploy
+- Ecossistema: ferramentas relacionadas, frameworks de teste, opções de implantação
 - Público-alvo: web, mobile, API, CLI, etc.
 
-### Passo 2: Pesquisar com Context7 (MCP)
+### Passo 2: Pesquisa com Context7 (MCP)
 
-**Usar Context7 para acessar documentação oficial:**
+**Usar o Context7 para acessar a documentação oficial:**
 
 ```
 Consultar Context7 para:
-1. Guia oficial de início
+1. Guia oficial de introdução
 2. Estrutura de projeto recomendada
-3. Best practices e design patterns
+3. Boas práticas e padrões de design
 4. Estratégias de teste (unitário, integração, e2e)
-5. Best practices de segurança
+5. Boas práticas de segurança
 6. Dicas de otimização de performance
-7. Recomendações de deploy
+7. Recomendações de implantação
 ```
 
 #### Informações a Extrair
 
-| Tema | Detalhes a Encontrar |
-|------|---------------------|
+| Tópico | Detalhes a Encontrar |
+|--------|----------------------|
 | Arquitetura | Padrões recomendados (MVC, Clean, Hexagonal, etc.) |
-| Padrões de Código | Guia de estilo, convenções de nomenclatura, estrutura de arquivos |
+| Padrões de Codificação | Guia de estilo, convenções de nomeação, estrutura de arquivos |
 | Ferramentas | Ferramentas CLI, formatadores, linters, bundlers |
 | Testes | Frameworks de teste, ferramentas de cobertura, estratégias de mock |
 | Segurança | Autenticação, autorização, vulnerabilidades comuns |
-| Qualidade | Análise estática, verificação de tipos, práticas de review |
+| Qualidade | Análise estática, verificação de tipos, práticas de revisão de código |
 
 ### Passo 3: Complementar com Pesquisa Web
 
-**Buscar tendências 2026 e práticas da comunidade:**
+**Pesquisar tendências de 2026 e práticas da comunidade:**
 
 1. **Últimas Tendências**
    - Versão estável atual
    - Recursos futuros
-   - Avisos de deprecação
+   - Avisos de depreciação
    - Guias de migração
 
-2. **Best Practices da Comunidade**
+2. **Boas Práticas da Comunidade**
    - Boilerplates populares
    - Configurações de produção
    - Benchmarks de performance
-   - Arquiteturas reais
+   - Arquiteturas do mundo real
 
 3. **Armadilhas Comuns**
    - Erros frequentes
@@ -91,7 +91,7 @@ Consultar Context7 para:
 
 ### Passo 4: Gerar Arquivos da Tecnologia
 
-**Criar estrutura completa em 5 idiomas (en, fr, es, de, pt):**
+**Criar a estrutura de arquivos completa em todos os 5 idiomas (en, fr, es, de, pt):**
 
 ```
 Dev/i18n/{lang}/{TECHNOLOGY}/
@@ -110,24 +110,45 @@ Dev/i18n/{lang}/{TECHNOLOGY}/
 │   ├── check-code-quality.md
 │   ├── check-testing.md
 │   ├── check-security.md
-│   └── [generate-*.md se aplicável]
+│   └── [generate-*.md if applicable]
 ├── templates/
-│   └── [templates específicos da tecnologia]
+│   └── [technology-specific templates]
 ├── checklists/
 │   ├── pre-commit.md
 │   └── new-feature.md
 ├── agents/
 │   └── {tech}-reviewer.md
 └── skills/
-    └── [skills específicos da tecnologia]
+    └── [technology-specific skills]
 ```
+
+#### Regras a Gerar
+
+| Arquivo | Conteúdo |
+|---------|----------|
+| `02-architecture-{tech}.md` | Padrões de arquitetura, estrutura de pastas, princípios de arquitetura limpa |
+| `03-coding-standards.md` | Guia de estilo, convenções de nomeação, organização de arquivos |
+| `06-tooling.md` | Comandos CLI, formatadores, linters, ferramentas de build |
+| `07-testing-{tech}.md` | Estratégias de teste, frameworks, requisitos de cobertura |
+| `08-quality-tools.md` | Análise estática, verificação de tipos, integração CI/CD |
+| `11-security-{tech}.md` | Práticas de segurança, vulnerabilidades comuns, autenticação |
+
+#### Comandos a Gerar
+
+| Comando | Propósito |
+|---------|-----------|
+| `check-compliance.md` | Auditoria completa de conformidade (pontuação /100) |
+| `check-architecture.md` | Revisão de arquitetura |
+| `check-code-quality.md` | Análise de qualidade do código |
+| `check-testing.md` | Cobertura e qualidade de testes |
+| `check-security.md` | Auditoria de segurança |
 
 ### Passo 5: Criar Script de Instalação
 
 **Gerar `Dev/scripts/install-{tech}-rules.sh`:**
 
 Seguir o padrão dos scripts existentes:
-- Suporte às opções `--lang`, `--force`, `--update`, `--dry-run`, `--backup`
+- Suportar as opções `--lang`, `--force`, `--update`, `--dry-run`, `--backup`
 - Copiar regras genéricas de Common/
 - Copiar regras específicas da tecnologia
 - Gerar CLAUDE.md e 00-project-context.md
@@ -140,34 +161,58 @@ Seguir o padrão dos scripts existentes:
 | Arquivo | Alterações |
 |---------|------------|
 | `README.md` | Adicionar tecnologia à lista de stacks suportadas |
-| `docs/index.html` | Incrementar stats, adicionar card da tecnologia |
+| `docs/index.html` | Incrementar estatísticas, adicionar card de tecnologia |
 | `docs/COMMANDS.md` | Documentar novos comandos |
 | `Makefile` | Adicionar target `install-{tech}` |
 
+#### Atualizações da Landing Page (docs/index.html)
+
+1. **Seção de Estatísticas**: Incrementar o contador "Tech Stacks"
+2. **Grade de Tecnologias**: Adicionar novo card de tecnologia:
+
+```html
+<div class="bg-slate-800/50 p-6 rounded-xl border border-white/5 hover:border-brand-500/50 transition-colors text-center group">
+    <div class="h-16 w-16 mx-auto bg-black rounded-full flex items-center justify-center mb-4 shadow-lg group-hover:scale-110 transition-transform">
+        <span class="text-2xl font-bold text-white">{ICON}</span>
+    </div>
+    <h3 class="font-bold text-white">{TECH_NAME}</h3>
+    <p class="text-xs text-slate-400 mt-2" data-i18n="tech_{tech}_desc">{DESCRIPTION}</p>
+</div>
+```
+
+3. **Traduções**: Adicionar chaves i18n para todos os 5 idiomas
+
+#### Target do Makefile
+
+```makefile
+install-{tech}:
+	./Dev/scripts/install-{tech}-rules.sh --lang=$(RULES_LANG) $(OPTIONS) $(TARGET)
+```
+
 ### Passo 7: Validação
 
-#### Checklist Definition of Done
+#### Checklist de Definição de Pronto
 
 ```
 ══════════════════════════════════════════════════════════════
-✅ DEFINITION OF DONE: Adicionar Tecnologia [{NOME_TECH}]
+✅ DEFINIÇÃO DE PRONTO: Adicionar Tecnologia [{TECH_NAME}]
 ══════════════════════════════════════════════════════════════
 
 📁 ARQUIVOS CRIADOS
 ──────────────────────────────────────────────────────────────
-- [ ] Rules (7 arquivos × 5 idiomas = 35 arquivos)
-- [ ] Commands (5 arquivos × 5 idiomas = 25 arquivos)
-- [ ] Templates (pelo menos 2 por idioma)
+- [ ] Regras (7 arquivos × 5 idiomas = 35 arquivos)
+- [ ] Comandos (5 arquivos × 5 idiomas = 25 arquivos)
+- [ ] Templates (mínimo 2 por idioma)
 - [ ] Checklists (2 arquivos × 5 idiomas = 10 arquivos)
-- [ ] Agent {tech}-reviewer (1 arquivo × 5 idiomas = 5 arquivos)
+- [ ] Agente {tech}-reviewer (1 arquivo × 5 idiomas = 5 arquivos)
 - [ ] CLAUDE.md.template (× 5 idiomas)
 - [ ] Script de instalação (Dev/scripts/install-{tech}-rules.sh)
 
 📄 DOCUMENTAÇÃO ATUALIZADA
 ──────────────────────────────────────────────────────────────
-- [ ] README.md: Tecnologia adicionada às stacks suportadas
-- [ ] docs/index.html: Stats incrementadas
-- [ ] docs/index.html: Card da tecnologia adicionado
+- [ ] README.md: Tecnologia adicionada à lista de stacks suportadas
+- [ ] docs/index.html: Estatísticas incrementadas
+- [ ] docs/index.html: Card de tecnologia adicionado
 - [ ] docs/index.html: Traduções i18n adicionadas (5 idiomas)
 - [ ] docs/COMMANDS.md: Novos comandos documentados
 - [ ] Makefile: Target install-{tech} adicionado
@@ -175,25 +220,78 @@ Seguir o padrão dos scripts existentes:
 🧪 VERIFICAÇÃO
 ──────────────────────────────────────────────────────────────
 - [ ] Script de instalação executa sem erros
-- [ ] Todos os arquivos estão corretamente formatados
-- [ ] Comandos são funcionais
-- [ ] Documentação está correta
+- [ ] Todos os arquivos estão devidamente formatados
+- [ ] Os comandos são funcionais
+- [ ] A documentação é precisa
 
+══════════════════════════════════════════════════════════════
+```
+
+### Formato de Saída
+
+Após concluir todos os passos, fornecer:
+
+```
+══════════════════════════════════════════════════════════════
+🎉 TECNOLOGIA ADICIONADA: {TECH_NAME}
+══════════════════════════════════════════════════════════════
+
+📊 RESUMO
+──────────────────────────────────────────────────────────────
+Tecnologia: {TECH_NAME}
+Categoria: {CATEGORY}
+Versão: {CURRENT_VERSION}
+
+Arquivos criados: {COUNT}
+- Regras: 35 arquivos
+- Comandos: 25 arquivos
+- Templates: {COUNT}
+- Checklists: 10 arquivos
+- Agentes: 5 arquivos
+
+📁 ESTRUTURA
+──────────────────────────────────────────────────────────────
+Dev/i18n/
+├── en/{TECH}/
+├── fr/{TECH}/
+├── es/{TECH}/
+├── de/{TECH}/
+└── pt/{TECH}/
+
+Dev/scripts/
+└── install-{tech}-rules.sh
+
+🔧 INSTALAÇÃO
+──────────────────────────────────────────────────────────────
+# Via Makefile
+make install-{tech} TARGET=~/my-project RULES_LANG=en
+
+# Script direto
+./Dev/scripts/install-{tech}-rules.sh ~/my-project
+
+📚 DOCUMENTAÇÃO
+──────────────────────────────────────────────────────────────
+- README.md ✅ Atualizado
+- docs/index.html ✅ Atualizado
+- docs/COMMANDS.md ✅ Atualizado
+- Makefile ✅ Atualizado
+
+✅ DEFINIÇÃO DE PRONTO: CONCLUÍDA
 ══════════════════════════════════════════════════════════════
 ```
 
 ### Diretrizes Importantes
 
-1. **Pesquisar primeiro** - Sempre usar Context7 e pesquisa web antes de gerar arquivos
-2. **Seguir padrões** - Usar tecnologias existentes (React, Symfony, Flutter) como modelos
-3. **5 idiomas** - Gerar conteúdo para en, fr, es, de, pt
-4. **Qualidade sobre velocidade** - Garantir que todos os arquivos estejam formatados corretamente
-5. **Atualizar tudo** - Não esquecer documentação e página inicial
+1. **Pesquisar Primeiro** - Sempre usar o Context7 e a pesquisa web antes de gerar arquivos
+2. **Seguir Padrões** - Usar tecnologias existentes (React, Symfony, Flutter) como modelos
+3. **Todos os 5 Idiomas** - Gerar conteúdo para en, fr, es, de, pt
+4. **Qualidade antes da Velocidade** - Garantir que todos os arquivos estejam devidamente formatados e funcionais
+5. **Atualizar Tudo** - Não esquecer a documentação e a landing page
 
 ### Tratamento de Erros
 
 Se a pesquisa falhar:
-- Indicar claramente qual informação está faltando
+- Indicar claramente quais informações estão faltando
 - Propor fontes alternativas
-- Pedir esclarecimentos ao usuário se necessário
-- NUNCA gerar arquivos com conteúdo placeholder ou inventado
+- Pedir esclarecimento ao usuário se necessário
+- NUNCA gerar arquivos com conteúdo de placeholder ou inventado

--- a/Dev/i18n/pt/Common/commands/ralph-run.md
+++ b/Dev/i18n/pt/Common/commands/ralph-run.md
@@ -1,64 +1,182 @@
 ---
-description: Executar Claude em loop continuo ate completar a tarefa (Ralph Wiggum v2.0)
-argument-hint: <descricao-tarefa> [--auto-detect|--init|--interactive]
+description: Executar Claude em loop contínuo até a conclusão da tarefa (Ralph Wiggum v2.0)
+argument-hint: <task-description> [--auto-detect|--init|--interactive]
 ---
 
-# Ralph Run - Loop Continuo de Agente IA v2.0
+# Ralph Run - Loop Contínuo de Agente IA v2.0
 
-Executa Claude em um loop continuo ate que a tarefa esteja completa ou os criterios de Definition of Done (DoD) sejam atendidos.
+Executa o Claude em loop contínuo até que a tarefa seja concluída ou os critérios da Definição de Pronto (DoD) sejam atendidos.
 
 ## Argumentos
 
 **$ARGUMENTS**
 
-- `<descricao-tarefa>`: A tarefa para Claude completar
-- `--auto-detect`: Detectar automaticamente o tipo de projeto e configurar DoD
-- `--init`: Gerar configuracao sem executar
-- `--interactive`: Assistente de configuracao interativo
+- `<task-description>`: A tarefa a ser concluída pelo Claude
+- `--auto-detect`: Detectar automaticamente o tipo de projeto e configurar o DoD
+- `--init`: Gerar configuração sem executar
+- `--interactive`: Assistente de configuração interativo
 
-## Modo Plano
+## Modo de Planejamento
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de fazer qualquer alteração.
 
-## Novas funcionalidades v2.0
+## Novidades v2.0
 
-| Funcionalidade | Descricao |
+| Funcionalidade | Descrição |
 |----------------|-----------|
-| **Integracao Hooks** | Integracao bidirecional com Claude Code 2.1.23+ |
-| **Auto-Deteccao** | Deteccao automatica do tipo de projeto |
-| **Dashboard** | Visualizacao em tempo real com barra de progresso |
-| **Export Metricas** | Metricas em formato JSON e Prometheus |
-| **Circuit Breaker Adaptativo** | 5 perfis com aprendizado historico |
-| **Monitor de Saude** | Deteccao de estagnacao, espiral de erros |
-| **Templates DoD** | Templates pre-configurados para 8 tecnologias |
+| **Integração de Hooks** | Integração bidirecional com Claude Code 2.1.23+ |
+| **Detecção Automática** | Detecção automática do tipo de projeto (Symfony, Flutter, React, etc.) |
+| **Painel** | Exibição em terminal em tempo real com barra de progresso |
+| **Exportação de Métricas** | Métricas nos formatos JSON e Prometheus |
+| **Circuit Breaker Adaptativo** | 5 perfis com aprendizado por histórico |
+| **Monitor de Saúde** | Detecção de estagnação, espiral de erros e inchaço de contexto |
+| **Templates de DoD** | Templates pré-configurados para 8 tecnologias |
 
-## Circuit Breaker Adaptativo (v2.0)
+## Processo
 
-| Perfil | Palavras-chave | Sem Mud. | Erros | Max Iter |
-|--------|----------------|----------|-------|----------|
+### 1. Inicialização da Sessão
+
+1. **Verificar pré-requisitos**:
+   - Verificar se o Claude está disponível
+   - Verificar configuração `ralph.yml`
+   - Inicializar diretório da sessão (`.ralph/`)
+
+2. **Detecção automática do projeto** (se `--auto-detect`):
+   - Detectar tipo de projeto (Symfony, Flutter, React, Python, .NET, Go, Rust)
+   - Carregar o template de DoD adequado
+   - Configurar comandos de teste e lint
+
+3. **Carregar configuração**:
+   - Ler `ralph.yml` ou `.claude/ralph.yml`
+   - Definir máximo de iterações, timeouts e critérios de DoD
+   - Inicializar hooks se habilitados
+
+### 2. Loop Principal com Painel
+
+```
+╔═══════════════════════════════════════════════════════════════╗
+║  RALPH WIGGUM - Session: ralph-xxx           PHASE: GREEN     ║
+╠═══════════════════════════════════════════════════════════════╣
+║  ITERATION 8/25              ELAPSED: 12:34                   ║
+║  PROGRESS ████████████████░░░░░░░░░░░░░░░░░░░░░░░░░░░░  32%  ║
+║                                                               ║
+║  Circuit Breaker: ░░ (0/4)    Context: ████████░░ 78%        ║
+╚═══════════════════════════════════════════════════════════════╝
+```
+
+### 3. Validação da Definição de Pronto
+
+O sistema de DoD valida a conclusão por meio de múltiplos critérios:
+
+| Validador | Descrição |
+|-----------|-----------|
+| `command` | Executar comando shell (testes, lint, build) |
+| `output_contains` | Verificar padrão na saída do Claude |
+| `file_changed` | Verificar se arquivos foram modificados |
+| `hook` | Executar hook existente do Claude |
+| `human` | Validação humana interativa |
+
+### 4. Circuit Breaker Adaptativo (v2.0)
+
+Seleciona automaticamente o perfil com base nas palavras-chave da tarefa:
+
+| Perfil | Palavras-chave | Sem Mudanças | Erros | Máx. Iter. |
+|--------|----------------|--------------|-------|------------|
 | `quick_fix` | fix, bug, typo | 2 | 3 | 10 |
 | `small_feature` | add, implement | 3 | 4 | 15 |
 | `medium_feature` | feature, create | 4 | 6 | 25 |
 | `large_feature` | refactor, migrate | 5 | 8 | 50 |
 | `exploration` | explore, investigate | 10 | 15 | 100 |
 
-## Exemplos rapidos
+### 5. Integração de Hooks (Claude Code 2.1.23+)
 
-```bash
-# Uso basico
-ralph.sh "Implementar autenticacao de usuario"
-
-# Detectar e gerar config
-ralph.sh --auto-detect --init
-
-# Assistente interativo
-ralph.sh --interactive
+```
+SessionStart → session-restore.sh → Injetar contexto Ralph
+     ↓
+PreToolUse (uma vez) → status-injector.sh → Injetar status DoD
+     ↓
+Claude trabalha...
+     ↓
+Stop → stop-dod-gate.sh → Bloquear se DoD não satisfeito (exit 2)
 ```
 
-## Templates DoD por tecnologia
+## Exemplos de Início Rápido
 
-| Tecnologia | Comando Teste | Comando Lint |
-|------------|---------------|--------------|
+```bash
+# Uso básico
+ralph.sh "Implement user authentication"
+
+# Detectar projeto automaticamente e gerar config
+ralph.sh --auto-detect --init
+
+# Assistente de configuração interativo
+ralph.sh --interactive
+
+# Com arquivo de configuração
+ralph.sh --config=ralph.yml "Fix the login bug"
+
+# Retomar sessão
+ralph.sh --continue=ralph-1704067200-a1b2
+```
+
+## Configuração (v2.0)
+
+```yaml
+version: "2.0"
+
+# Integração de hooks
+hooks:
+  enabled: true
+  mode: "advanced"  # simple ou advanced
+
+# Detecção automática
+auto_detect:
+  enabled: true
+  interactive: false
+
+# Painel em tempo real
+dashboard:
+  enabled: true
+  mode: "full"  # simple, full, headless
+
+# Exportação de métricas
+metrics:
+  enabled: true
+  format: "both"  # json, prometheus, both
+
+# Monitoramento de saúde
+health_monitor:
+  enabled: true
+  patterns:
+    stall_detection: true
+    error_spiral: true
+    context_bloat: true
+
+# Circuit breaker adaptativo
+circuit_breaker:
+  adaptive: true
+  default_profile: "medium_feature"
+  learning:
+    enabled: true
+    min_samples: 5
+
+# Definição de Pronto
+definition_of_done:
+  checklist:
+    - id: tests
+      type: command
+      command: "docker compose exec app npm test"
+      required: true
+    - id: completion
+      type: output_contains
+      pattern: "<promise>COMPLETE</promise>"
+      required: true
+```
+
+## Templates de DoD por Tecnologia
+
+| Tecnologia | Comando de Teste | Comando de Lint |
+|------------|------------------|-----------------|
 | Symfony | `vendor/bin/phpunit` | `vendor/bin/phpstan analyse` |
 | Flutter | `flutter test` | `flutter analyze` |
 | React | `npm test` | `npm run lint` |
@@ -67,8 +185,94 @@ ralph.sh --interactive
 | Go | `go test ./...` | `golangci-lint run` |
 | Rust | `cargo test` | `cargo clippy` |
 
-## Relacionado
+## Saída
 
-- `@ralph-conductor` - Agente para orquestracao Ralph
-- `/qa:tdd` - Correcao de bugs com TDD
+```
+╔════════════════════════════════════════════════════════════╗
+║     🔁 Ralph Wiggum - Continuous AI Agent Loop v2.0        ║
+╚════════════════════════════════════════════════════════════╝
+
+✓ Detected: react-typescript (HIGH confidence)
+✓ Session created: ralph-1704067200-a1b2
+✓ Hooks initialized (advanced mode)
+
+ℹ Starting Ralph loop...
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+Iteration 1 of 25 (Profile: medium_feature)
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+ℹ Invoking Claude...
+ℹ Checking DoD criteria...
+  ✓ [tests] All tests pass - PASS
+  ✓ [lint] No lint errors - PASS
+  ✓ [completion] Claude signals completion - PASS
+
+  All required criteria passed!
+
+✓ DoD PASSED
+
+╔════════════════════════════════════════════════════════════╗
+║     📊 Session Summary                                      ║
+╚════════════════════════════════════════════════════════════╝
+
+  Session ID:        ralph-1704067200-a1b2
+  Profile:           medium_feature
+  Total iterations:  3
+  Duration:          45s
+  DoD status:        PASSED
+  Exit reason:       dod_complete
+  Metrics exported:  .ralph/sessions/.../metrics-export.json
+```
+
+## Modos de Falha e Recuperação
+
+### Falhas de Validação de DoD
+
+Quando os validadores de DoD falham repetidamente, o Ralph aplica recuperação progressiva:
+
+| Falhas Consecutivas | Ação |
+|--------------------|------|
+| 1-2 | Tentar novamente com contexto — Ralph inclui a saída de erro anterior |
+| 3 | Acionar verificação do circuit breaker — avaliar se a tarefa está travada |
+| 4+ | Circuit breaker ativado — sessão para com `exit_reason: circuit_breaker` |
+
+### Tratamento de Timeout
+
+| Tipo de Timeout | Padrão | Configuração |
+|----------------|---------|--------------|
+| Por iteração | 5 min | `circuit_breaker.iteration_timeout` |
+| Sessão total | 30 min | `circuit_breaker.session_timeout` |
+| Comando DoD | 60 seg | `definition_of_done.timeout` |
+
+Quando um timeout ocorre:
+1. A iteração atual é cancelada
+2. O progresso parcial é preservado no estado da sessão
+3. O contador do circuit breaker incrementa
+4. Retomar com `--continue=<session-id>` para tentar novamente
+
+### Razões de Saída Comuns
+
+| Razão de Saída | Significado | Recuperação |
+|----------------|-------------|-------------|
+| `dod_complete` | Todos os critérios de DoD passaram | Sucesso — nenhuma ação necessária |
+| `circuit_breaker` | Muitas falhas | Revisar escopo da tarefa, simplificar DoD |
+| `max_iterations` | Limite de iterações atingido | Aumentar o limite ou dividir em subtarefas |
+| `timeout` | Timeout da sessão expirado | Retomar ou aumentar o timeout |
+| `user_abort` | Usuário cancelou (Ctrl+C) | Retomar com `--continue` |
+
+## Boas Práticas
+
+1. **Usar detecção automática**: Deixar o Ralph configurar o DoD para sua stack
+2. **Descrição clara da tarefa**: Fornecer tarefas específicas e acionáveis
+3. **Usar TDD**: Escrever testes primeiro, deixar o Ralph implementar
+4. **Monitorar o painel**: Acompanhar o progresso em tempo real
+5. **Revisar métricas**: Analisar métricas da sessão para otimização
+6. **Definir timeouts realistas**: Adaptar os timeouts à complexidade da tarefa
+7. **Usar perfis do circuit breaker**: Combinar o perfil ao tipo de tarefa (quick_fix vs large_feature)
+
+## Relacionados
+
+- `@ralph-conductor` - Agente para orquestração Ralph
+- `/qa:tdd` - Correção de bugs baseada em TDD
 - `/sprint:dev` - Desenvolvimento de sprint com TDD

--- a/Dev/i18n/pt/Flutter/commands/analyze-performance.md
+++ b/Dev/i18n/pt/Flutter/commands/analyze-performance.md
@@ -1,76 +1,361 @@
 ---
-description: Analisar Performance do Aplicativo Flutter
+description: Análise de Performance Flutter
+argument-hint: [arguments]
 ---
 
-# Analisar Performance do Aplicativo Flutter
+# Análise de Performance Flutter
 
-Analise a performance do aplicativo Flutter, identifique gargalos de renderização, problemas de memória e oportunidades de otimização.
+Você é um especialista em performance Flutter. Você deve analisar o desempenho da aplicação, identificar problemas (jank, vazamentos de memória, rebuilds desnecessários) e propor otimizações.
 
-## Ações a Realizar
+## Argumentos
+$ARGUMENTS
 
-### 1. Análise de Renderização
+Argumentos:
+- (Opcional) Foco: rendering, memory, network, all
+
+Exemplo: `/flutter:analyze-performance rendering`
+
+## Plan Mode
+
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer uma investigação transversal.
+
+## MISSÃO
+
+### Etapa 1: Coleta de Métricas
 
 ```bash
 # Executar em modo profile
 flutter run --profile
 
-# No DevTools, verificar:
-# - Frame rendering time
-# - Rebuild Count
-# - Layer Count
+# DevTools
+flutter pub global activate devtools
+dart devtools
+
+# Analisar o código
+dart analyze --fatal-infos
 ```
 
-### 2. Análise de Memória
+### Etapa 2: Análise de Renderização
 
-```bash
-# Memory profiler no DevTools
-# Verificar:
-# - Memory leaks
-# - Heap snapshots
-# - Allocation tracking
+#### Identificar Rebuilds Desnecessários
+
+```dart
+// Adicionar no main.dart para debug
+import 'package:flutter/rendering.dart';
+
+void main() {
+  debugProfileBuildsEnabled = true;  // Log dos builds
+  debugPrintRebuildDirtyWidgets = true;  // Log dos rebuilds
+  runApp(const MyApp());
+}
 ```
 
-### 3. Verificar Otimização de Widgets
+#### Problemas Comuns e Soluções
 
-```bash
-# Buscar widgets sem const
-grep -r "Widget build" lib/ | grep -v "const"
+##### 1. Rebuilds em Cascata
 
-# Buscar ListView sem builder
-grep -r "ListView(" lib/ | grep -v "ListView.builder"
+```dart
+// ❌ BAD - Tudo reconstrói a cada mudança
+class ParentWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Consumer<MyModel>(
+      builder: (context, model, _) => Column(
+        children: [
+          HeaderWidget(title: model.title),
+          BodyWidget(items: model.items),
+          FooterWidget(), // Rebuild desnecessário!
+        ],
+      ),
+    );
+  }
+}
+
+// ✅ GOOD - Granularidade fina
+class ParentWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Selector<MyModel, String>(
+          selector: (_, model) => model.title,
+          builder: (_, title, __) => HeaderWidget(title: title),
+        ),
+        Selector<MyModel, List<Item>>(
+          selector: (_, model) => model.items,
+          builder: (_, items, __) => BodyWidget(items: items),
+        ),
+        const FooterWidget(), // const = sem rebuild
+      ],
+    );
+  }
+}
 ```
 
-### 4. Análise de Build
+##### 2. ListView Não Otimizada
 
-```bash
-# Analisar tamanho do bundle
-flutter build apk --analyze-size
-flutter build appbundle --analyze-size
+```dart
+// ❌ BAD - Cria todos os widgets de uma vez
+ListView(
+  children: items.map((item) => ItemWidget(item: item)).toList(),
+)
 
-# Web bundle
-flutter build web --source-maps
+// ✅ GOOD - Lazy loading
+ListView.builder(
+  itemCount: items.length,
+  itemBuilder: (context, index) => ItemWidget(item: items[index]),
+  // Otimizações adicionais
+  cacheExtent: 500, // Pré-renderização
+  addAutomaticKeepAlives: false, // Se não precisar manter o estado
+)
+
+// ✅ AINDA MELHOR - Com tamanho fixo
+ListView.builder(
+  itemCount: items.length,
+  itemExtent: 80, // Altura fixa = cálculo otimizado
+  itemBuilder: (context, index) => ItemWidget(item: items[index]),
+)
 ```
 
-## Modo Plano
+##### 3. Imagens Não Otimizadas
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+```dart
+// ❌ BAD
+Image.network(
+  'https://example.com/large_image.jpg',
+)
 
-## Relatório de Saída
+// ✅ GOOD - Com cache e redimensionamento
+CachedNetworkImage(
+  imageUrl: 'https://example.com/large_image.jpg',
+  cacheWidth: 300, // Redimensionamento em memória
+  cacheHeight: 300,
+  memCacheWidth: 300,
+  placeholder: (context, url) => const Shimmer(),
+  errorWidget: (context, url, error) => const Icon(Icons.error),
+)
+```
 
-Gere um relatório contendo:
+### Etapa 3: Análise de Memória
 
-1. **Problemas de Performance Identificados**
-   - Widgets não otimizados
-   - Rebuilds desnecessários
-   - Problemas de memória
+#### Detectar Vazamentos de Memória
 
-2. **Métricas**
-   - Tempo médio de frame
-   - Uso de memória
-   - Tamanho do app
+```dart
+// Verificar os dispose() ausentes
+class _MyWidgetState extends State<MyWidget> {
+  late StreamSubscription _subscription;
+  late AnimationController _controller;
+  Timer? _timer;
 
-3. **Recomendações**
-   - Adicionar const
-   - Usar builders
-   - RepaintBoundary onde necessário
-   - Otimização de imagens
+  @override
+  void initState() {
+    super.initState();
+    _subscription = stream.listen((_) {});
+    _controller = AnimationController(vsync: this);
+    _timer = Timer.periodic(Duration(seconds: 1), (_) {});
+  }
+
+  @override
+  void dispose() {
+    _subscription.cancel();  // ✅ Importante!
+    _controller.dispose();   // ✅ Importante!
+    _timer?.cancel();        // ✅ Importante!
+    super.dispose();
+  }
+}
+```
+
+#### Padrões Problemáticos
+
+```dart
+// ❌ BAD - Closure captura o context
+onPressed: () async {
+  await longOperation();
+  Navigator.of(context).pop(); // context pode ser inválido!
+}
+
+// ✅ GOOD - Verificar o mounted
+onPressed: () async {
+  await longOperation();
+  if (mounted) {
+    Navigator.of(context).pop();
+  }
+}
+```
+
+### Etapa 4: Otimizações Recomendadas
+
+#### Checklist de Otimização de Widgets
+
+```dart
+// 1. Usar const sempre que possível
+const MyWidget(); // ✅
+
+// 2. RepaintBoundary para partes custosas
+RepaintBoundary(
+  child: ExpensiveWidget(),
+)
+
+// 3. Separar os widgets que mudam com frequência
+class OptimizedWidget extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        const StaticHeader(),      // Nunca reconstrói
+        const AnimatedCounter(),   // Isolado
+        const StaticFooter(),      // Nunca reconstrói
+      ],
+    );
+  }
+}
+
+// 4. Evitar builds dentro de builds
+// ❌ BAD
+build(context) {
+  final items = generateItems(); // Chamado a cada build!
+  return ListView.builder(...);
+}
+
+// ✅ GOOD
+late final items = generateItems(); // Apenas uma vez
+
+// 5. Usar Keys corretamente
+ListView.builder(
+  itemBuilder: (context, index) => ItemWidget(
+    key: ValueKey(items[index].id), // Key estável
+    item: items[index],
+  ),
+)
+```
+
+### Etapa 5: Gerar o Relatório
+
+```
+══════════════════════════════════════════════════════════════
+📊 RELATÓRIO DE PERFORMANCE FLUTTER
+══════════════════════════════════════════════════════════════
+
+──────────────────────────────────────────────────────────────
+🎯 MÉTRICAS DE RENDERIZAÇÃO
+──────────────────────────────────────────────────────────────
+
+| Página  | Build Time | Raster Time | FPS | Status |
+|---------|------------|-------------|-----|--------|
+| Home    | 8ms        | 12ms        | 60  | ✅     |
+| List    | 45ms       | 35ms        | 45  | ⚠️     |
+| Detail  | 15ms       | 18ms        | 58  | ✅     |
+
+Limites:
+- Build < 16ms : ✅
+- Build > 16ms : ⚠️ Jank possível
+- Build > 32ms : ❌ Jank visível
+
+──────────────────────────────────────────────────────────────
+🧠 MÉTRICAS DE MEMÓRIA
+──────────────────────────────────────────────────────────────
+
+| Métrica        | Valor  | Limite   | Status |
+|----------------|--------|----------|--------|
+| Heap Used      | 85MB   | < 150MB  | ✅     |
+| Heap Capacity  | 120MB  | < 200MB  | ✅     |
+| External       | 25MB   | < 50MB   | ✅     |
+| RSS            | 180MB  | < 300MB  | ✅     |
+
+──────────────────────────────────────────────────────────────
+⚠️ PROBLEMAS DETECTADOS
+──────────────────────────────────────────────────────────────
+
+### Crítico
+1. **Rebuilds excessivos** - ProductListPage
+   - 150 rebuilds/seg detectados
+   - Causa: Provider no nível errado
+   - Correção: Usar Selector ou Consumer granular
+
+### Importante
+2. **ListView não otimizada** - OrderHistoryPage
+   - Sem itemExtent definido
+   - 500+ itens sem lazy loading
+   - Correção: ListView.builder com itemExtent
+
+3. **Imagens sem cache** - ProductCard
+   - Image.network sem cache
+   - Correção: Usar cached_network_image
+
+### Menor
+4. **Widgets não const** - AppBar customizada
+   - 5 widgets podem ser const
+   - Correção: Adicionar a palavra-chave const
+
+──────────────────────────────────────────────────────────────
+🔧 OTIMIZAÇÕES SUGERIDAS
+──────────────────────────────────────────────────────────────
+
+### 1. ProductListPage - Rebuilds (Impacto: Alto)
+```dart
+// Antes
+Consumer<CartModel>(
+  builder: (_, cart, __) => ProductList(cart: cart),
+)
+
+// Depois
+Selector<CartModel, int>(
+  selector: (_, cart) => cart.itemCount,
+  builder: (_, count, child) => child!,
+  child: const ProductList(),
+)
+```
+
+### 2. OrderHistoryPage - ListView (Impacto: Alto)
+```dart
+// Antes
+ListView(children: orders.map((o) => OrderTile(o)).toList())
+
+// Depois
+ListView.builder(
+  itemCount: orders.length,
+  itemExtent: 72,
+  itemBuilder: (_, i) => OrderTile(orders[i]),
+)
+```
+
+### 3. ProductCard - Imagens (Impacto: Médio)
+```dart
+// Antes
+Image.network(product.imageUrl)
+
+// Depois
+CachedNetworkImage(
+  imageUrl: product.imageUrl,
+  cacheWidth: 200,
+  memCacheWidth: 200,
+)
+```
+
+──────────────────────────────────────────────────────────────
+📈 IMPACTO ESTIMADO
+──────────────────────────────────────────────────────────────
+
+| Otimização               | Antes | Depois | Ganho |
+|--------------------------|-------|--------|-------|
+| ProductListPage FPS      | 45    | 60     | +33%  |
+| Memória de imagens       | 85MB  | 45MB   | -47%  |
+| Time to interactive      | 2.5s  | 1.8s   | -28%  |
+
+──────────────────────────────────────────────────────────────
+📋 COMANDOS ÚTEIS
+──────────────────────────────────────────────────────────────
+
+# Profiling
+flutter run --profile
+flutter analyze
+
+# DevTools
+flutter pub global activate devtools
+dart devtools
+
+# Performance overlay
+MaterialApp(
+  showPerformanceOverlay: true,
+)
+```

--- a/Dev/i18n/pt/Flutter/commands/check-compliance.md
+++ b/Dev/i18n/pt/Flutter/commands/check-compliance.md
@@ -1,48 +1,253 @@
 ---
-description: Verificar Conformidade com Padrões Flutter
+description: Verificar Conformidade Completa do Flutter
+argument-hint: [arguments]
 ---
 
-# Verificar Conformidade com Padrões Flutter
+# Verificar Conformidade Completa do Flutter
 
-Verifique se o projeto está em conformidade com os padrões e guidelines oficiais do Flutter e Dart.
+## Argumentos
 
-## Verificações
+$ARGUMENTS (opcional: caminho para o projeto a analisar)
 
-### 1. Effective Dart
+## Modo de Planejamento
 
-- [ ] Style guide seguido
-- [ ] Documentation presente
-- [ ] Usage guidelines respeitados
-- [ ] Design patterns apropriados
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
-### 2. Flutter Best Practices
+## MISSÃO
 
-- [ ] Widget composition adequada
-- [ ] Estado gerenciado corretamente
-- [ ] BuildContext usado apropriadamente
-- [ ] Keys usadas quando necessário
+Realizar uma auditoria de conformidade completa do projeto Flutter orquestrando as 4 verificações principais: Arquitetura, Qualidade de Código, Testes e Segurança. Produzir um relatório consolidado com uma pontuação geral de 100 pontos.
 
-### 3. Dependências
+### Etapa 1: Preparação da Auditoria
 
-```bash
-# Verificar dependências
-flutter pub outdated
+Preparar o ambiente de auditoria:
+- [ ] Identificar o caminho do projeto a auditar
+- [ ] Verificar a presença dos arquivos de configuração (pubspec.yaml, analysis_options.yaml)
+- [ ] Listar os diretórios principais (lib/, test/, android/, ios/, etc.)
+- [ ] Identificar a estrutura do projeto e a versão do Flutter
 
-# Verificar licenças
-flutter pub deps --json | jq '.packages[].license'
+**Nota**: Se $ARGUMENTS for fornecido, usá-lo como caminho do projeto; caso contrário, usar o diretório atual.
+
+### Etapa 2: Auditoria de Arquitetura (25 pontos)
+
+Executar a verificação completa de arquitetura:
+
+**Comando**: Usar o slash command `/flutter:check-architecture` ou seguir manualmente as etapas em `check-architecture.md`
+
+**Critérios Avaliados**:
+- Organização das camadas de Clean Architecture (6 pts)
+- Separação Domain/Data/Presentation (6 pts)
+- Injeção de dependências (get_it, injectable, riverpod) (4 pts)
+- Estrutura modular baseada em features (4 pts)
+- Princípios SOLID na arquitetura (3 pts)
+- Utilitários Core/Shared (2 pts)
+
+**Referência**: `check-architecture.md`
+
+### Etapa 3: Auditoria de Qualidade de Código (25 pontos)
+
+Executar a verificação de qualidade de código:
+
+**Comando**: Usar o slash command `/flutter:check-code-quality` ou seguir manualmente as etapas em `check-code-quality.md`
+
+**Critérios Avaliados**:
+- Convenções Effective Dart (5 pts)
+- Flutter analyze (zero avisos) (5 pts)
+- Rigor de linting e analysis_options (4 pts)
+- Princípios KISS/DRY/YAGNI (4 pts)
+- Documentação com comentários /// (4 pts)
+- Tratamento de erros (3 pts)
+
+**Referência**: `check-code-quality.md`
+
+### Etapa 4: Auditoria de Testes (25 pontos)
+
+Executar a verificação de testes:
+
+**Comando**: Usar o slash command `/flutter:check-testing` ou seguir manualmente as etapas em `check-testing.md`
+
+**Critérios Avaliados**:
+- Cobertura de código (7 pts)
+- Testes unitários para domain e data (6 pts)
+- Testes de widget para UI (4 pts)
+- Testes de integração (3 pts)
+- Qualidade dos testes e padrão AAA (3 pts)
+- Mocks (mockito/mocktail) e fixtures (2 pts)
+
+**Referência**: `check-testing.md`
+
+### Etapa 5: Auditoria de Segurança (25 pontos)
+
+Executar a verificação de segurança:
+
+**Comando**: Usar o slash command `/flutter:check-security` ou seguir manualmente as etapas em `check-security.md`
+
+**Critérios Avaliados**:
+- Segredos e credenciais hardcoded (6 pts)
+- Segurança de rede (HTTPS, SSL/TLS) (5 pts)
+- Armazenamento de dados sensíveis (flutter_secure_storage) (4 pts)
+- Vulnerabilidades de dependências (4 pts)
+- Permissões de plataforma (Android/iOS) (3 pts)
+- Validação de entrada (2 pts)
+- Ofuscação no release (1 pt)
+
+**Referência**: `check-security.md`
+
+### Etapa 6: Consolidação e Pontuação Global
+
+Calcular a pontuação geral e produzir o relatório consolidado:
+- [ ] Somar as 4 pontuações (máximo 100 pontos)
+- [ ] Identificar categorias críticas (<50%)
+- [ ] Listar todos os problemas transversais críticos
+- [ ] Priorizar ações por impacto/esforço
+- [ ] Produzir o relatório final consolidado
+
+**Escala de Avaliação**:
+- 90-100: Excelente - Projeto de referência
+- 75-89: Muito Bom - Pequenas melhorias necessárias
+- 60-74: Aceitável - Requer melhorias
+- 40-59: Insuficiente - Refatoração significativa necessária
+- 0-39: Crítico - Reformulação completa necessária
+
+### Etapa 7: Recomendações e Plano de Ação
+
+Produzir recomendações finais:
+- [ ] Identificar as 3 ações prioritárias em todas as categorias
+- [ ] Estimar esforço (Baixo/Médio/Alto) para cada ação
+- [ ] Estimar impacto (Baixo/Médio/Alto) para cada ação
+- [ ] Propor ordem de implementação
+- [ ] Sugerir quick wins (alta relação impacto/esforço)
+
+## FORMATO DE SAÍDA
+
+```
+AUDITORIA DE CONFORMIDADE FLUTTER - RELATÓRIO COMPLETO
+=============================================
+
+PONTUAÇÃO GERAL: XX/100
+
+NÍVEL DE CONFORMIDADE: [Excelente/Muito Bom/Aceitável/Insuficiente/Crítico]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PONTUAÇÕES POR CATEGORIA:
+
+ARQUITETURA        : XX/25  [██████████░░░░░░░░░░] XX%
+QUALIDADE DE CÓDIGO: XX/25  [██████████░░░░░░░░░░] XX%
+TESTES             : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURANÇA          : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PONTOS FORTES GERAIS:
+1. [Ponto forte identificado em múltiplas categorias]
+2. [Outro ponto forte importante]
+3. [Terceiro ponto forte]
+
+MELHORIAS GERAIS:
+1. [Melhoria transversal menor]
+2. [Outra melhoria recomendada]
+3. [Terceira melhoria]
+
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico #1 - categoria afetada]
+2. [Problema crítico #2 - categoria afetada]
+3. [Problema crítico #3 - categoria afetada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALHES POR CATEGORIA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITETURA (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Sub-pontuações:
+  • Camadas Clean Architecture   : XX/6
+  • Separação de camadas         : XX/6
+  • Injeção de dependências      : XX/4
+  • Módulos baseados em features : XX/4
+  • Princípios SOLID             : XX/3
+  • Utilitários Core/Shared      : XX/2
+
+Pontos Fortes:
+- [Pontos fortes de arquitetura]
+
+Problemas:
+- [Problemas de arquitetura]
+
+[Seções similares para Qualidade de Código, Testes e Segurança...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 AÇÕES PRIORITÁRIAS (TODAS AS CATEGORIAS):
+
+1. CRÍTICO - [Ação #1]
+   Categoria : [Arquitetura/Qualidade/Testes/Segurança]
+   Impacto   : [Alto/Médio/Baixo]
+   Esforço   : [Alto/Médio/Baixo]
+   Prioridade: IMEDIATA
+
+   Descrição detalhada:
+   [Explicação do problema e solução proposta]
+
+   Arquivos afetados:
+   - [arquivo:linha]
+
+   Exemplo de correção:
+   [Código ou comando de correção]
+
+2. IMPORTANTE - [Ação #2]
+   [Mesmo formato...]
+
+3. RECOMENDADO - [Ação #3]
+   [Mesmo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+QUICK WINS (Alto Impacto / Baixo Esforço):
+
+- [Quick win #1] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Quick win #2] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Quick win #3] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLANO DE AÇÃO RECOMENDADO:
+
+SEMANA 1 (Imediato):
+- [ ] [Ação crítica #1]
+- [ ] [Quick win prioritário]
+
+SEMANAS 2-4 (Curto prazo):
+- [ ] [Ação importante #2]
+- [ ] [Outros quick wins]
+
+MESES 2-3 (Médio prazo):
+- [ ] [Ação recomendada #3]
+- [ ] [Melhorias progressivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMO EXECUTIVO:
+
+[Parágrafo de resumo sobre o estado geral do projeto, pontos fortes
+principais, principais fraquezas e trajetória recomendada para melhorar
+a conformidade. Indicar se o projeto está pronto para produção,
+requer correções ou precisa de refatoração.]
+
+Recomendação Geral: [Pronto para produção / Correções menores /
+Refatoração significativa / Reformulação necessária]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 4. Configurações de Build
+## NOTAS IMPORTANTES
 
-- [ ] analysis_options.yaml presente e configurado
-- [ ] pubspec.yaml bem estruturado
-- [ ] README.md completo
-- [ ] CHANGELOG.md atualizado
-
-## Modo Plano
-
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
-
-## Relatório
-
-Gere checklist de conformidade indicando status de cada área.
+- Este comando orquestra as 4 auditorias especializadas
+- Usar Docker para todas as ferramentas de análise
+- Fornecer exemplos concretos com arquivo:linha para cada problema
+- Priorizar ações com base na matriz de Impacto/Esforço
+- Problemas de segurança são SEMPRE a prioridade máxima
+- Propor correções automatizáveis (scripts, pre-commit hooks)
+- O relatório deve ser acionável, não apenas descritivo
+- Adaptar as recomendações ao contexto de negócio do projeto

--- a/Dev/i18n/pt/Flutter/commands/generate-feature.md
+++ b/Dev/i18n/pt/Flutter/commands/generate-feature.md
@@ -1,69 +1,544 @@
 ---
-description: Gerar Nova Funcionalidade Flutter
+description: Geração de Feature Flutter Completa
+argument-hint: [arguments]
 ---
 
-# Gerar Nova Funcionalidade Flutter
+# Geração de Feature Flutter Completa
 
-Gere toda a estrutura necessária para uma nova funcionalidade seguindo Clean Architecture.
+Você é um desenvolvedor Flutter sênior. Você deve gerar uma feature completa seguindo a Clean Architecture com BLoC/Riverpod, incluindo todos os arquivos necessários e os testes.
 
-## Entrada Necessária
+## Argumentos
+$ARGUMENTS
 
-- Nome da funcionalidade (ex: "user_profile")
-- Camadas necessárias: [data, domain, presentation]
-- Tipo de gerenciamento de estado: [bloc, riverpod, provider]
+Argumentos:
+- Nome da feature (ex: `authentication`, `product_catalog`)
+- (Opcional) Gerenciamento de estado (bloc, riverpod, cubit)
 
-## Modo Plano
+Exemplo: `/flutter:generate-feature authentication riverpod`
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+## Plan Mode
 
-## Estrutura a Gerar
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
 
-```
-lib/features/{feature_name}/
-  data/
-    datasources/
-      {feature}_local_datasource.dart
-      {feature}_remote_datasource.dart
-    models/
-      {feature}_model.dart
-    repositories/
-      {feature}_repository_impl.dart
-  domain/
-    entities/
-      {feature}.dart
-    repositories/
-      {feature}_repository.dart
-    usecases/
-      get_{feature}.dart
-  presentation/
-    bloc/
-      {feature}_bloc.dart
-      {feature}_event.dart
-      {feature}_state.dart
-    pages/
-      {feature}_page.dart
-    widgets/
-      {feature}_widget.dart
-```
+## MISSÃO
 
-## Testes a Gerar
+### Etapa 1: Estrutura da Feature
 
 ```
-test/features/{feature_name}/
-  data/
-    models/{feature}_model_test.dart
-    repositories/{feature}_repository_impl_test.dart
-  domain/
-    usecases/get_{feature}_test.dart
-  presentation/
-    bloc/{feature}_bloc_test.dart
-    widgets/{feature}_widget_test.dart
+lib/
+└── features/
+    └── {feature}/
+        ├── data/
+        │   ├── datasources/
+        │   │   ├── {feature}_local_datasource.dart
+        │   │   └── {feature}_remote_datasource.dart
+        │   ├── models/
+        │   │   └── {feature}_model.dart
+        │   └── repositories/
+        │       └── {feature}_repository_impl.dart
+        ├── domain/
+        │   ├── entities/
+        │   │   └── {feature}_entity.dart
+        │   ├── repositories/
+        │   │   └── {feature}_repository.dart
+        │   └── usecases/
+        │       ├── get_{feature}.dart
+        │       └── create_{feature}.dart
+        └── presentation/
+            ├── bloc/ (ou providers/)
+            │   ├── {feature}_bloc.dart
+            │   ├── {feature}_event.dart
+            │   └── {feature}_state.dart
+            ├── pages/
+            │   ├── {feature}_page.dart
+            │   └── {feature}_detail_page.dart
+            └── widgets/
+                ├── {feature}_list_item.dart
+                └── {feature}_form.dart
+
+test/
+└── features/
+    └── {feature}/
+        ├── data/
+        │   └── repositories/
+        │       └── {feature}_repository_impl_test.dart
+        ├── domain/
+        │   └── usecases/
+        │       └── get_{feature}_test.dart
+        └── presentation/
+            ├── bloc/
+            │   └── {feature}_bloc_test.dart
+            └── pages/
+                └── {feature}_page_test.dart
 ```
 
-## Ações
+### Etapa 2: Camada de Domínio
 
-1. Criar estrutura de pastas
-2. Gerar arquivos com templates
-3. Configurar injeção de dependências
-4. Adicionar ao roteamento se necessário
-5. Criar testes básicos
+#### Entidade
+```dart
+// lib/features/{feature}/domain/entities/{feature}_entity.dart
+import 'package:equatable/equatable.dart';
+
+class {Feature}Entity extends Equatable {
+  final String id;
+  final String name;
+  final String? description;
+  final DateTime createdAt;
+  final DateTime? updatedAt;
+
+  const {Feature}Entity({
+    required this.id,
+    required this.name,
+    this.description,
+    required this.createdAt,
+    this.updatedAt,
+  });
+
+  @override
+  List<Object?> get props => [id, name, description, createdAt, updatedAt];
+
+  {Feature}Entity copyWith({
+    String? id,
+    String? name,
+    String? description,
+    DateTime? createdAt,
+    DateTime? updatedAt,
+  }) {
+    return {Feature}Entity(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      description: description ?? this.description,
+      createdAt: createdAt ?? this.createdAt,
+      updatedAt: updatedAt ?? this.updatedAt,
+    );
+  }
+}
+```
+
+#### Interface do Repositório
+```dart
+// lib/features/{feature}/domain/repositories/{feature}_repository.dart
+import 'package:dartz/dartz.dart';
+import '../entities/{feature}_entity.dart';
+import '../../../../core/error/failures.dart';
+
+abstract class {Feature}Repository {
+  Future<Either<Failure, List<{Feature}Entity>>> getAll();
+  Future<Either<Failure, {Feature}Entity>> getById(String id);
+  Future<Either<Failure, {Feature}Entity>> create({Feature}Entity entity);
+  Future<Either<Failure, {Feature}Entity>> update({Feature}Entity entity);
+  Future<Either<Failure, void>> delete(String id);
+}
+```
+
+#### Casos de Uso
+```dart
+// lib/features/{feature}/domain/usecases/get_{feature}_list.dart
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/usecases/usecase.dart';
+import '../entities/{feature}_entity.dart';
+import '../repositories/{feature}_repository.dart';
+
+class Get{Feature}List implements UseCase<List<{Feature}Entity>, NoParams> {
+  final {Feature}Repository repository;
+
+  Get{Feature}List(this.repository);
+
+  @override
+  Future<Either<Failure, List<{Feature}Entity>>> call(NoParams params) {
+    return repository.getAll();
+  }
+}
+```
+
+### Etapa 3: Camada de Dados
+
+#### Modelo
+```dart
+// lib/features/{feature}/data/models/{feature}_model.dart
+import '../../domain/entities/{feature}_entity.dart';
+
+class {Feature}Model extends {Feature}Entity {
+  const {Feature}Model({
+    required super.id,
+    required super.name,
+    super.description,
+    required super.createdAt,
+    super.updatedAt,
+  });
+
+  factory {Feature}Model.fromJson(Map<String, dynamic> json) {
+    return {Feature}Model(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      description: json['description'] as String?,
+      createdAt: DateTime.parse(json['created_at'] as String),
+      updatedAt: json['updated_at'] != null
+          ? DateTime.parse(json['updated_at'] as String)
+          : null,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'description': description,
+      'created_at': createdAt.toIso8601String(),
+      'updated_at': updatedAt?.toIso8601String(),
+    };
+  }
+
+  factory {Feature}Model.fromEntity({Feature}Entity entity) {
+    return {Feature}Model(
+      id: entity.id,
+      name: entity.name,
+      description: entity.description,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+    );
+  }
+}
+```
+
+#### Implementação do Repositório
+```dart
+// lib/features/{feature}/data/repositories/{feature}_repository_impl.dart
+import 'package:dartz/dartz.dart';
+import '../../../../core/error/exceptions.dart';
+import '../../../../core/error/failures.dart';
+import '../../../../core/network/network_info.dart';
+import '../../domain/entities/{feature}_entity.dart';
+import '../../domain/repositories/{feature}_repository.dart';
+import '../datasources/{feature}_local_datasource.dart';
+import '../datasources/{feature}_remote_datasource.dart';
+import '../models/{feature}_model.dart';
+
+class {Feature}RepositoryImpl implements {Feature}Repository {
+  final {Feature}RemoteDataSource remoteDataSource;
+  final {Feature}LocalDataSource localDataSource;
+  final NetworkInfo networkInfo;
+
+  {Feature}RepositoryImpl({
+    required this.remoteDataSource,
+    required this.localDataSource,
+    required this.networkInfo,
+  });
+
+  @override
+  Future<Either<Failure, List<{Feature}Entity>>> getAll() async {
+    if (await networkInfo.isConnected) {
+      try {
+        final remoteData = await remoteDataSource.getAll();
+        await localDataSource.cacheAll(remoteData);
+        return Right(remoteData);
+      } on ServerException {
+        return Left(ServerFailure());
+      }
+    } else {
+      try {
+        final localData = await localDataSource.getAll();
+        return Right(localData);
+      } on CacheException {
+        return Left(CacheFailure());
+      }
+    }
+  }
+
+  // Outros métodos...
+}
+```
+
+### Etapa 4: Camada de Apresentação (BLoC)
+
+#### BLoC
+```dart
+// lib/features/{feature}/presentation/bloc/{feature}_bloc.dart
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import '../../domain/entities/{feature}_entity.dart';
+import '../../domain/usecases/get_{feature}_list.dart';
+import '../../../../core/usecases/usecase.dart';
+
+part '{feature}_event.dart';
+part '{feature}_state.dart';
+
+class {Feature}Bloc extends Bloc<{Feature}Event, {Feature}State> {
+  final Get{Feature}List get{Feature}List;
+
+  {Feature}Bloc({required this.get{Feature}List}) : super(const {Feature}Initial()) {
+    on<Load{Feature}List>(_onLoad{Feature}List);
+    on<Refresh{Feature}List>(_onRefresh{Feature}List);
+  }
+
+  Future<void> _onLoad{Feature}List(
+    Load{Feature}List event,
+    Emitter<{Feature}State> emit,
+  ) async {
+    emit(const {Feature}Loading());
+
+    final result = await get{Feature}List(NoParams());
+
+    result.fold(
+      (failure) => emit({Feature}Error(message: failure.message)),
+      (data) => emit({Feature}Loaded(items: data)),
+    );
+  }
+
+  Future<void> _onRefresh{Feature}List(
+    Refresh{Feature}List event,
+    Emitter<{Feature}State> emit,
+  ) async {
+    final result = await get{Feature}List(NoParams());
+
+    result.fold(
+      (failure) => emit({Feature}Error(message: failure.message)),
+      (data) => emit({Feature}Loaded(items: data)),
+    );
+  }
+}
+```
+
+#### Eventos
+```dart
+// lib/features/{feature}/presentation/bloc/{feature}_event.dart
+part of '{feature}_bloc.dart';
+
+abstract class {Feature}Event extends Equatable {
+  const {Feature}Event();
+
+  @override
+  List<Object> get props => [];
+}
+
+class Load{Feature}List extends {Feature}Event {
+  const Load{Feature}List();
+}
+
+class Refresh{Feature}List extends {Feature}Event {
+  const Refresh{Feature}List();
+}
+```
+
+#### Estados
+```dart
+// lib/features/{feature}/presentation/bloc/{feature}_state.dart
+part of '{feature}_bloc.dart';
+
+abstract class {Feature}State extends Equatable {
+  const {Feature}State();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class {Feature}Initial extends {Feature}State {
+  const {Feature}Initial();
+}
+
+class {Feature}Loading extends {Feature}State {
+  const {Feature}Loading();
+}
+
+class {Feature}Loaded extends {Feature}State {
+  final List<{Feature}Entity> items;
+
+  const {Feature}Loaded({required this.items});
+
+  @override
+  List<Object?> get props => [items];
+}
+
+class {Feature}Error extends {Feature}State {
+  final String message;
+
+  const {Feature}Error({required this.message});
+
+  @override
+  List<Object?> get props => [message];
+}
+```
+
+### Etapa 5: Página
+
+```dart
+// lib/features/{feature}/presentation/pages/{feature}_page.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../bloc/{feature}_bloc.dart';
+import '../widgets/{feature}_list_item.dart';
+
+class {Feature}Page extends StatelessWidget {
+  const {Feature}Page({super.key});
+
+  static const routeName = '/{feature}';
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('{Feature}'),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.refresh),
+            onPressed: () {
+              context.read<{Feature}Bloc>().add(const Refresh{Feature}List());
+            },
+          ),
+        ],
+      ),
+      body: BlocBuilder<{Feature}Bloc, {Feature}State>(
+        builder: (context, state) {
+          return switch (state) {
+            {Feature}Initial() => const Center(
+                child: Text('Pressione refresh'),
+              ),
+            {Feature}Loading() => const Center(
+                child: CircularProgressIndicator(),
+              ),
+            {Feature}Loaded(:final items) => items.isEmpty
+                ? const Center(child: Text('Nenhum item'))
+                : RefreshIndicator(
+                    onRefresh: () async {
+                      context
+                          .read<{Feature}Bloc>()
+                          .add(const Refresh{Feature}List());
+                    },
+                    child: ListView.builder(
+                      itemCount: items.length,
+                      itemBuilder: (context, index) {
+                        return {Feature}ListItem(item: items[index]);
+                      },
+                    ),
+                  ),
+            {Feature}Error(:final message) => Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    Text('Erro: $message'),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () {
+                        context
+                            .read<{Feature}Bloc>()
+                            .add(const Load{Feature}List());
+                      },
+                      child: const Text('Tentar novamente'),
+                    ),
+                  ],
+                ),
+              ),
+          };
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          // Navegação para criação
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}
+```
+
+### Etapa 6: Testes
+
+```dart
+// test/features/{feature}/presentation/bloc/{feature}_bloc_test.dart
+import 'package:bloc_test/bloc_test.dart';
+import 'package:dartz/dartz.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+class MockGet{Feature}List extends Mock implements Get{Feature}List {}
+
+void main() {
+  late {Feature}Bloc bloc;
+  late MockGet{Feature}List mockGet{Feature}List;
+
+  setUp(() {
+    mockGet{Feature}List = MockGet{Feature}List();
+    bloc = {Feature}Bloc(get{Feature}List: mockGet{Feature}List);
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  test('initial state should be {Feature}Initial', () {
+    expect(bloc.state, const {Feature}Initial());
+  });
+
+  blocTest<{Feature}Bloc, {Feature}State>(
+    'emits [Loading, Loaded] when Load{Feature}List is added successfully',
+    build: () {
+      when(() => mockGet{Feature}List(any()))
+          .thenAnswer((_) async => const Right([]));
+      return bloc;
+    },
+    act: (bloc) => bloc.add(const Load{Feature}List()),
+    expect: () => [
+      const {Feature}Loading(),
+      const {Feature}Loaded(items: []),
+    ],
+  );
+
+  blocTest<{Feature}Bloc, {Feature}State>(
+    'emits [Loading, Error] when Load{Feature}List fails',
+    build: () {
+      when(() => mockGet{Feature}List(any()))
+          .thenAnswer((_) async => Left(ServerFailure()));
+      return bloc;
+    },
+    act: (bloc) => bloc.add(const Load{Feature}List()),
+    expect: () => [
+      const {Feature}Loading(),
+      isA<{Feature}Error>(),
+    ],
+  );
+}
+```
+
+### Etapa 7: Resumo
+
+```
+══════════════════════════════════════════════════════════════
+✅ FEATURE GERADA - {feature}
+══════════════════════════════════════════════════════════════
+
+📁 Arquivos criados:
+
+Camada de Domínio (4 arquivos):
+- lib/features/{feature}/domain/entities/{feature}_entity.dart
+- lib/features/{feature}/domain/repositories/{feature}_repository.dart
+- lib/features/{feature}/domain/usecases/get_{feature}_list.dart
+- lib/features/{feature}/domain/usecases/create_{feature}.dart
+
+Camada de Dados (4 arquivos):
+- lib/features/{feature}/data/models/{feature}_model.dart
+- lib/features/{feature}/data/repositories/{feature}_repository_impl.dart
+- lib/features/{feature}/data/datasources/{feature}_remote_datasource.dart
+- lib/features/{feature}/data/datasources/{feature}_local_datasource.dart
+
+Camada de Apresentação (6 arquivos):
+- lib/features/{feature}/presentation/bloc/{feature}_bloc.dart
+- lib/features/{feature}/presentation/bloc/{feature}_event.dart
+- lib/features/{feature}/presentation/bloc/{feature}_state.dart
+- lib/features/{feature}/presentation/pages/{feature}_page.dart
+- lib/features/{feature}/presentation/widgets/{feature}_list_item.dart
+- lib/features/{feature}/presentation/widgets/{feature}_form.dart
+
+Testes (4 arquivos):
+- test/features/{feature}/domain/usecases/get_{feature}_list_test.dart
+- test/features/{feature}/data/repositories/{feature}_repository_impl_test.dart
+- test/features/{feature}/presentation/bloc/{feature}_bloc_test.dart
+- test/features/{feature}/presentation/pages/{feature}_page_test.dart
+
+🔧 Próximas etapas:
+1. Configurar a injeção de dependências (get_it/riverpod)
+2. Adicionar as rotas
+3. Implementar os datasources
+4. Executar os testes: flutter test
+```

--- a/Dev/i18n/pt/Flutter/commands/generate-widget.md
+++ b/Dev/i18n/pt/Flutter/commands/generate-widget.md
@@ -1,73 +1,561 @@
 ---
-description: Gerar Widget Flutter
+description: Geração de Widget Flutter com Testes
+argument-hint: [arguments]
 ---
 
-# Gerar Widget Flutter
+# Geração de Widget Flutter com Testes
 
-Gere um widget Flutter com testes e documentação.
+Você é um desenvolvedor Flutter sênior. Você deve gerar um widget reutilizável com documentação, testes unitários e widget tests.
 
-## Entrada
+## Argumentos
+$ARGUMENTS
 
-- Nome do widget (ex: "CustomButton")
-- Tipo: [stateless, stateful, consumer]
-- Localização: lib/features/{feature}/presentation/widgets/
+Argumentos:
+- Nome do widget (ex: `CustomButton`, `UserCard`)
+- (Opcional) Tipo (stateless, stateful, hook)
 
-## Modo Plano
+Exemplo: `/flutter:generate-widget UserCard stateless`
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+## Plan Mode
 
-## Gerar
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
 
-### 1. Widget
+## MISSÃO
 
+### Etapa 1: Criar o Widget
+
+#### StatelessWidget
 ```dart
-// lib/.../widgets/{widget_name}.dart
+// lib/shared/widgets/{widget_name}.dart
 import 'package:flutter/material.dart';
 
-/// Descrição do widget
+/// Um widget que exibe {description}.
+///
+/// Exemplo de uso:
+/// ```dart
+/// {WidgetName}(
+///   title: 'Meu título',
+///   onTap: () => print('Tapped'),
+/// )
+/// ```
 class {WidgetName} extends StatelessWidget {
+  /// O título exibido no widget.
+  final String title;
+
+  /// O subtítulo opcional.
+  final String? subtitle;
+
+  /// O ícone exibido à esquerda.
+  final IconData? leadingIcon;
+
+  /// Callback chamado ao tocar.
+  final VoidCallback? onTap;
+
+  /// Indica se o widget está habilitado.
+  final bool isEnabled;
+
+  /// Cria um novo [{WidgetName}].
   const {WidgetName}({
     super.key,
-    required this.param1,
+    required this.title,
+    this.subtitle,
+    this.leadingIcon,
+    this.onTap,
+    this.isEnabled = true,
   });
-
-  final Type param1;
 
   @override
   Widget build(BuildContext context) {
-    return Container();
+    final theme = Theme.of(context);
+
+    return Semantics(
+      button: onTap != null,
+      enabled: isEnabled,
+      child: Material(
+        color: Colors.transparent,
+        child: InkWell(
+          onTap: isEnabled ? onTap : null,
+          borderRadius: BorderRadius.circular(12),
+          child: Container(
+            padding: const EdgeInsets.all(16),
+            decoration: BoxDecoration(
+              color: theme.cardColor,
+              borderRadius: BorderRadius.circular(12),
+              boxShadow: [
+                BoxShadow(
+                  color: Colors.black.withOpacity(0.05),
+                  blurRadius: 10,
+                  offset: const Offset(0, 2),
+                ),
+              ],
+            ),
+            child: Row(
+              children: [
+                if (leadingIcon != null) ...[
+                  Icon(
+                    leadingIcon,
+                    color: isEnabled
+                        ? theme.colorScheme.primary
+                        : theme.disabledColor,
+                  ),
+                  const SizedBox(width: 12),
+                ],
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        title,
+                        style: theme.textTheme.titleMedium?.copyWith(
+                          color: isEnabled ? null : theme.disabledColor,
+                        ),
+                      ),
+                      if (subtitle != null) ...[
+                        const SizedBox(height: 4),
+                        Text(
+                          subtitle!,
+                          style: theme.textTheme.bodySmall?.copyWith(
+                            color: theme.textTheme.bodySmall?.color
+                                ?.withOpacity(0.7),
+                          ),
+                        ),
+                      ],
+                    ],
+                  ),
+                ),
+                if (onTap != null)
+                  Icon(
+                    Icons.chevron_right,
+                    color: isEnabled
+                        ? theme.colorScheme.onSurface.withOpacity(0.5)
+                        : theme.disabledColor,
+                  ),
+              ],
+            ),
+          ),
+        ),
+      ),
+    );
   }
 }
 ```
 
-### 2. Teste de Widget
-
+#### StatefulWidget (com animação)
 ```dart
-// test/.../widgets/{widget_name}_test.dart
+// lib/shared/widgets/{widget_name}.dart
+import 'package:flutter/material.dart';
+
+class {WidgetName} extends StatefulWidget {
+  final String title;
+  final bool isExpanded;
+  final Widget child;
+  final ValueChanged<bool>? onExpansionChanged;
+
+  const {WidgetName}({
+    super.key,
+    required this.title,
+    this.isExpanded = false,
+    required this.child,
+    this.onExpansionChanged,
+  });
+
+  @override
+  State<{WidgetName}> createState() => _{WidgetName}State();
+}
+
+class _{WidgetName}State extends State<{WidgetName}>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _heightFactor;
+  late Animation<double> _iconTurns;
+
+  bool _isExpanded = false;
+
+  @override
+  void initState() {
+    super.initState();
+    _isExpanded = widget.isExpanded;
+
+    _controller = AnimationController(
+      duration: const Duration(milliseconds: 200),
+      vsync: this,
+    );
+
+    _heightFactor = _controller.drive(CurveTween(curve: Curves.easeIn));
+    _iconTurns = _controller.drive(
+      Tween<double>(begin: 0.0, end: 0.5).chain(
+        CurveTween(curve: Curves.easeIn),
+      ),
+    );
+
+    if (_isExpanded) {
+      _controller.value = 1.0;
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  void _handleTap() {
+    setState(() {
+      _isExpanded = !_isExpanded;
+      if (_isExpanded) {
+        _controller.forward();
+      } else {
+        _controller.reverse();
+      }
+      widget.onExpansionChanged?.call(_isExpanded);
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return AnimatedBuilder(
+      animation: _controller,
+      builder: (context, child) {
+        return Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            InkWell(
+              onTap: _handleTap,
+              child: Padding(
+                padding: const EdgeInsets.all(16),
+                child: Row(
+                  children: [
+                    Expanded(
+                      child: Text(
+                        widget.title,
+                        style: theme.textTheme.titleMedium,
+                      ),
+                    ),
+                    RotationTransition(
+                      turns: _iconTurns,
+                      child: const Icon(Icons.expand_more),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+            ClipRect(
+              child: Align(
+                heightFactor: _heightFactor.value,
+                child: child,
+              ),
+            ),
+          ],
+        );
+      },
+      child: widget.child,
+    );
+  }
+}
+```
+
+### Etapa 2: Testes
+
+#### Widget Test
+```dart
+// test/shared/widgets/{widget_name}_test.dart
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:app/shared/widgets/{widget_name}.dart';
 
 void main() {
   group('{WidgetName}', () {
-    testWidgets('should render correctly', (tester) async {
+    testWidgets('renders correctly with required props', (tester) async {
       await tester.pumpWidget(
-        MaterialApp(
+        const MaterialApp(
           home: Scaffold(
-            body: {WidgetName}(param1: testValue),
+            body: {WidgetName}(
+              title: 'Test Title',
+            ),
           ),
         ),
       );
 
-      expect(find.byType({WidgetName}), findsOneWidget);
+      expect(find.text('Test Title'), findsOneWidget);
+    });
+
+    testWidgets('renders subtitle when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: {WidgetName}(
+              title: 'Test Title',
+              subtitle: 'Test Subtitle',
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Test Subtitle'), findsOneWidget);
+    });
+
+    testWidgets('renders leading icon when provided', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: {WidgetName}(
+              title: 'Test Title',
+              leadingIcon: Icons.person,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byIcon(Icons.person), findsOneWidget);
+    });
+
+    testWidgets('calls onTap when tapped', (tester) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: {WidgetName}(
+              title: 'Test Title',
+              onTap: () => tapped = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType({WidgetName}));
+      await tester.pump();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('does not call onTap when disabled', (tester) async {
+      var tapped = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: {WidgetName}(
+              title: 'Test Title',
+              onTap: () => tapped = true,
+              isEnabled: false,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType({WidgetName}));
+      await tester.pump();
+
+      expect(tapped, isFalse);
+    });
+
+    testWidgets('has correct semantics', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: {WidgetName}(
+              title: 'Test Title',
+              onTap: () {},
+            ),
+          ),
+        ),
+      );
+
+      final semantics = tester.getSemantics(find.byType({WidgetName}));
+      expect(semantics.hasFlag(SemanticsFlag.isButton), isTrue);
+      expect(semantics.hasFlag(SemanticsFlag.isEnabled), isTrue);
+    });
+
+    testWidgets('applies theme correctly', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.light(),
+          home: const Scaffold(
+            body: {WidgetName}(
+              title: 'Test Title',
+            ),
+          ),
+        ),
+      );
+
+      // Verificar que o widget utiliza as cores do tema
+      final container = tester.widget<Container>(
+        find.descendant(
+          of: find.byType({WidgetName}),
+          matching: find.byType(Container),
+        ).first,
+      );
+
+      expect(container.decoration, isNotNull);
+    });
+  });
+
+  group('{WidgetName} Golden Tests', () {
+    testWidgets('matches golden - light theme', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.light(),
+          home: const Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 300,
+                child: {WidgetName}(
+                  title: 'Test Title',
+                  subtitle: 'Test Subtitle',
+                  leadingIcon: Icons.person,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await expectLater(
+        find.byType({WidgetName}),
+        matchesGoldenFile('goldens/{widget_name}_light.png'),
+      );
+    });
+
+    testWidgets('matches golden - dark theme', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: ThemeData.dark(),
+          home: const Scaffold(
+            body: Center(
+              child: SizedBox(
+                width: 300,
+                child: {WidgetName}(
+                  title: 'Test Title',
+                  subtitle: 'Test Subtitle',
+                  leadingIcon: Icons.person,
+                ),
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await expectLater(
+        find.byType({WidgetName}),
+        matchesGoldenFile('goldens/{widget_name}_dark.png'),
+      );
     });
   });
 }
 ```
 
-## Verificar
+### Etapa 3: Exportação
 
-- [ ] Widget criado
-- [ ] Teste criado
-- [ ] Documentação presente
-- [ ] Const constructor se stateless
-- [ ] Teste passa
+```dart
+// lib/shared/widgets/widgets.dart
+export '{widget_name}.dart';
+// Adicionar os outros widgets...
+```
+
+### Etapa 4: Documentação Storybook (opcional)
+
+```dart
+// lib/shared/widgets/{widget_name}_stories.dart
+import 'package:flutter/material.dart';
+import '{widget_name}.dart';
+
+class {WidgetName}Stories extends StatelessWidget {
+  const {WidgetName}Stories({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('{WidgetName} Stories')),
+      body: ListView(
+        padding: const EdgeInsets.all(16),
+        children: [
+          _buildStory(
+            'Default',
+            const {WidgetName}(title: 'Default Title'),
+          ),
+          _buildStory(
+            'With Subtitle',
+            const {WidgetName}(
+              title: 'With Subtitle',
+              subtitle: 'This is a subtitle',
+            ),
+          ),
+          _buildStory(
+            'With Icon',
+            const {WidgetName}(
+              title: 'With Icon',
+              leadingIcon: Icons.star,
+            ),
+          ),
+          _buildStory(
+            'Disabled',
+            const {WidgetName}(
+              title: 'Disabled',
+              isEnabled: false,
+            ),
+          ),
+          _buildStory(
+            'Full Example',
+            {WidgetName}(
+              title: 'Full Example',
+              subtitle: 'All props enabled',
+              leadingIcon: Icons.person,
+              onTap: () {},
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildStory(String name, Widget widget) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text(
+          name,
+          style: const TextStyle(
+            fontSize: 12,
+            fontWeight: FontWeight.bold,
+            color: Colors.grey,
+          ),
+        ),
+        const SizedBox(height: 8),
+        widget,
+        const SizedBox(height: 24),
+      ],
+    );
+  }
+}
+```
+
+### Resumo
+
+```
+══════════════════════════════════════════════════════════════
+✅ WIDGET GERADO - {WidgetName}
+══════════════════════════════════════════════════════════════
+
+📁 Arquivos criados:
+- lib/shared/widgets/{widget_name}.dart
+- test/shared/widgets/{widget_name}_test.dart
+- test/shared/widgets/goldens/{widget_name}_light.png (a gerar)
+- test/shared/widgets/goldens/{widget_name}_dark.png (a gerar)
+
+🔧 Comandos úteis:
+# Executar os testes
+flutter test test/shared/widgets/{widget_name}_test.dart
+
+# Atualizar os golden tests
+flutter test --update-goldens
+
+📖 Props disponíveis:
+- title (String, required)
+- subtitle (String?)
+- leadingIcon (IconData?)
+- onTap (VoidCallback?)
+- isEnabled (bool, default: true)
+```

--- a/Dev/i18n/pt/Flutter/commands/golden-update.md
+++ b/Dev/i18n/pt/Flutter/commands/golden-update.md
@@ -1,85 +1,361 @@
 ---
-description: Atualizar Golden Tests
+description: Atualização dos Golden Tests
+argument-hint: [arguments]
 ---
 
-# Atualizar Golden Tests
+# Atualização dos Golden Tests
 
-Atualize os arquivos golden (screenshots de referência) para testes visuais de widgets.
+Você é um desenvolvedor Flutter sênior. Você deve gerenciar os golden tests do projeto, atualizá-los após mudanças visuais intencionais e verificar regressões.
 
-## Uso
+## Argumentos
+$ARGUMENTS
+
+Argumentos:
+- Ação: update, check, compare
+- (Opcional) Caminho para um teste específico
+
+Exemplo: `/flutter:golden-update update` ou `/flutter:golden-update check test/widgets/button_test.dart`
+
+## Modo de Planejamento
+
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar a sua validação antes de realizar qualquer alteração.
+
+## MISSÃO
+
+### Etapa 1: Compreender os Golden Tests
+
+Os golden tests comparam o renderizado visual de um widget com uma imagem de referência.
+
+```dart
+// test/widgets/my_button_test.dart
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:my_app/widgets/my_button.dart';
+
+void main() {
+  group('MyButton Golden Tests', () {
+    testWidgets('estado padrão', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: MyButton(label: 'Clique aqui'),
+            ),
+          ),
+        ),
+      );
+
+      await expectLater(
+        find.byType(MyButton),
+        matchesGoldenFile('goldens/my_button_default.png'),
+      );
+    });
+
+    testWidgets('estado pressionado', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: MyButton(
+                label: 'Clique aqui',
+                isPressed: true,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await expectLater(
+        find.byType(MyButton),
+        matchesGoldenFile('goldens/my_button_pressed.png'),
+      );
+    });
+
+    testWidgets('estado desabilitado', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: Center(
+              child: MyButton(
+                label: 'Clique aqui',
+                isEnabled: false,
+              ),
+            ),
+          ),
+        ),
+      );
+
+      await expectLater(
+        find.byType(MyButton),
+        matchesGoldenFile('goldens/my_button_disabled.png'),
+      );
+    });
+  });
+}
+```
+
+### Etapa 2: Comandos Básicos
 
 ```bash
-# Atualizar todos os goldens
+# Verificar os golden tests (comparar com as referências)
+flutter test --tags=golden
+
+# Atualizar TODOS os golden tests
 flutter test --update-goldens
 
-# Atualizar goldens específicos
-flutter test test/golden/ --update-goldens
+# Atualizar um teste específico
+flutter test --update-goldens test/widgets/my_button_test.dart
 
-# Executar apenas golden tests
-flutter test --tags=golden
+# Executar com um device específico (importante para consistência)
+flutter test --update-goldens --device-id=linux
+
+# Ignorar os golden tests no CI (se necessário)
+flutter test --exclude-tags=golden
 ```
 
-## Modo Plano
+### Etapa 3: Configuração Recomendada
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
-
-## Workflow
-
-### 1. Modificação de UI
-
-Quando você modifica a aparência de um widget:
-
-```bash
-# 1. Executar testes (vão falhar)
-flutter test test/golden/
-
-# 2. Revisar diferenças visuais
-# Verificar que mudanças são intencionais
-
-# 3. Atualizar goldens
-flutter test test/golden/ --update-goldens
-
-# 4. Verificar novos goldens
-git diff test/golden/
-```
-
-### 2. Novos Golden Tests
+#### flutter_test_config.dart
 
 ```dart
-testWidgets('my widget golden', (tester) async {
-  await tester.pumpWidget(
-    MaterialApp(home: MyWidget()),
-  );
+// test/flutter_test_config.dart
+import 'dart:async';
+import 'package:flutter/material.dart';
 
-  await expectLater(
-    find.byType(MyWidget),
-    matchesGoldenFile('goldens/my_widget_default.png'),
-  );
-});
+Future<void> testExecutable(FutureOr<void> Function() testMain) async {
+  // Configuração de fontes para consistência
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  // Configurar o comparador de golden files
+  if (goldenFileComparator is LocalFileComparator) {
+    final testUrl = (goldenFileComparator as LocalFileComparator).basedir;
+    goldenFileComparator = _CustomGoldenFileComparator(testUrl);
+  }
+
+  await testMain();
+}
+
+class _CustomGoldenFileComparator extends LocalFileComparator {
+  _CustomGoldenFileComparator(Uri basedir) : super(basedir);
+
+  @override
+  Future<bool> compare(Uint8List imageBytes, Uri golden) async {
+    final result = await super.compare(imageBytes, golden);
+    if (!result) {
+      // Log mais detalhado em caso de falha
+      print('Golden test falhou: $golden');
+    }
+    return result;
+  }
+}
 ```
 
-### 3. Diferentes Temas/Tamanhos
+#### Tags para os Golden Tests
 
 ```dart
-// Dark mode
-testWidgets('dark theme golden', (tester) async {
+// test/widgets/my_button_test.dart
+@Tags(['golden'])
+library;
+
+import 'package:flutter_test/flutter_test.dart';
+// ...
+```
+
+### Etapa 4: Boas Práticas
+
+#### Estrutura de Pastas
+
+```
+test/
+├── goldens/
+│   ├── widgets/
+│   │   ├── my_button_default.png
+│   │   ├── my_button_pressed.png
+│   │   └── my_button_disabled.png
+│   └── screens/
+│       ├── home_screen.png
+│       └── settings_screen.png
+├── widgets/
+│   └── my_button_test.dart
+└── screens/
+    └── home_screen_test.dart
+```
+
+#### Wrapper para Golden Tests
+
+```dart
+// test/helpers/golden_test_wrapper.dart
+import 'package:flutter/material.dart';
+
+Widget goldenTestWrapper({
+  required Widget child,
+  ThemeData? theme,
+  Size size = const Size(400, 600),
+}) {
+  return MaterialApp(
+    debugShowCheckedModeBanner: false,
+    theme: theme ?? ThemeData.light(),
+    home: Scaffold(
+      body: SizedBox(
+        width: size.width,
+        height: size.height,
+        child: Center(child: child),
+      ),
+    ),
+  );
+}
+
+// Uso
+testWidgets('golden do meu widget', (tester) async {
   await tester.pumpWidget(
-    MaterialApp(
-      theme: ThemeData.dark(),
-      home: MyWidget(),
+    goldenTestWrapper(
+      child: const MyWidget(),
+      size: const Size(300, 200),
     ),
   );
 
   await expectLater(
     find.byType(MyWidget),
-    matchesGoldenFile('goldens/my_widget_dark.png'),
+    matchesGoldenFile('goldens/my_widget.png'),
   );
 });
 ```
 
-## Atenção
+#### Multi-Tema e Multi-Plataforma
 
-- [ ] Revisar mudanças visuais antes de atualizar
-- [ ] Commitar novos goldens
-- [ ] Documentar mudanças no PR
-- [ ] CI deve ter goldens atualizados
+```dart
+void main() {
+  final themes = {
+    'light': ThemeData.light(),
+    'dark': ThemeData.dark(),
+  };
+
+  for (final entry in themes.entries) {
+    testWidgets('MyButton - tema ${entry.key}', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          theme: entry.value,
+          home: const Scaffold(
+            body: Center(child: MyButton(label: 'Test')),
+          ),
+        ),
+      );
+
+      await expectLater(
+        find.byType(MyButton),
+        matchesGoldenFile('goldens/my_button_${entry.key}.png'),
+      );
+    });
+  }
+}
+```
+
+### Etapa 5: Workflow CI/CD
+
+```yaml
+# .github/workflows/flutter.yml
+name: Flutter Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.24.0'
+
+      - name: Instalar dependências
+        run: flutter pub get
+
+      - name: Executar testes unitários
+        run: flutter test --exclude-tags=golden
+
+      - name: Executar golden tests
+        run: flutter test --tags=golden
+        continue-on-error: true  # Para visualizar as diferenças
+
+      - name: Fazer upload das falhas dos golden tests
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: golden-failures
+          path: '**/failures/*.png'
+```
+
+### Etapa 6: Resolver as Diferenças
+
+```
+══════════════════════════════════════════════════════════════
+🖼️ GOLDEN TESTS - RESULTADO
+══════════════════════════════════════════════════════════════
+
+──────────────────────────────────────────────────────────────
+📊 RESUMO
+──────────────────────────────────────────────────────────────
+
+| Categoria   | Testes | Aprovados | Reprovados |
+|-------------|--------|-----------|------------|
+| Widgets     | 15     | 12        | 3          |
+| Screens     | 8      | 8         | 0          |
+| Components  | 10     | 10        | 0          |
+| **Total**   | 33     | 30        | 3          |
+
+──────────────────────────────────────────────────────────────
+❌ TESTES REPROVADOS
+──────────────────────────────────────────────────────────────
+
+### 1. my_button_default.png
+
+Diferença detectada: 2,3%
+
+Causa provável:
+- Mudança de padding
+- Modificação da fonte
+- Atualização do tema
+
+Ações:
+- [ ] Verificar se a mudança é intencional
+- [ ] Se sim: `flutter test --update-goldens test/widgets/my_button_test.dart`
+- [ ] Se não: reverter as mudanças
+
+### 2. user_card_avatar.png
+
+Diferença detectada: 15,7%
+
+Causa provável:
+- Novo design do avatar
+- Mudança de border-radius
+
+Ações:
+- [ ] Revisar com o designer
+- [ ] Atualizar se validado
+
+──────────────────────────────────────────────────────────────
+🔧 COMANDOS
+──────────────────────────────────────────────────────────────
+
+# Ver as diferenças
+open test/goldens/failures/
+
+# Atualizar os testes reprovados
+flutter test --update-goldens test/widgets/my_button_test.dart
+
+# Atualizar todos os golden tests
+flutter test --update-goldens --tags=golden
+
+# Executar somente os golden tests
+flutter test --tags=golden
+
+──────────────────────────────────────────────────────────────
+⚠️ LEMBRETES
+──────────────────────────────────────────────────────────────
+
+1. Sempre verificar visualmente antes de atualizar
+2. Commitar os novos .png junto com o código
+3. Usar o mesmo ambiente para gerar os goldens
+4. Documentar as mudanças visuais na PR
+```

--- a/Dev/i18n/pt/Flutter/commands/localization-check.md
+++ b/Dev/i18n/pt/Flutter/commands/localization-check.md
@@ -1,79 +1,320 @@
 ---
-description: Verificar Localização/Internacionalização
+description: Verificação de Traduções
+argument-hint: [arguments]
 ---
 
-# Verificar Localização/Internacionalização
+# Verificação de Traduções
 
-Verifique se o aplicativo está corretamente internacionalizado e todas as strings estão traduzidas.
+Você é um desenvolvedor Flutter sênior. Você deve verificar a completude e a coerência das traduções (i18n) do projeto.
 
-## Verificações
+## Argumentos
+$ARGUMENTS
 
-### 1. Configuração
+Argumentos:
+- (Opcional) Idioma a verificar (ex: `fr`, `en`, `all`)
+
+Exemplo: `/flutter:localization-check all`
+
+## Modo de Planejamento
+
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
+
+## MISSÃO
+
+### Etapa 1: Identificar a Configuração i18n
 
 ```yaml
 # pubspec.yaml
 dependencies:
   flutter_localizations:
     sdk: flutter
-  intl: any
+  intl: ^0.19.0
 
 flutter:
   generate: true
-```
 
-```yaml
 # l10n.yaml
 arb-dir: lib/l10n
 template-arb-file: app_en.arb
 output-localization-file: app_localizations.dart
+output-class: AppLocalizations
 ```
 
-### 2. Buscar Strings Hardcoded
+### Etapa 2: Analisar os Arquivos ARB
 
 ```bash
-# Buscar Text widgets com strings literais
-grep -r "Text\s*(" lib/ | grep -v "S\.of\|AppLocalizations\|context\.l10n"
+# Listar os arquivos de tradução
+ls -la lib/l10n/
 
-# Buscar strings entre aspas em widgets
-grep -r "'\|\"" lib/presentation/ | grep -v "import\|class\|//\|key:"
+# Gerar os arquivos Dart
+flutter gen-l10n
 ```
 
-### 3. Verificar ARB Files
-
-```bash
-# Verificar se todas as chaves existem em todos os idiomas
-cd lib/l10n
-
-# Contar chaves
-for file in *.arb; do
-  echo "$file: $(jq 'keys | length' $file) keys"
-done
-
-# Encontrar chaves faltantes
-comm -23 <(jq -r 'keys[]' app_en.arb | sort) <(jq -r 'keys[]' app_pt.arb | sort)
-```
-
-### 4. Uso Correto
+### Etapa 3: Verificar as Chaves
 
 ```dart
-// ✅ BOM
-Text(S.of(context).welcomeMessage)
+// Script de verificação (executar manualmente ou via teste)
+import 'dart:convert';
+import 'dart:io';
 
-// ✅ BOM
-Text(AppLocalizations.of(context)!.welcomeMessage)
+void main() {
+  final arbFiles = Directory('lib/l10n')
+      .listSync()
+      .whereType<File>()
+      .where((f) => f.path.endsWith('.arb'));
 
-// ❌ RUIM
-Text('Welcome') // String hardcoded
+  final Map<String, Map<String, dynamic>> translations = {};
+
+  for (final file in arbFiles) {
+    final lang = file.path.split('app_').last.replaceAll('.arb', '');
+    final content = jsonDecode(file.readAsStringSync()) as Map<String, dynamic>;
+    translations[lang] = content;
+  }
+
+  // Encontrar o idioma de referência (template)
+  final reference = translations['en']!;
+  final referenceKeys = reference.keys
+      .where((k) => !k.startsWith('@'))
+      .toSet();
+
+  print('Idioma de referência: en');
+  print('Quantidade de chaves: ${referenceKeys.length}');
+  print('');
+
+  for (final entry in translations.entries) {
+    if (entry.key == 'en') continue;
+
+    final keys = entry.value.keys
+        .where((k) => !k.startsWith('@'))
+        .toSet();
+
+    final missing = referenceKeys.difference(keys);
+    final extra = keys.difference(referenceKeys);
+
+    print('Idioma: ${entry.key}');
+    print('  Chaves: ${keys.length}');
+    print('  Faltando: ${missing.length}');
+    print('  Extras: ${extra.length}');
+
+    if (missing.isNotEmpty) {
+      print('  Chaves faltando:');
+      for (final key in missing) {
+        print('    - $key');
+      }
+    }
+    print('');
+  }
+}
 ```
 
-## Modo Plano
+### Etapa 4: Verificar o Uso
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+```bash
+# Procurar chaves hardcoded
+grep -rn "Text('" lib/ --include="*.dart" | grep -v "AppLocalizations"
+grep -rn 'Text("' lib/ --include="*.dart" | grep -v "AppLocalizations"
 
-## Relatório
+# Procurar usos corretos
+grep -rn "AppLocalizations.of(context)" lib/ --include="*.dart"
+grep -rn "context.l10n" lib/ --include="*.dart"  # Se extensão disponível
+```
 
-Liste:
-- Strings hardcoded encontradas
-- Idiomas disponíveis
-- Completude da tradução (%)
-- Chaves faltantes por idioma
+### Etapa 5: Gerar o Relatório
+
+```
+══════════════════════════════════════════════════════════════
+🌍 RELATÓRIO DE LOCALIZAÇÃO
+══════════════════════════════════════════════════════════════
+
+──────────────────────────────────────────────────────────────
+📊 RESUMO
+──────────────────────────────────────────────────────────────
+
+| Idioma   | Chaves | Completude | Status |
+|----------|--------|------------|--------|
+| en (ref) | 145    | 100%       | ✅     |
+| fr       | 142    | 98%        | ⚠️     |
+| de       | 130    | 90%        | ⚠️     |
+| es       | 145    | 100%       | ✅     |
+| ja       | 120    | 83%        | ❌     |
+
+──────────────────────────────────────────────────────────────
+❌ CHAVES FALTANDO
+──────────────────────────────────────────────────────────────
+
+### fr (3 chaves faltando)
+
+| Chave            | Valor EN          | Prioridade |
+|------------------|-------------------|------------|
+| `orderCancelled` | "Order cancelled" | Alta       |
+| `paymentFailed`  | "Payment failed"  | Alta       |
+| `retryButton`    | "Retry"           | Média      |
+
+### de (15 chaves faltando)
+
+| Chave            | Valor EN   | Prioridade |
+|------------------|------------|------------|
+| `settingsTitle`  | "Settings" | Alta       |
+| `profileSection` | "Profile"  | Média      |
+| ...              | ...        | ...        |
+
+### ja (25 chaves faltando)
+
+[Lista completa no arquivo report_ja.md]
+
+──────────────────────────────────────────────────────────────
+⚠️ CHAVES NÃO UTILIZADAS
+──────────────────────────────────────────────────────────────
+
+As seguintes chaves estão definidas mas não são utilizadas no código:
+
+| Chave               | Idiomas    | Ação     |
+|---------------------|------------|----------|
+| `oldFeatureTitle`   | en, fr, de | Remover? |
+| `deprecatedMessage` | en, fr     | Remover? |
+| `testKey`           | en         | Remover  |
+
+──────────────────────────────────────────────────────────────
+🔍 TEXTOS HARDCODED
+──────────────────────────────────────────────────────────────
+
+Arquivos com textos potencialmente não traduzidos:
+
+| Arquivo                      | Linha | Texto                       |
+|------------------------------|-------|-----------------------------|
+| lib/screens/home.dart        | 45    | `Text('Welcome')`           |
+| lib/widgets/header.dart      | 23    | `Text("Loading...")`        |
+| lib/screens/error.dart       | 12    | `Text('An error occurred')` |
+
+──────────────────────────────────────────────────────────────
+📝 BOAS PRÁTICAS
+──────────────────────────────────────────────────────────────
+
+### Extensão Recomendada
+
+```dart
+// lib/core/extensions/l10n_extension.dart
+import 'package:flutter/widgets.dart';
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+extension L10nExtension on BuildContext {
+  AppLocalizations get l10n => AppLocalizations.of(this)!;
+}
+
+// Uso
+Text(context.l10n.welcomeMessage)
+```
+
+### Formato das Chaves
+
+```json
+// app_en.arb
+{
+  "welcomeMessage": "Welcome, {name}!",
+  "@welcomeMessage": {
+    "description": "Welcome message with user name",
+    "placeholders": {
+      "name": {
+        "type": "String",
+        "example": "John"
+      }
+    }
+  },
+  "itemCount": "{count, plural, =0{No items} =1{1 item} other{{count} items}}",
+  "@itemCount": {
+    "description": "Number of items",
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
+}
+```
+
+──────────────────────────────────────────────────────────────
+🔧 COMANDOS
+──────────────────────────────────────────────────────────────
+
+# Gerar os arquivos de localização
+flutter gen-l10n
+
+# Verificar a sintaxe ARB
+dart run intl_utils:check
+
+# Extrair novas chaves (se estiver usando intl_utils)
+dart run intl_utils:extract
+
+──────────────────────────────────────────────────────────────
+🎯 AÇÕES PRIORITÁRIAS
+──────────────────────────────────────────────────────────────
+
+1. [ ] Traduzir 3 chaves faltando em francês (crítico)
+2. [ ] Traduzir 15 chaves faltando em alemão
+3. [ ] Remover 3 chaves não utilizadas
+4. [ ] Converter 3 textos hardcoded em chaves i18n
+5. [ ] Atualizar as traduções em japonês (25 chaves)
+```
+
+### Etapa 6: Template ARB
+
+```json
+// lib/l10n/app_en.arb
+{
+  "@@locale": "en",
+  "@@last_modified": "2024-01-15T10:30:00Z",
+
+  "appTitle": "My App",
+  "@appTitle": {
+    "description": "The title of the application"
+  },
+
+  "welcomeMessage": "Welcome, {userName}!",
+  "@welcomeMessage": {
+    "description": "Welcome message shown on home screen",
+    "placeholders": {
+      "userName": {
+        "type": "String",
+        "example": "John"
+      }
+    }
+  },
+
+  "itemsInCart": "{count, plural, =0{Your cart is empty} =1{1 item in cart} other{{count} items in cart}}",
+  "@itemsInCart": {
+    "description": "Shows number of items in shopping cart",
+    "placeholders": {
+      "count": {
+        "type": "int",
+        "format": "compact"
+      }
+    }
+  },
+
+  "orderDate": "Ordered on {date}",
+  "@orderDate": {
+    "description": "Shows when an order was placed",
+    "placeholders": {
+      "date": {
+        "type": "DateTime",
+        "format": "yMMMd"
+      }
+    }
+  },
+
+  "price": "{amount}",
+  "@price": {
+    "description": "Formatted price",
+    "placeholders": {
+      "amount": {
+        "type": "double",
+        "format": "currency",
+        "optionalParameters": {
+          "symbol": "€",
+          "decimalDigits": 2
+        }
+      }
+    }
+  }
+}
+```

--- a/Dev/i18n/pt/Laravel/commands/check-compliance.md
+++ b/Dev/i18n/pt/Laravel/commands/check-compliance.md
@@ -1,145 +1,253 @@
 ---
-description: Check Laravel project compliance with coding standards
+description: Verificar Conformidade Completa do Laravel
+argument-hint: [arguments]
 ---
 
-# Laravel Compliance Check
+# Verificar Conformidade Completa do Laravel
 
-You are a Laravel expert auditor. Your mission is to verify that the project follows Laravel best practices and coding standards.
+## Argumentos
 
-## Audit Process
+$ARGUMENTS (opcional: caminho para o projeto a analisar)
 
-### 1. Project Structure Analysis
+## Modo de Planejamento
 
-Check if the project follows the recommended architecture:
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
+
+## MISSÃO
+
+Realizar uma auditoria de conformidade completa do projeto Laravel orquestrando as 4 verificações principais: Arquitetura, Qualidade de Código, Testes e Segurança. Produzir um relatório consolidado com uma pontuação geral de 100 pontos.
+
+### Etapa 1: Preparação da Auditoria
+
+Preparar o ambiente de auditoria:
+- [ ] Identificar o caminho do projeto a auditar
+- [ ] Verificar a presença de arquivos de configuração (composer.json com laravel/*, .env.example)
+- [ ] Listar os diretórios principais (app/, tests/, config/, routes/, etc.)
+- [ ] Identificar a estrutura do projeto e a versão do Laravel
+
+**Nota**: Se $ARGUMENTS for fornecido, utilizá-lo como caminho do projeto; caso contrário, usar o diretório atual.
+
+### Etapa 2: Auditoria de Arquitetura (25 pontos)
+
+Executar a verificação completa de arquitetura:
+
+**Comando**: Usar o slash command `/laravel:check-architecture` ou seguir manualmente os passos em `check-architecture.md`
+
+**Critérios Avaliados**:
+- Separação de camadas em Clean Architecture (6 pts)
+- Estrutura Domain/Application/Infrastructure (6 pts)
+- Padrão de Actions e controllers enxutos (4 pts)
+- Bindings de Service Providers (4 pts)
+- Padrão Repository e interfaces (3 pts)
+- Regras de dependência (2 pts)
+
+**Referência**: `check-architecture.md`
+
+### Etapa 3: Auditoria de Qualidade de Código (25 pontos)
+
+Executar a verificação de qualidade de código:
+
+**Comando**: Usar o slash command `/laravel:check-code-quality` ou seguir manualmente os passos em `check-code-quality.md`
+
+**Critérios Avaliados**:
+- Conformidade com PSR-12 e Laravel Pint (5 pts)
+- Análise estática com PHPStan (5 pts)
+- Funcionalidades modernas do PHP (enums, readonly, typed properties) (4 pts)
+- Princípios KISS/DRY/YAGNI (4 pts)
+- Convenções de nomenclatura (padrões Laravel) (4 pts)
+- Tratamento de erros e logging (3 pts)
+
+**Referência**: `check-code-quality.md`
+
+### Etapa 4: Auditoria de Testes (25 pontos)
+
+Executar a verificação de testes:
+
+**Comando**: Usar o slash command `/laravel:check-testing` ou seguir manualmente os passos em `check-testing.md`
+
+**Critérios Avaliados**:
+- Cobertura de código (7 pts)
+- Testes unitários para lógica de Domínio (6 pts)
+- Testes de funcionalidade para endpoints HTTP (4 pts)
+- Uso do Pest PHP e qualidade dos testes (3 pts)
+- Factories e seeders de banco de dados (3 pts)
+- Isolamento de testes e mocking (2 pts)
+
+**Referência**: `check-testing.md`
+
+### Etapa 5: Auditoria de Segurança (25 pontos)
+
+Executar a verificação de segurança:
+
+**Comando**: Usar o slash command `/laravel:check-security` ou seguir manualmente os passos em `check-security.md`
+
+**Critérios Avaliados**:
+- Proteções OWASP Top 10 (6 pts)
+- Gestão de segredos e credenciais (5 pts)
+- Validação com Form Request (4 pts)
+- Vulnerabilidades de dependências (composer audit) (4 pts)
+- Autenticação e Autorização (Policies) (3 pts)
+- CSRF e configuração de middlewares (2 pts)
+- Prevenção de injeção SQL (1 pt)
+
+**Referência**: `check-security.md`
+
+### Etapa 6: Consolidação e Pontuação Global
+
+Calcular a pontuação geral e produzir o relatório consolidado:
+- [ ] Somar as 4 pontuações (máximo de 100 pontos)
+- [ ] Identificar categorias críticas (<50%)
+- [ ] Listar todos os problemas transversais críticos
+- [ ] Priorizar ações por impacto/esforço
+- [ ] Produzir o relatório consolidado final
+
+**Escala de Avaliação**:
+- 90-100: Excelente — Projeto de referência
+- 75-89: Muito Bom — Algumas melhorias menores
+- 60-74: Aceitável — Requer melhorias
+- 40-59: Insuficiente — Refatoração significativa necessária
+- 0-39: Crítico — Revisão completa necessária
+
+### Etapa 7: Recomendações e Plano de Ação
+
+Produzir as recomendações finais:
+- [ ] Identificar as 3 ações prioritárias em todas as categorias
+- [ ] Estimar o esforço (Baixo/Médio/Alto) para cada ação
+- [ ] Estimar o impacto (Baixo/Médio/Alto) para cada ação
+- [ ] Propor a ordem de implementação
+- [ ] Sugerir ganhos rápidos (alta relação impacto/esforço)
+
+## FORMATO DE SAÍDA
 
 ```
-app/
-├── Domain/           # Business logic (if using Clean Architecture)
-├── Application/      # Use cases, Actions, DTOs
-├── Infrastructure/   # External services, Repositories
-├── Http/
-│   ├── Controllers/  # Thin controllers
-│   ├── Requests/     # Form Requests for validation
-│   ├── Resources/    # API Resources
-│   └── Middleware/
-├── Models/           # Eloquent models
-├── Services/         # Business services
-├── Jobs/             # Queue jobs
-├── Events/           # Domain events
-├── Listeners/        # Event listeners
-├── Policies/         # Authorization policies
-└── Providers/        # Service providers
+AUDITORIA DE CONFORMIDADE LARAVEL - RELATÓRIO COMPLETO
+=======================================================
+
+PONTUAÇÃO GERAL: XX/100
+
+NÍVEL DE CONFORMIDADE: [Excelente/Muito Bom/Aceitável/Insuficiente/Crítico]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PONTUAÇÕES POR CATEGORIA:
+
+ARQUITETURA        : XX/25  [██████████░░░░░░░░░░] XX%
+QUALIDADE DE CÓDIGO: XX/25  [██████████░░░░░░░░░░] XX%
+TESTES             : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURANÇA          : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PONTOS FORTES GERAIS:
+1. [Ponto forte identificado em múltiplas categorias]
+2. [Outro ponto forte principal]
+3. [Terceiro ponto forte]
+
+MELHORIAS GERAIS:
+1. [Melhoria transversal menor]
+2. [Outra melhoria recomendada]
+3. [Terceira melhoria]
+
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico nº 1 - categoria afetada]
+2. [Problema crítico nº 2 - categoria afetada]
+3. [Problema crítico nº 3 - categoria afetada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALHES POR CATEGORIA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITETURA (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Sub-pontuações:
+  • Camadas de Clean Architecture : XX/6
+  • Estrutura Domain/App/Infra    : XX/6
+  • Actions e controllers enxutos : XX/4
+  • Bindings de Service Provider  : XX/4
+  • Padrão Repository             : XX/3
+  • Regras de dependência         : XX/2
+
+Pontos Fortes:
+- [Pontos fortes de arquitetura]
+
+Problemas:
+- [Problemas de arquitetura]
+
+[Seções semelhantes para Qualidade de Código, Testes e Segurança...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 AÇÕES PRIORITÁRIAS (TODAS AS CATEGORIAS):
+
+1. CRÍTICO - [Ação nº 1]
+   Categoria : [Arquitetura/Qualidade/Testes/Segurança]
+   Impacto   : [Alto/Médio/Baixo]
+   Esforço   : [Alto/Médio/Baixo]
+   Prioridade: IMEDIATA
+
+   Descrição detalhada:
+   [Explicação do problema e solução proposta]
+
+   Arquivos afetados:
+   - [arquivo:linha]
+
+   Exemplo de correção:
+   [Código ou comando de correção]
+
+2. IMPORTANTE - [Ação nº 2]
+   [Mesmo formato...]
+
+3. RECOMENDADO - [Ação nº 3]
+   [Mesmo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GANHOS RÁPIDOS (Alto Impacto / Baixo Esforço):
+
+- [Ganho rápido nº 1] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Ganho rápido nº 2] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Ganho rápido nº 3] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLANO DE AÇÃO RECOMENDADO:
+
+SEMANA 1 (Imediato):
+- [ ] [Ação crítica nº 1]
+- [ ] [Ganho rápido prioritário]
+
+SEMANAS 2-4 (Curto prazo):
+- [ ] [Ação importante nº 2]
+- [ ] [Outros ganhos rápidos]
+
+MESES 2-3 (Médio prazo):
+- [ ] [Ação recomendada nº 3]
+- [ ] [Melhorias progressivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMO EXECUTIVO:
+
+[Parágrafo de síntese sobre o estado geral do projeto, principais pontos
+fortes, principais pontos fracos e a trajetória recomendada para melhorar
+a conformidade. Indicar se o projeto está pronto para produção,
+requer correções ou necessita de refatoração.]
+
+Recomendação Geral: [Pronto para produção / Correções menores /
+Refatoração significativa / Revisão completa necessária]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Code Standards Verification
+## NOTAS IMPORTANTES
 
-#### Naming Conventions
-- [ ] Controllers: Singular, PascalCase (`OrderController`)
-- [ ] Models: Singular, PascalCase (`Order`, `OrderItem`)
-- [ ] Tables: Plural, snake_case (`orders`, `order_items`)
-- [ ] Columns: snake_case (`created_at`, `customer_id`)
-- [ ] Methods: camelCase (`getUserOrders()`)
-- [ ] Variables: camelCase (`$orderTotal`)
-
-#### Modern PHP Features (8.3+)
-- [ ] Constructor property promotion used
-- [ ] Readonly properties/classes where appropriate
-- [ ] Enums for status/type fields
-- [ ] Match expressions instead of switch
-- [ ] Named arguments for clarity
-- [ ] Type declarations on all methods
-- [ ] Return types specified
-
-#### Laravel Conventions
-- [ ] Form Requests for validation (not validation in controllers)
-- [ ] API Resources for response transformation
-- [ ] Policies for authorization
-- [ ] Eloquent casts for type conversion
-- [ ] Scopes for reusable queries
-- [ ] Events for cross-cutting concerns
-
-### 3. Architecture Compliance
-
-#### Layer Dependencies
-- Domain layer has NO external dependencies
-- Application layer only depends on Domain
-- Infrastructure implements Domain interfaces
-- Controllers are thin (delegate to Actions/Services)
-
-#### Repository Pattern (if applicable)
-- [ ] Interfaces defined in Domain/Contracts
-- [ ] Implementations in Infrastructure
-- [ ] Bindings in Service Providers
-
-### 4. Configuration Check
-
-- [ ] No hardcoded values (use config files)
-- [ ] Environment variables via config(), not env()
-- [ ] Sensitive data in .env (not committed)
-- [ ] Config caching compatible
-
-### 5. Generate Report
-
-After analysis, provide:
-
-1. **Compliance Score**: X/100
-2. **Critical Issues**: Must-fix problems
-3. **Warnings**: Recommended improvements
-4. **Good Practices**: What's done well
-5. **Action Items**: Prioritized list of fixes
-
-## Modo Plano
-
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
-
-## Commands to Run
-
-```bash
-# Check code style
-./vendor/bin/pint --test
-
-# Static analysis
-./vendor/bin/phpstan analyse
-
-# Run tests
-php artisan test
-
-# Check for security vulnerabilities
-composer audit
-```
-
-## Output Format
-
-```markdown
-# Laravel Compliance Report
-
-## Summary
-- **Score**: 85/100
-- **Critical Issues**: 2
-- **Warnings**: 5
-- **Files Analyzed**: 150
-
-## Critical Issues
-
-### 1. Missing Form Request Validation
-**File**: `app/Http/Controllers/OrderController.php:45`
-**Issue**: Validation done in controller instead of Form Request
-**Fix**: Create `StoreOrderRequest` and move validation rules
-
-### 2. [Issue description]
-
-## Warnings
-
-### 1. [Warning description]
-
-## Recommendations
-
-1. [Recommendation 1]
-2. [Recommendation 2]
-
-## Good Practices Observed
-
-- Using Eloquent casts for type conversion
-- Proper use of API Resources
-- Events for decoupling
-```
+- Este comando orquestra as 4 auditorias especializadas
+- Usar Docker para todas as ferramentas de análise
+- Fornecer exemplos concretos com arquivo:linha para cada problema
+- Priorizar ações com base na matriz Impacto/Esforço
+- Problemas de segurança são SEMPRE a prioridade máxima
+- Propor correções automatizáveis (scripts, hooks de pré-commit)
+- O relatório deve ser acionável, não apenas descritivo
+- Adaptar as recomendações ao contexto de negócio do projeto

--- a/Dev/i18n/pt/React/commands/accessibility-check.md
+++ b/Dev/i18n/pt/React/commands/accessibility-check.md
@@ -4,28 +4,28 @@ description: Auditoria de Acessibilidade
 
 # Auditoria de Acessibilidade
 
-Realizar uma auditoria completa de acessibilidade (a11y) da aplicacao React.
+Realize uma auditoria completa de acessibilidade (a11y) da aplicação React.
 
 ## O Que Este Comando Faz
 
-1. **Analise de Acessibilidade**
-   - Escanear componentes em busca de problemas de a11y
-   - Verificar rotulos ARIA
-   - Verificar HTML semantico
-   - Testar navegacao por teclado
+1. **Análise de Acessibilidade**
+   - Verificar componentes em busca de problemas de a11y
+   - Checar rótulos ARIA
+   - Verificar HTML semântico
+   - Testar navegação por teclado
    - Verificar contrastes de cores
 
-2. **Ferramentas Usadas**
+2. **Ferramentas Utilizadas**
    - eslint-plugin-jsx-a11y
    - axe-core
    - Lighthouse
    - React DevTools
 
-3. **Relatorio Gerado**
-   - Lista de violacoes de a11y
-   - Nivel de severidade (critico, serio, moderado, menor)
-   - Recomendacoes acionaveis
-   - Exemplos de codigo para correcoes
+3. **Relatório Gerado**
+   - Lista de violações de a11y
+   - Nível de severidade (crítico, sério, moderado, menor)
+   - Recomendações acionáveis
+   - Exemplos de código para correções
 
 ## Como Usar
 
@@ -37,29 +37,29 @@ npm run a11y:check
 pnpm a11y:check
 ```
 
-## Modo Plano
+## Modo de Planejamento
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
 ## O Que Verificar
 
-### 1. HTML Semantico
+### 1. HTML Semântico
 
 ```typescript
-// ❌ Ruim - Nao-semantico
-<div onClick={handleClick}>Clique em mim</div>
+// ❌ Ruim - Não semântico
+<div onClick={handleClick}>Clique aqui</div>
 
-// ✅ Bom - Semantico
-<button onClick={handleClick}>Clique em mim</button>
+// ✅ Bom - Semântico
+<button onClick={handleClick}>Clique aqui</button>
 ```
 
-### 2. Rotulos ARIA
+### 2. Rótulos ARIA
 
 ```typescript
-// ❌ Ruim - Faltando rotulo
+// ❌ Ruim - Sem rótulo
 <input type="text" />
 
-// ✅ Bom - Com rotulo
+// ✅ Bom - Com label
 <label htmlFor="name">Nome</label>
 <input id="name" type="text" />
 
@@ -69,13 +69,13 @@ pnpm a11y:check
 </button>
 ```
 
-### 3. Navegacao por Teclado
+### 3. Navegação por Teclado
 
 ```typescript
-// ✅ Bom - Navegacao por Tab funciona
-<button onClick={handleClick}>Acao</button>
+// ✅ Bom - Navegação por Tab funciona
+<button onClick={handleClick}>Ação</button>
 
-// ✅ Bom - Manipulacao de teclado personalizada
+// ✅ Bom - Tratamento de teclado personalizado
 <div
   role="button"
   tabIndex={0}
@@ -86,38 +86,147 @@ pnpm a11y:check
     }
   }}
 >
-  Botao Personalizado
+  Botão Personalizado
 </div>
 ```
 
 ### 4. Contraste de Cores
 
-- Texto deve ter razao de contraste suficiente
-- WCAG AA: 4.5:1 para texto normal
+- O texto deve ter uma taxa de contraste suficiente
+- WCAG AA: 4,5:1 para texto normal
 - WCAG AAA: 7:1 para texto normal
-- Usar ferramentas para verificar contrastes
+- Use ferramentas para verificar os contrastes
 
 ### 5. Texto Alternativo para Imagens
 
 ```typescript
-// ❌ Ruim - Faltando alt
-<img src="foto.jpg" />
+// ❌ Ruim - Alt ausente
+<img src="photo.jpg" />
 
 // ✅ Bom - Alt descritivo
-<img src="foto.jpg" alt="Equipe da empresa na conferencia anual" />
+<img src="photo.jpg" alt="Equipe da empresa na conferência anual" />
 
 // ✅ Bom - Imagem decorativa
-<img src="decoracao.jpg" alt="" role="presentation" />
+<img src="decoration.jpg" alt="" role="presentation" />
 ```
 
-## Melhores Praticas
+## Configuração
 
-1. **Usar HTML semantico** (button, nav, main, header, footer)
-2. **Adicionar rotulos ARIA** quando necessario
-3. **Testar navegacao por teclado** (Tab, Enter, Escape)
-4. **Verificar contrastes de cores** (minimo WCAG AA)
-5. **Fornecer texto alternativo** para imagens
-6. **Suportar leitores de tela**
+### ESLint (eslint-plugin-jsx-a11y)
+
+```json
+// .eslintrc.json
+{
+  "extends": [
+    "plugin:jsx-a11y/recommended"
+  ],
+  "rules": {
+    "jsx-a11y/alt-text": "error",
+    "jsx-a11y/anchor-is-valid": "error",
+    "jsx-a11y/aria-props": "error",
+    "jsx-a11y/aria-role": "error",
+    "jsx-a11y/click-events-have-key-events": "error",
+    "jsx-a11y/label-has-associated-control": "error",
+    "jsx-a11y/no-noninteractive-element-interactions": "error"
+  }
+}
+```
+
+### Testes Automatizados com axe-core
+
+```typescript
+// test/a11y.test.tsx
+import { render } from '@testing-library/react';
+import { axe, toHaveNoViolations } from 'jest-axe';
+import { MyComponent } from './MyComponent';
+
+expect.extend(toHaveNoViolations);
+
+describe('Acessibilidade', () => {
+  it('não deve ter violações de a11y', async () => {
+    const { container } = render(<MyComponent />);
+    const results = await axe(container);
+    expect(results).toHaveNoViolations();
+  });
+});
+```
+
+## Problemas Comuns e Correções
+
+### Problema 1: Rótulos de Formulário Ausentes
+
+```typescript
+// ❌ Problema
+<input type="email" placeholder="Email" />
+
+// ✅ Solução
+<label htmlFor="email">Email</label>
+<input id="email" type="email" placeholder="seu@email.com" />
+```
+
+### Problema 2: Elementos Não Interativos com Manipuladores de Clique
+
+```typescript
+// ❌ Problema
+<div onClick={handleClick}>Clique aqui</div>
+
+// ✅ Solução 1: Usar button
+<button onClick={handleClick}>Clique aqui</button>
+
+// ✅ Solução 2: Adicionar role adequado e suporte a teclado
+<div
+  role="button"
+  tabIndex={0}
+  onClick={handleClick}
+  onKeyDown={(e) => e.key === 'Enter' && handleClick()}
+>
+  Clique aqui
+</div>
+```
+
+### Problema 3: Texto Alternativo Ausente
+
+```typescript
+// ❌ Problema
+<img src="logo.png" />
+
+// ✅ Solução
+<img src="logo.png" alt="Logo da Empresa" />
+```
+
+### Problema 4: Informação Transmitida Apenas por Cor
+
+```typescript
+// ❌ Problema
+<span style={{ color: 'red' }}>Erro</span>
+
+// ✅ Solução
+<span style={{ color: 'red' }} aria-label="Erro">
+  <ErrorIcon aria-hidden="true" /> Erro
+</span>
+```
+
+## Testes com Lighthouse
+
+```bash
+# Instalar Lighthouse
+npm install -g lighthouse
+
+# Executar auditoria
+lighthouse http://localhost:3000 --view
+
+# Salvar relatório
+lighthouse http://localhost:3000 --output html --output-path ./report.html
+```
+
+## Boas Práticas
+
+1. **Use HTML semântico** (button, nav, main, header, footer)
+2. **Adicione rótulos ARIA** onde necessário
+3. **Teste a navegação por teclado** (Tab, Enter, Escape)
+4. **Verifique contrastes de cores** (mínimo WCAG AA)
+5. **Forneça texto alternativo** para imagens
+6. **Suporte a leitores de tela**
 7. **Testes automatizados** com axe-core
 8. **Testes manuais** com leitores de tela (NVDA, JAWS, VoiceOver)
 
@@ -125,5 +234,5 @@ pnpm a11y:check
 
 - [Diretrizes WCAG](https://www.w3.org/WAI/WCAG21/quickref/)
 - [MDN Acessibilidade](https://developer.mozilla.org/pt-BR/docs/Web/Accessibility)
-- [React Acessibilidade](https://pt-br.react.dev/learn/accessibility)
+- [React Acessibilidade](https://react.dev/learn/accessibility)
 - [axe DevTools](https://www.deque.com/axe/devtools/)

--- a/Dev/i18n/pt/React/commands/bundle-analyze.md
+++ b/Dev/i18n/pt/React/commands/bundle-analyze.md
@@ -1,30 +1,30 @@
 ---
-description: Analise de Tamanho do Bundle
+description: Análise do Tamanho do Bundle
 ---
 
-# Analise de Tamanho do Bundle
+# Análise do Tamanho do Bundle
 
-Analisar o bundle de producao para identificar oportunidades de otimizacao.
+Analise o bundle de produção para identificar oportunidades de otimização.
 
 ## O Que Este Comando Faz
 
-1. **Analise do Bundle**
-   - Visualizar composicao do bundle
-   - Identificar dependencias grandes
-   - Detectar codigo duplicado
-   - Verificar code splitting
+1. **Análise do Bundle**
+   - Visualizar a composição do bundle
+   - Identificar dependências volumosas
+   - Detectar código duplicado
+   - Verificar a divisão de código (code splitting)
    - Analisar tamanhos de chunks
 
-2. **Ferramentas Usadas**
+2. **Ferramentas Utilizadas**
    - rollup-plugin-visualizer (Vite)
    - webpack-bundle-analyzer (Webpack)
    - source-map-explorer
 
-3. **Relatorio Gerado**
+3. **Relatório Gerado**
    - Treemap interativo
-   - Decomposicao de tamanho por modulo
-   - Tamanhos comprimidos com gzip
-   - Recomendacoes de otimizacao
+   - Detalhamento de tamanho por módulo
+   - Tamanhos comprimidos (gzip)
+   - Recomendações de otimização
 
 ## Como Usar
 
@@ -36,24 +36,299 @@ npm run build:analyze
 pnpm build:analyze
 ```
 
-## Modo Plano
+## Modo de Planejamento
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
-## Tamanhos Recomendados de Bundle
+## Configuração
+
+### Vite (rollup-plugin-visualizer)
+
+```typescript
+// vite.config.ts
+import { defineConfig } from 'vite';
+import { visualizer } from 'rollup-plugin-visualizer';
+
+export default defineConfig({
+  plugins: [
+    react(),
+    visualizer({
+      filename: './dist/stats.html',
+      open: true,
+      gzipSize: true,
+      brotliSize: true,
+      template: 'treemap' // ou 'sunburst', 'network'
+    })
+  ],
+  build: {
+    rollupOptions: {
+      output: {
+        manualChunks: {
+          'react-vendor': ['react', 'react-dom', 'react-router-dom'],
+          'query-vendor': ['@tanstack/react-query'],
+          'form-vendor': ['react-hook-form', 'zod']
+        }
+      }
+    }
+  }
+});
+```
+
+### Webpack (webpack-bundle-analyzer)
+
+```typescript
+// webpack.config.js
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
+
+module.exports = {
+  plugins: [
+    new BundleAnalyzerPlugin({
+      analyzerMode: 'static',
+      reportFilename: 'bundle-report.html',
+      openAnalyzer: true
+    })
+  ]
+};
+```
+
+## O Que Verificar
+
+### 1. Dependências Volumosas
+
+```typescript
+// ❌ Ruim - Importando biblioteca inteira
+import _ from 'lodash';
+import moment from 'moment';
+
+// ✅ Bom - Importando apenas o necessário
+import debounce from 'lodash/debounce';
+import { format } from 'date-fns';
+```
+
+### 2. Código Duplicado
+
+```typescript
+// ❌ Ruim - Duplicado em múltiplos chunks
+// Verificar se o mesmo código aparece em múltiplos bundles
+
+// ✅ Bom - Extrair para chunk compartilhado
+// vite.config.ts
+build: {
+  rollupOptions: {
+    output: {
+      manualChunks: {
+        'shared': ['./src/utils/common.ts']
+      }
+    }
+  }
+}
+```
+
+### 3. Divisão de Código (Code Splitting)
+
+```typescript
+// ❌ Ruim - Carregando tudo de uma vez
+import { HeavyComponent } from './HeavyComponent';
+
+// ✅ Bom - Carregamento preguiçoso (lazy loading)
+const HeavyComponent = lazy(() => import('./HeavyComponent'));
+
+<Suspense fallback={<Loading />}>
+  <HeavyComponent />
+</Suspense>
+```
+
+### 4. Tree Shaking
+
+```typescript
+// ❌ Ruim - Impede o tree shaking
+import * as Utils from './utils';
+
+// ✅ Bom - Permite o tree shaking
+import { formatDate, validateEmail } from './utils';
+```
+
+## Estratégias de Otimização
+
+### 1. Carregamento Preguiçoso de Rotas
+
+```typescript
+// App.tsx
+import { lazy, Suspense } from 'react';
+
+const HomePage = lazy(() => import('./pages/HomePage'));
+const Dashboard = lazy(() => import('./pages/Dashboard'));
+const Settings = lazy(() => import('./pages/Settings'));
+
+function App() {
+  return (
+    <Suspense fallback={<Loading />}>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/dashboard" element={<Dashboard />} />
+        <Route path="/settings" element={<Settings />} />
+      </Routes>
+    </Suspense>
+  );
+}
+```
+
+### 2. Importações Dinâmicas
+
+```typescript
+// Carregar biblioteca pesada somente quando necessário
+const loadChart = async () => {
+  const Chart = await import('chart.js');
+  return Chart;
+};
+
+function ChartComponent() {
+  useEffect(() => {
+    loadChart().then((Chart) => {
+      // Usar Chart.js
+    });
+  }, []);
+}
+```
+
+### 3. Substituir Bibliotecas Pesadas
+
+```bash
+# Substituir moment.js (290KB) por date-fns (13KB)
+npm uninstall moment
+npm install date-fns
+
+# Substituir lodash (71KB) por lodash-es (tree-shakeable)
+npm uninstall lodash
+npm install lodash-es
+```
+
+### 4. Remover Código Não Utilizado
+
+```bash
+# Encontrar exportações não utilizadas
+npx ts-prune
+
+# Remover dependências não utilizadas
+npx depcheck
+```
+
+## Metas de Tamanho
+
+### Tamanhos de Bundle Recomendados
 
 - **Bundle Inicial**: < 200KB (gzipped)
 - **JavaScript Total**: < 500KB (gzipped)
 - **Chunks Individuais**: < 100KB cada
 - **Maior Chunk**: < 200KB
 
-## Melhores Praticas
+### Configuração de Budget
 
-1. **Analisar regularmente** apos adicionar dependencias
-2. **Definir orcamentos de tamanho** e aplicar no CI
-3. **Lazy load** codigo nao-critico
-4. **Tree shake** agressivamente
-5. **Monitorar** tamanho do bundle ao longo do tempo
-6. **Dividir codigo** inteligentemente
-7. **Escolher alternativas leves**
-8. **Remover** dependencias nao utilizadas
+```json
+// vite.config.ts
+export default defineConfig({
+  build: {
+    chunkSizeWarningLimit: 500, // KB
+    rollupOptions: {
+      output: {
+        manualChunks(id) {
+          if (id.includes('node_modules')) {
+            return 'vendor';
+          }
+        }
+      }
+    }
+  }
+});
+```
+
+## Budget de Performance (Lighthouse)
+
+```json
+// budget.json
+[
+  {
+    "resourceSizes": [
+      {
+        "resourceType": "script",
+        "budget": 200
+      },
+      {
+        "resourceType": "total",
+        "budget": 500
+      }
+    ]
+  }
+]
+```
+
+## Monitoramento Contínuo
+
+### Integração CI/CD
+
+```yaml
+# .github/workflows/bundle-size.yml
+name: Bundle Size Check
+
+on: [pull_request]
+
+jobs:
+  check-size:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+      - run: npm ci
+      - run: npm run build
+      - uses: andresz1/size-limit-action@v1
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+```
+
+## Problemas Comuns
+
+### Problema 1: Bundle de Vendor Grande
+
+**Solução**: Dividir o código de vendor
+```typescript
+manualChunks: {
+  'react-vendor': ['react', 'react-dom'],
+  'router-vendor': ['react-router-dom'],
+  'query-vendor': ['@tanstack/react-query']
+}
+```
+
+### Problema 2: Dependências Duplicadas
+
+**Solução**: Verificar e desduplicar
+```bash
+npm dedupe
+# ou
+pnpm dedupe
+```
+
+### Problema 3: CSS Não Utilizado
+
+**Solução**: PurgeCSS
+```bash
+npm install -D @fullhuman/postcss-purgecss
+```
+
+## Ferramentas
+
+- [rollup-plugin-visualizer](https://github.com/btd/rollup-plugin-visualizer)
+- [webpack-bundle-analyzer](https://github.com/webpack-contrib/webpack-bundle-analyzer)
+- [source-map-explorer](https://github.com/danvk/source-map-explorer)
+- [bundlephobia](https://bundlephobia.com/)
+- [Package Phobia](https://packagephobia.com/)
+
+## Boas Práticas
+
+1. **Analisar regularmente** após adicionar dependências
+2. **Definir budgets de tamanho** e aplicá-los no CI
+3. **Carregar preguiçosamente** código não crítico
+4. **Aplicar tree shaking** de forma agressiva
+5. **Monitorar** o tamanho do bundle ao longo do tempo
+6. **Dividir o código** de forma inteligente
+7. **Escolher alternativas leves** para bibliotecas pesadas
+8. **Remover dependências** não utilizadas

--- a/Dev/i18n/pt/React/commands/check-architecture.md
+++ b/Dev/i18n/pt/React/commands/check-architecture.md
@@ -1,59 +1,394 @@
 ---
-description: Verificacao de Conformidade de Arquitetura
+description: Verificação de Conformidade Arquitetural
 ---
 
-# Verificacao de Conformidade de Arquitetura
+# Verificação de Conformidade Arquitetural
 
-Verificar se o projeto segue padroes arquiteturais e melhores praticas estabelecidas.
+Verifique se o projeto segue os padrões arquiteturais estabelecidos e as melhores práticas.
 
 ## O Que Este Comando Faz
 
-1. **Analise de Arquitetura**
-   - Verificar estrutura de pastas
-   - Verificar separacao de responsabilidades
-   - Validar organizacao de componentes
-   - Verificar direcoes de dependencia
-   - Verificar padroes de design
+1. **Análise de Arquitetura**
+   - Verificar a estrutura de pastas
+   - Validar a separação de responsabilidades
+   - Confirmar a organização dos componentes
+   - Verificar as direções de dependência
+   - Validar os padrões de design utilizados
 
-2. **Pontos de Verificacao**
-   - Estrutura baseada em funcionalidades
+2. **Pontos de Verificação**
+   - Estrutura baseada em features
    - Hierarquia de componentes
    - Gerenciamento de estado
-   - Separacao da camada de API
-   - Definicoes de tipos
+   - Separação da camada de API
+   - Definições de tipos
 
-3. **Relatorio Gerado**
-   - Violacoes de arquitetura
-   - Recomendacoes
-   - Oportunidades de refatoracao
-   - Score de conformidade
+3. **Relatório Gerado**
+   - Violações arquiteturais
+   - Recomendações
+   - Oportunidades de refatoração
+   - Pontuação de conformidade
 
 ## Modo Plano
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou exige investigação transversal.
 
-## Estrutura Esperada
+## Arquitetura Esperada
+
+### Estrutura de Pastas
 
 ```
 src/
-├── app/                    # Configuracao da aplicacao
-├── features/              # Funcionalidades (logica de negocio)
+├── app/                    # Configuração da aplicação
+│   ├── App.tsx
+│   ├── routes.tsx
+│   └── providers.tsx
+│
+├── features/              # Features (lógica de negócio)
+│   └── users/
+│       ├── components/    # Componentes específicos da feature
+│       ├── hooks/         # Hooks específicos da feature
+│       ├── services/      # Chamadas de API
+│       ├── stores/        # Gerenciamento de estado
+│       ├── types/         # Tipos TypeScript
+│       └── utils/         # Funções utilitárias
+│
 ├── components/            # Componentes compartilhados
+│   ├── ui/               # Primitivas de UI (Button, Input)
+│   ├── layout/           # Componentes de layout
+│   └── common/           # Componentes comuns
+│
 ├── hooks/                 # Hooks compartilhados
-├── services/             # Servicos compartilhados
+├── services/             # Serviços compartilhados
 ├── stores/               # Estado global
 ├── types/                # Tipos globais
-├── utils/                # Funcoes utilitarias
-└── config/               # Configuracao
+├── utils/                # Funções utilitárias
+├── constants/            # Constantes
+└── config/               # Configuração
 ```
 
-## Melhores Praticas
+## O Que Verificar
 
-1. **Isolamento de funcionalidades**: Cada funcionalidade e autocontida
-2. **Limites claros**: Camadas de apresentacao, logica, dados
-3. **Injecao de dependencia**: Servicos atraves de hooks/context
-4. **Type safety**: TypeScript em todos os lugares
-5. **Nomenclatura consistente**: Seguir convencoes
-6. **Responsabilidade unica**: Um componente, uma tarefa
-7. **Composicao sobre heranca**: Usar composicao
-8. **Documentacao**: Documentar decisoes de arquitetura
+### 1. Organização de Componentes
+
+```typescript
+// ❌ Ruim - Tudo em um único arquivo
+src/components/UserList.tsx (1000 linhas)
+
+// ✅ Bom - Organização adequada
+src/features/users/
+  ├── components/
+  │   ├── UserList/
+  │   │   ├── UserList.tsx
+  │   │   ├── UserList.test.tsx
+  │   │   ├── UserListItem.tsx
+  │   │   └── index.ts
+  │   └── UserForm/
+  │       ├── UserForm.tsx
+  │       └── UserForm.test.tsx
+  ├── hooks/
+  │   └── useUsers.ts
+  └── services/
+      └── user.service.ts
+```
+
+### 2. Separação de Responsabilidades
+
+```typescript
+// ❌ Ruim - Responsabilidades misturadas
+export const UserList: FC = () => {
+  const [users, setUsers] = useState([]);
+
+  useEffect(() => {
+    fetch('/api/users')
+      .then(res => res.json())
+      .then(setUsers);
+  }, []);
+
+  return (
+    <div>
+      {users.map(user => (
+        <div key={user.id}>
+          <h3>{user.name}</h3>
+          <p>{user.email}</p>
+        </div>
+      ))}
+    </div>
+  );
+};
+
+// ✅ Bom - Responsabilidades separadas
+// hooks/useUsers.ts
+export const useUsers = () => {
+  return useQuery({
+    queryKey: ['users'],
+    queryFn: () => userService.getAll()
+  });
+};
+
+// services/user.service.ts
+export const userService = {
+  getAll: () => apiClient.get<User[]>('/users')
+};
+
+// components/UserList.tsx
+export const UserList: FC = () => {
+  const { data: users, isLoading } = useUsers();
+
+  if (isLoading) return <Spinner />;
+
+  return (
+    <ul>
+      {users?.map(user => (
+        <UserListItem key={user.id} user={user} />
+      ))}
+    </ul>
+  );
+};
+```
+
+### 3. Direção das Dependências
+
+```typescript
+// ✅ Bom - As dependências fluem para dentro
+features/users/
+  └── components/     → Pode usar hooks/
+      └── hooks/      → Pode usar services/
+          └── services/ → Pode usar utils/
+
+// ❌ Ruim - Dependências circulares
+services/user.service.ts importa de components/
+```
+
+### 4. Tipos de Componentes
+
+```typescript
+// Componentes de Apresentação (apenas UI)
+export const Button: FC<ButtonProps> = ({ children, ...props }) => {
+  return <button {...props}>{children}</button>;
+};
+
+// Componentes Container (lógica)
+export const UserListContainer: FC = () => {
+  const { data: users } = useUsers();
+  const deleteUser = useDeleteUser();
+
+  return <UserListPresenter users={users} onDelete={deleteUser} />;
+};
+
+// Componentes de Página (roteamento)
+export const UsersPage: FC = () => {
+  return (
+    <MainLayout>
+      <PageHeader title="Usuários" />
+      <UserListContainer />
+    </MainLayout>
+  );
+};
+```
+
+### 5. Gerenciamento de Estado
+
+```typescript
+// ❌ Ruim - Estado em vários lugares
+const [users, setUsers] = useState([]);
+// Mesmos dados em 5 componentes diferentes
+
+// ✅ Bom - Estado centralizado
+// stores/userStore.ts
+export const useUserStore = create<UserStore>((set) => ({
+  users: [],
+  setUsers: (users) => set({ users })
+}));
+
+// Ou React Query para estado do servidor
+export const useUsers = () => {
+  return useQuery({
+    queryKey: ['users'],
+    queryFn: () => userService.getAll()
+  });
+};
+```
+
+## Padrões Arquiteturais
+
+### 1. Estrutura Baseada em Features
+
+```
+src/features/
+├── auth/
+│   ├── components/
+│   ├── hooks/
+│   ├── services/
+│   └── stores/
+├── users/
+└── products/
+```
+
+### 2. Camadas de Clean Architecture
+
+```
+Camada de Apresentação (Componentes)
+    ↓
+Camada de Lógica de Negócio (Hooks, Services)
+    ↓
+Camada de Dados (API, Store)
+```
+
+### 3. Design Atômico
+
+```
+src/components/
+├── atoms/        # Button, Input, Label
+├── molecules/    # FormField, SearchBar
+├── organisms/    # UserForm, Header
+├── templates/    # PageLayout, DashboardLayout
+└── pages/        # HomePage, UsersPage
+```
+
+## Regras de Validação
+
+### Regra 1: Sem Lógica de Negócio em Componentes
+
+```typescript
+// ❌ Ruim
+export const UserForm: FC = () => {
+  const [email, setEmail] = useState('');
+
+  const validate = () => {
+    return email.includes('@') && email.length > 5;
+  };
+
+  // ... lógica de validação complexa
+};
+
+// ✅ Bom
+export const UserForm: FC = () => {
+  const form = useForm({
+    resolver: zodResolver(userSchema)
+  });
+
+  // Validação no schema, lógica no hook
+};
+```
+
+### Regra 2: Chamadas de API Através de Serviços
+
+```typescript
+// ❌ Ruim - fetch direto no componente
+const response = await fetch('/api/users');
+
+// ✅ Bom - Através do serviço
+const users = await userService.getAll();
+```
+
+### Regra 3: Tipos São Centralizados
+
+```typescript
+// ✅ Boa estrutura
+src/features/users/types/
+  ├── user.types.ts
+  ├── dto.types.ts
+  └── index.ts
+```
+
+## Verificações Automatizadas
+
+### Regras ESLint para Arquitetura
+
+```json
+// .eslintrc.json
+{
+  "rules": {
+    "no-restricted-imports": [
+      "error",
+      {
+        "patterns": [
+          {
+            "group": ["../**/features/*"],
+            "message": "Features não devem importar de outras features"
+          },
+          {
+            "group": ["**/components/**/services/*"],
+            "message": "Componentes não devem importar serviços diretamente"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+### Script Personalizado
+
+```typescript
+// scripts/check-architecture.ts
+import { glob } from 'glob';
+import { readFile } from 'fs/promises';
+
+const checkImports = async () => {
+  const files = await glob('src/**/*.{ts,tsx}');
+  const violations = [];
+
+  for (const file of files) {
+    const content = await readFile(file, 'utf-8');
+
+    // Verificar violações
+    if (file.includes('/components/') && content.includes('fetch(')) {
+      violations.push({
+        file,
+        rule: 'Sem chamadas diretas de API em componentes',
+        line: content.split('\n').findIndex(l => l.includes('fetch('))
+      });
+    }
+  }
+
+  return violations;
+};
+```
+
+## Melhores Práticas
+
+1. **Isolamento de features**: Cada feature é autocontida
+2. **Fronteiras claras**: Camadas de apresentação, lógica e dados
+3. **Injeção de dependências**: Serviços através de hooks/context
+4. **Segurança de tipos**: TypeScript em todo lugar
+5. **Nomenclatura consistente**: Seguir as convenções
+6. **Responsabilidade única**: Um componente, uma responsabilidade
+7. **Composição sobre herança**: Usar composição
+8. **Documentação**: Documentar as decisões arquiteturais
+
+## Violações Comuns
+
+### Violação 1: Componentes Deus
+
+**Problema**: O componente faz coisas demais
+**Solução**: Dividir em componentes menores
+
+### Violação 2: Dependências Circulares
+
+**Problema**: A importa B, B importa A
+**Solução**: Extrair código comum ou repensar a estrutura
+
+### Violação 3: Prop Drilling
+
+**Problema**: Passar props por muitos níveis
+**Solução**: Usar Context ou gerenciamento de estado
+
+### Violação 4: Responsabilidades Misturadas
+
+**Problema**: UI e lógica de negócio misturadas
+**Solução**: Separar em apresentador (presenter) e container
+
+## Ferramentas
+
+- ESLint com regras personalizadas
+- Dependency cruiser
+- Madge (grafo de dependências)
+- SonarQube
+- Scripts personalizados
+
+## Recursos
+
+- [Melhores Práticas de Arquitetura React](https://react.dev/learn/thinking-in-react)
+- [Feature-Sliced Design](https://feature-sliced.design/)
+- [Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)

--- a/Dev/i18n/pt/React/commands/check-code-quality.md
+++ b/Dev/i18n/pt/React/commands/check-code-quality.md
@@ -1,41 +1,41 @@
 ---
-description: Verificacao de Qualidade de Codigo
+description: Verificação de Qualidade de Código
 ---
 
-# Verificacao de Qualidade de Codigo
+# Verificação de Qualidade de Código
 
-Realizar uma analise abrangente de qualidade de codigo da aplicacao React.
+Realize uma análise abrangente da qualidade de código da aplicação React.
 
 ## O Que Este Comando Faz
 
-1. **Analise de Qualidade**
+1. **Análise de Qualidade**
    - Executar linting (ESLint)
-   - Verificacao de tipos (TypeScript)
-   - Formatacao de codigo (Prettier)
-   - Analise de complexidade
-   - Deteccao de code smells
-   - Verificacao de cobertura de testes
+   - Verificação de tipos (TypeScript)
+   - Formatação de código (Prettier)
+   - Análise de complexidade
+   - Detecção de code smells
+   - Verificação de cobertura de testes
 
-2. **Metricas Medidas**
-   - Complexidade ciclomatica
-   - Duplicacao de codigo
+2. **Métricas Medidas**
+   - Complexidade ciclomática
+   - Duplicação de código
    - Cobertura de testes
-   - Divida tecnica
-   - Indice de manutenibilidade
+   - Dívida técnica
+   - Índice de manutenibilidade
 
-3. **Relatorio Gerado**
-   - Score de qualidade
+3. **Relatório Gerado**
+   - Pontuação de qualidade
    - Problemas por severidade
-   - Recomendacoes de refatoracao
-   - Tendencias ao longo do tempo
+   - Recomendações de refatoração
+   - Tendências ao longo do tempo
 
 ## Como Usar
 
 ```bash
-# Verificacao completa de qualidade
+# Verificação completa de qualidade
 npm run quality
 
-# Verificacoes individuais
+# Verificações individuais
 npm run lint
 npm run type-check
 npm run format:check
@@ -44,21 +44,427 @@ npm run test:coverage
 
 ## Modo Plano
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou exige investigação transversal.
 
-## Metas de Metricas de Qualidade
+## Verificações de Qualidade
 
-- **Complexidade Ciclomatica**: < 10 por funcao
-- **Cobertura de Testes**: > 80%
-- **Duplicacao de Codigo**: < 3%
+### 1. Linting (ESLint)
 
-## Melhores Praticas
+```bash
+# Verificar erros
+npm run lint
 
-1. **Executar verificacoes localmente** antes de fazer push
-2. **Automatizar no CI/CD** para aplicar padroes
-3. **Definir quality gates** que devem passar
-4. **Monitorar tendencias** ao longo do tempo
-5. **Refatorar regularmente** para reduzir divida tecnica
-6. **Documentar padroes** para a equipe
-7. **Revisar metricas** em reunioes de equipe
+# Corrigir erros automaticamente
+npm run lint:fix
+```
+
+**Configuração**:
+```json
+// .eslintrc.json
+{
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/recommended",
+    "plugin:react/recommended",
+    "plugin:react-hooks/recommended"
+  ],
+  "rules": {
+    "no-console": "warn",
+    "no-debugger": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react-hooks/exhaustive-deps": "warn"
+  }
+}
+```
+
+### 2. Verificação de Tipos (TypeScript)
+
+```bash
+# Verificar tipos
+npm run type-check
+
+# Modo observação
+npm run type-check:watch
+```
+
+**Problemas Comuns**:
+```typescript
+// ❌ Ruim - Tipo any
+const data: any = fetchData();
+
+// ✅ Bom - Tipos adequados
+interface User {
+  id: string;
+  name: string;
+}
+const data: User = fetchData();
+
+// ❌ Ruim - any implícito
+const handleClick = (event) => {};
+
+// ✅ Bom - Tipos explícitos
+const handleClick = (event: React.MouseEvent) => {};
+```
+
+### 3. Formatação de Código (Prettier)
+
+```bash
+# Verificar formatação
+npm run format:check
+
+# Formatar todos os arquivos
+npm run format
+```
+
+**Configuração**:
+```json
+// .prettierrc
+{
+  "semi": true,
+  "trailingComma": "all",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2
+}
+```
+
+### 4. Análise de Complexidade
+
+```typescript
+// ❌ Ruim - Alta complexidade (10+)
+function processUser(user, options) {
+  if (user.isActive) {
+    if (user.role === 'admin') {
+      if (options.includeStats) {
+        if (user.lastLogin) {
+          // ... lógica aninhada
+        }
+      }
+    }
+  }
+  // Complexidade: 15
+}
+
+// ✅ Bom - Baixa complexidade
+function processUser(user, options) {
+  if (!user.isActive) return null;
+  if (user.role !== 'admin') return formatBasicUser(user);
+  if (!options.includeStats) return formatAdminUser(user);
+  return formatAdminUserWithStats(user);
+  // Complexidade: 4
+}
+```
+
+### 5. Duplicação de Código
+
+```typescript
+// ❌ Ruim - Código duplicado
+export const UserList = () => {
+  const [users, setUsers] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch('/api/users')
+      .then(res => res.json())
+      .then(setUsers)
+      .finally(() => setLoading(false));
+  }, []);
+};
+
+export const ProductList = () => {
+  const [products, setProducts] = useState([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch('/api/products')
+      .then(res => res.json())
+      .then(setProducts)
+      .finally(() => setLoading(false));
+  }, []);
+};
+
+// ✅ Bom - Hook reutilizável
+export const useFetch = <T>(url: string) => {
+  const [data, setData] = useState<T[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    setLoading(true);
+    fetch(url)
+      .then(res => res.json())
+      .then(setData)
+      .finally(() => setLoading(false));
+  }, [url]);
+
+  return { data, loading };
+};
+```
+
+## Métricas de Qualidade de Código
+
+### Complexidade Ciclomática
+
+**Meta**: < 10 por função
+
+```bash
+# Instalar verificador de complexidade
+npm install -D eslint-plugin-complexity
+
+# Adicionar à configuração do ESLint
+{
+  "rules": {
+    "complexity": ["error", 10]
+  }
+}
+```
+
+### Cobertura de Testes
+
+**Metas**:
+- Linhas: > 80%
+- Funções: > 80%
+- Branches: > 75%
+- Declarações: > 80%
+
+```bash
+# Gerar relatório de cobertura
+npm run test:coverage
+```
+
+```json
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html'],
+      lines: 80,
+      functions: 80,
+      branches: 75,
+      statements: 80
+    }
+  }
+});
+```
+
+### Duplicação de Código
+
+**Meta**: < 3% de duplicação
+
+```bash
+# Instalar jscpd
+npm install -D jscpd
+
+# Executar verificação de duplicação
+npx jscpd src/
+```
+
+## Portões de Qualidade
+
+### Verificações de Pré-Commit
+
+```json
+// package.json
+{
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write",
+      "vitest related --run --passWithNoTests"
+    ]
+  }
+}
+```
+
+### Portões de Qualidade no CI/CD
+
+```yaml
+# .github/workflows/quality.yml
+name: Quality Check
+
+on: [pull_request]
+
+jobs:
+  quality:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Verificação de tipos
+        run: npm run type-check
+
+      - name: Verificação de formatação
+        run: npm run format:check
+
+      - name: Testes com cobertura
+        run: npm run test:coverage
+
+      - name: Verificar cobertura
+        uses: codecov/codecov-action@v3
+```
+
+## Code Smells
+
+### 1. Listas de Parâmetros Longas
+
+```typescript
+// ❌ Ruim - Muitos parâmetros
+function createUser(
+  name: string,
+  email: string,
+  age: number,
+  address: string,
+  phone: string,
+  role: string
+) {}
+
+// ✅ Bom - Usar parâmetro de objeto
+interface CreateUserParams {
+  name: string;
+  email: string;
+  age: number;
+  address: string;
+  phone: string;
+  role: string;
+}
+
+function createUser(params: CreateUserParams) {}
+```
+
+### 2. Funções Muito Longas
+
+```typescript
+// ❌ Ruim - Função muito longa (100+ linhas)
+function handleSubmit() {
+  // ... 100 linhas de código
+}
+
+// ✅ Bom - Dividir em funções menores
+function handleSubmit() {
+  validateForm();
+  processData();
+  submitToAPI();
+}
+```
+
+### 3. Números Mágicos
+
+```typescript
+// ❌ Ruim - Números mágicos
+if (user.age > 18 && cart.total > 100) {}
+
+// ✅ Bom - Constantes nomeadas
+const ADULT_AGE = 18;
+const FREE_SHIPPING_THRESHOLD = 100;
+
+if (user.age > ADULT_AGE && cart.total > FREE_SHIPPING_THRESHOLD) {}
+```
+
+### 4. Aninhamento Profundo
+
+```typescript
+// ❌ Ruim - Aninhamento profundo
+if (user) {
+  if (user.isActive) {
+    if (user.role === 'admin') {
+      if (hasPermission) {
+        // ...
+      }
+    }
+  }
+}
+
+// ✅ Bom - Guard clauses (cláusulas de guarda)
+if (!user) return;
+if (!user.isActive) return;
+if (user.role !== 'admin') return;
+if (!hasPermission) return;
+// ...
+```
+
+## Integração com SonarQube
+
+```bash
+# Instalar o SonarScanner
+npm install -D sonarqube-scanner
+
+# Executar análise
+npx sonar-scanner \
+  -Dsonar.projectKey=my-project \
+  -Dsonar.sources=src \
+  -Dsonar.host.url=http://localhost:9000 \
+  -Dsonar.login=your-token
+```
+
+## Melhoria Contínua
+
+### Acompanhar Métricas ao Longo do Tempo
+
+```json
+// .qualityrc
+{
+  "metrics": {
+    "complexity": {
+      "current": 8,
+      "target": 10,
+      "trend": "improving"
+    },
+    "coverage": {
+      "current": 85,
+      "target": 80,
+      "trend": "stable"
+    },
+    "duplication": {
+      "current": 2,
+      "target": 3,
+      "trend": "improving"
+    }
+  }
+}
+```
+
+### Dashboard de Qualidade
+
+Crie um dashboard para visualizar:
+- Tendências de cobertura de código
+- Tendências de complexidade
+- Número de problemas por severidade
+- Estimativa da dívida técnica
+
+## Ferramentas
+
+- **ESLint**: Análise estática de código
+- **TypeScript**: Verificação de tipos
+- **Prettier**: Formatação de código
+- **Vitest**: Cobertura de testes
+- **SonarQube**: Plataforma de qualidade de código
+- **jscpd**: Detecção de duplicação
+- **Lighthouse**: Auditoria de desempenho
+
+## Melhores Práticas
+
+1. **Executar verificações localmente** antes de fazer push
+2. **Automatizar no CI/CD** para impor padrões
+3. **Definir portões de qualidade** que devem ser aprovados
+4. **Monitorar tendências** ao longo do tempo
+5. **Refatorar regularmente** para reduzir a dívida técnica
+6. **Documentar padrões** para a equipe
+7. **Revisar métricas** nas reuniões de equipe
 8. **Celebrar melhorias**
+
+## Recursos
+
+- [Regras do ESLint](https://eslint.org/docs/rules/)
+- [Manual do TypeScript](https://www.typescriptlang.org/docs/handbook/intro.html)
+- [Princípios de Código Limpo](https://github.com/ryanmcdermott/clean-code-javascript)
+- [Refactoring Guru](https://refactoring.guru/)

--- a/Dev/i18n/pt/React/commands/check-compliance.md
+++ b/Dev/i18n/pt/React/commands/check-compliance.md
@@ -1,83 +1,253 @@
 ---
-description: Verificacao de Conformidade de Padroes
+description: Verificar Conformidade Completa React
+argument-hint: [arguments]
 ---
 
-# Verificacao de Conformidade de Padroes
+# Verificar Conformidade Completa React
 
-Verificar se o projeto React segue padroes de codigo e melhores praticas estabelecidas.
+## Argumentos
 
-## O Que Este Comando Faz
+$ARGUMENTS (opcional: caminho do projeto a analisar)
 
-1. **Verificacao de Padroes**
-   - Verificar convencoes de codigo
-   - Verificar convencoes de nomenclatura
-   - Validar organizacao de arquivos
-   - Verificar ordem de imports
-   - Verificar padroes de documentacao
+## Modo de Planejamento
 
-2. **Areas de Conformidade**
-   - Melhores praticas TypeScript
-   - Padroes React
-   - Convencoes CSS/Styling
-   - Padroes de testes
-   - Convencoes de commit Git
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
-3. **Relatorio Gerado**
-   - Arquivos nao-conformes
-   - Niveis de severidade
-   - Recomendacoes de remediacao
-   - Score de conformidade
+## MISSÃO
 
-## Modo Plano
+Realizar uma auditoria de conformidade completa do projeto React orquestrando as 4 grandes verificações: Arquitetura, Qualidade de Código, Testes e Segurança. Produzir um relatório consolidado com uma pontuação global de 100 pontos.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+### Passo 1: Preparação da Auditoria
 
-## Padroes de Codigo
+Preparar o ambiente de auditoria:
+- [ ] Identificar o caminho do projeto a auditar
+- [ ] Verificar a presença dos arquivos de configuração (package.json, tsconfig.json)
+- [ ] Listar os diretórios principais (src/, tests/, public/, etc.)
+- [ ] Identificar a estrutura do projeto e a versão do React
 
-### 1. Convencoes de Nomenclatura
+**Nota**: Se $ARGUMENTS fornecido, usar como caminho do projeto; caso contrário, usar o diretório atual.
 
-```typescript
-// ✅ Componentes: PascalCase
-export const UserProfile: FC = () => {};
+### Passo 2: Auditoria de Arquitetura (25 pontos)
 
-// ✅ Funcoes/variaveis: camelCase
-const getUserData = () => {};
-const isAuthenticated = true;
+Executar verificação completa de arquitetura:
 
-// ✅ Constantes: UPPER_SNAKE_CASE
-const API_BASE_URL = 'https://api.exemplo.com';
-const MAX_RETRY_ATTEMPTS = 3;
+**Comando**: Usar o slash command `/react:check-architecture` ou seguir manualmente os passos em `check-architecture.md`
 
-// ✅ Tipos/Interfaces: PascalCase
-interface User {}
-type UserRole = 'admin' | 'user';
+**Critérios Avaliados**:
+- Estrutura baseada em features (6 pts)
+- Organização de componentes e colocation (6 pts)
+- Padrões de gerenciamento de estado (4 pts)
+- Roteamento e navegação (4 pts)
+- Separação do módulo compartilhado/comum (3 pts)
+- Regras de dependência e exportações barrel (2 pts)
+
+**Referência**: `check-architecture.md`
+
+### Passo 3: Auditoria de Qualidade de Código (25 pontos)
+
+Executar verificação de qualidade de código:
+
+**Comando**: Usar o slash command `/react:check-code-quality` ou seguir manualmente os passos em `check-code-quality.md`
+
+**Critérios Avaliados**:
+- Modo estrito TypeScript e segurança de tipos (5 pts)
+- Conformidade com ESLint e Prettier (5 pts)
+- Padrões React e regras de hooks (4 pts)
+- Princípios KISS/DRY/YAGNI (4 pts)
+- Convenções de nomenclatura (4 pts)
+- Tratamento de erros e error boundaries (3 pts)
+
+**Referência**: `check-code-quality.md`
+
+### Passo 4: Auditoria de Testes (25 pontos)
+
+Executar verificação de testes:
+
+**Comando**: Usar o slash command `/react:check-testing` ou seguir manualmente os passos em `check-testing.md`
+
+**Critérios Avaliados**:
+- Cobertura de código (7 pts)
+- Testes unitários para hooks e utilitários (6 pts)
+- Testes de componentes com Testing Library (4 pts)
+- Testes de integração (3 pts)
+- Qualidade dos testes e padrão AAA (3 pts)
+- Organização de mocks e fixtures (2 pts)
+
+**Referência**: `check-testing.md`
+
+### Passo 5: Auditoria de Segurança (25 pontos)
+
+Executar verificação de segurança:
+
+**Comando**: Usar o slash command `/react:check-security` ou seguir manualmente os passos em `check-security.md`
+
+**Critérios Avaliados**:
+- Prevenção de XSS (dangerouslySetInnerHTML) (6 pts)
+- Gerenciamento de segredos e credenciais (5 pts)
+- Validação e sanitização de entradas (4 pts)
+- Vulnerabilidades em dependências (4 pts)
+- Autenticação e autorização (3 pts)
+- Comunicação segura com a API (2 pts)
+- Proteção contra CSRF (1 pt)
+
+**Referência**: `check-security.md`
+
+### Passo 6: Consolidação e Pontuação Global
+
+Calcular a pontuação geral e produzir o relatório consolidado:
+- [ ] Somar as 4 pontuações (máximo 100 pontos)
+- [ ] Identificar categorias críticas (<50%)
+- [ ] Listar todos os problemas críticos transversais
+- [ ] Priorizar ações por impacto/esforço
+- [ ] Produzir o relatório consolidado final
+
+**Escala de Avaliação**:
+- 90-100: Excelente — Projeto de referência
+- 75-89: Muito Bom — Algumas melhorias pontuais
+- 60-74: Aceitável — Requer melhorias
+- 40-59: Insuficiente — Refatoração importante necessária
+- 0-39: Crítico — Reformulação completa necessária
+
+### Passo 7: Recomendações e Plano de Ação
+
+Produzir recomendações finais:
+- [ ] Identificar as 3 ações prioritárias em todas as categorias
+- [ ] Estimar o esforço (Baixo/Médio/Alto) para cada ação
+- [ ] Estimar o impacto (Baixo/Médio/Alto) para cada ação
+- [ ] Propor a ordem de implementação
+- [ ] Sugerir quick wins (alta relação impacto/esforço)
+
+## FORMATO DE SAÍDA
+
+```
+AUDITORIA DE CONFORMIDADE REACT - RELATÓRIO COMPLETO
+=====================================================
+
+PONTUAÇÃO GERAL: XX/100
+
+NÍVEL DE CONFORMIDADE: [Excelente/Muito Bom/Aceitável/Insuficiente/Crítico]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PONTUAÇÕES POR CATEGORIA:
+
+ARQUITETURA        : XX/25  [██████████░░░░░░░░░░] XX%
+QUALIDADE DE CÓDIGO: XX/25  [██████████░░░░░░░░░░] XX%
+TESTES             : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURANÇA          : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PONTOS FORTES GERAIS:
+1. [Ponto forte identificado em múltiplas categorias]
+2. [Outro ponto forte importante]
+3. [Terceiro ponto forte]
+
+MELHORIAS GERAIS:
+1. [Melhoria transversal menor]
+2. [Outra melhoria recomendada]
+3. [Terceira melhoria]
+
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico nº 1 — categoria afetada]
+2. [Problema crítico nº 2 — categoria afetada]
+3. [Problema crítico nº 3 — categoria afetada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALHES POR CATEGORIA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITETURA (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Sub-pontuações:
+  • Estrutura baseada em features    : XX/6
+  • Organização de componentes       : XX/6
+  • Gerenciamento de estado          : XX/4
+  • Roteamento e navegação           : XX/4
+  • Separação do módulo compartilhado: XX/3
+  • Regras de dependência            : XX/2
+
+Pontos Fortes:
+- [Pontos fortes de arquitetura]
+
+Problemas:
+- [Problemas de arquitetura]
+
+[Seções similares para Qualidade de Código, Testes e Segurança...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 AÇÕES PRIORITÁRIAS (TODAS AS CATEGORIAS):
+
+1. CRÍTICO - [Ação nº 1]
+   Categoria  : [Arquitetura/Qualidade/Testes/Segurança]
+   Impacto    : [Alto/Médio/Baixo]
+   Esforço    : [Alto/Médio/Baixo]
+   Prioridade : IMEDIATA
+
+   Descrição detalhada:
+   [Explicação do problema e solução proposta]
+
+   Arquivos afetados:
+   - [arquivo:linha]
+
+   Exemplo de correção:
+   [Código ou comando de correção]
+
+2. IMPORTANTE - [Ação nº 2]
+   [Mesmo formato...]
+
+3. RECOMENDADO - [Ação nº 3]
+   [Mesmo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+QUICK WINS (Alto Impacto / Baixo Esforço):
+
+- [Quick win nº 1] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Quick win nº 2] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Quick win nº 3] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLANO DE AÇÃO RECOMENDADO:
+
+SEMANA 1 (Imediato):
+- [ ] [Ação crítica nº 1]
+- [ ] [Quick win prioritário]
+
+SEMANAS 2-4 (Curto prazo):
+- [ ] [Ação importante nº 2]
+- [ ] [Outros quick wins]
+
+MESES 2-3 (Médio prazo):
+- [ ] [Ação recomendada nº 3]
+- [ ] [Melhorias progressivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMO EXECUTIVO:
+
+[Parágrafo de síntese sobre o estado geral do projeto, principais pontos
+fortes, principais pontos fracos e a trajetória recomendada para melhorar
+a conformidade. Mencionar se o projeto está pronto para produção,
+requer correções ou necessita de refatoração.]
+
+Recomendação Geral: [Pronto para produção / Correções pontuais /
+Refatoração importante / Reformulação necessária]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Organizacao de Arquivos
+## NOTAS IMPORTANTES
 
-```typescript
-// ✅ Bom - Organizacao adequada
-src/
-├── features/
-│   └── users/
-│       ├── components/
-│       ├── hooks/
-│       └── types/
-```
-
-## Checklist de Conformidade
-
-- [ ] Convencoes de nomenclatura seguidas
-- [ ] Arquivos organizados adequadamente
-- [ ] Imports ordenados corretamente
-- [ ] Modo strict do TypeScript habilitado
-- [ ] Sem tipos `any` usados
-- [ ] Todas as props tipadas adequadamente
-- [ ] Regras dos React Hooks seguidas
-- [ ] Testes seguem padrao AAA
-- [ ] Cobertura de testes > 80%
-- [ ] CSS organizado (modules/Tailwind)
-- [ ] Commits seguem convencoes
-- [ ] Componentes documentados
-- [ ] ESLint passa sem erros
-- [ ] Formatacao Prettier aplicada
+- Este comando orquestra as 4 auditorias especializadas
+- Usar Docker para todas as ferramentas de análise
+- Fornecer exemplos concretos com arquivo:linha para cada problema
+- Priorizar ações com base na matriz Impacto/Esforço
+- Problemas de segurança são SEMPRE a prioridade máxima
+- Propor correções automatizáveis (scripts, pre-commit hooks)
+- O relatório deve ser acionável, não apenas descritivo
+- Adaptar as recomendações ao contexto de negócio do projeto

--- a/Dev/i18n/pt/React/commands/check-security.md
+++ b/Dev/i18n/pt/React/commands/check-security.md
@@ -1,62 +1,401 @@
 ---
-description: Auditoria de Seguranca
+description: Auditoria de Segurança
 ---
 
-# Auditoria de Seguranca
+# Auditoria de Segurança
 
-Realizar uma auditoria completa de seguranca da aplicacao React.
+Realize uma auditoria de segurança abrangente da aplicação React.
 
 ## O Que Este Comando Faz
 
-1. **Analise de Seguranca**
-   - Verificar vulnerabilidades XSS
-   - Verificar validacao de entrada
-   - Auditar dependencias
-   - Verificar implementacao de autenticacao
-   - Verificar gerenciamento de segredos
-   - Verificar headers CSP
+1. **Análise de Segurança**
+   - Verificar vulnerabilidades de XSS
+   - Validar a sanitização de entradas
+   - Auditar dependências
+   - Verificar a implementação de autenticação
+   - Validar o gerenciamento de segredos
+   - Verificar cabeçalhos CSP
 
-2. **Ferramentas Usadas**
+2. **Ferramentas Utilizadas**
    - npm audit
    - Snyk
-   - Plugins de seguranca ESLint
+   - Plugins de segurança para ESLint
    - OWASP ZAP (opcional)
 
-3. **Relatorio Gerado**
-   - Vulnerabilidades de seguranca
-   - Niveis de severidade (critico, alto, medio, baixo)
-   - Passos de remediacao
+3. **Relatório Gerado**
+   - Vulnerabilidades de segurança
+   - Níveis de severidade (crítico, alto, médio, baixo)
+   - Etapas de remediação
    - Status de conformidade
 
 ## Como Usar
 
 ```bash
-# Executar auditoria de seguranca
+# Executar auditoria de segurança
 npm run security:check
 
-# Ou verificacoes individuais
+# Ou verificações individuais
 npm audit
 npm run lint:security
 ```
 
 ## Modo Plano
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou exige investigação transversal.
 
-## Checklist de Seguranca
+## Verificações de Segurança
 
-- [ ] Protecao XSS implementada (DOMPurify para HTML)
-- [ ] Validacao de entrada em todos os formularios (Zod/Yup)
-- [ ] Autenticacao implementada corretamente
+### 1. Prevenção de XSS
+
+```typescript
+// ❌ PERIGOSO - Nunca use com entrada do usuário
+const UnsafeComponent = ({ html }: { html: string }) => {
+  return <div dangerouslySetInnerHTML={{ __html: html }} />;
+};
+
+// ✅ SEGURO - Sanitizar primeiro
+import DOMPurify from 'dompurify';
+
+const SafeComponent = ({ html }: { html: string }) => {
+  const sanitized = DOMPurify.sanitize(html);
+  return <div dangerouslySetInnerHTML={{ __html: sanitized }} />;
+};
+
+// ✅ SEGURO - React escapa por padrão
+const SafeComponent = ({ text }: { text: string }) => {
+  return <div>{text}</div>; // React escapa automaticamente
+};
+```
+
+### 2. Validação de Entrada
+
+```typescript
+// ❌ RUIM - Sem validação
+const handleSubmit = (email: string) => {
+  sendEmail(email); // Perigoso!
+};
+
+// ✅ BOM - Validação com Zod
+import { z } from 'zod';
+
+const emailSchema = z.string().email().max(255);
+
+const handleSubmit = (email: string) => {
+  const result = emailSchema.safeParse(email);
+  if (!result.success) {
+    throw new Error('E-mail inválido');
+  }
+  sendEmail(result.data);
+};
+```
+
+### 3. Autenticação
+
+```typescript
+// ❌ RUIM - Token no localStorage (vulnerável a XSS)
+localStorage.setItem('token', jwt);
+
+// ✅ BOM - Cookie HttpOnly (lado do servidor)
+// O servidor define: Set-Cookie: token=xxx; HttpOnly; Secure; SameSite=Strict
+
+// ✅ ACEITÁVEL - Se armazenamento no lado do cliente for necessário, criptografar
+import CryptoJS from 'crypto-js';
+
+const encryptedToken = CryptoJS.AES.encrypt(token, secretKey).toString();
+sessionStorage.setItem('auth', encryptedToken);
+```
+
+### 4. Rotas Protegidas
+
+```typescript
+// ✅ BOM - Proteção de rotas
+export const ProtectedRoute: FC<{ children: ReactNode }> = ({ children }) => {
+  const { isAuthenticated } = useAuth();
+  const location = useLocation();
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return <>{children}</>;
+};
+```
+
+### 5. Proteção CSRF
+
+```typescript
+// ✅ BOM - Token CSRF nas requisições
+import axios from 'axios';
+
+const apiClient = axios.create({
+  baseURL: process.env.VITE_API_URL,
+  withCredentials: true
+});
+
+apiClient.interceptors.request.use((config) => {
+  const csrfToken = document
+    .querySelector('meta[name="csrf-token"]')
+    ?.getAttribute('content');
+
+  if (csrfToken) {
+    config.headers['X-CSRF-TOKEN'] = csrfToken;
+  }
+
+  return config;
+});
+```
+
+## Segurança de Dependências
+
+### NPM Audit
+
+```bash
+# Verificar vulnerabilidades
+npm audit
+
+# Corrigir automaticamente (atenção a breaking changes)
+npm audit fix
+
+# Verificar sem corrigir
+npm audit --audit-level=moderate
+```
+
+### Snyk
+
+```bash
+# Instalar o Snyk
+npm install -g snyk
+
+# Autenticar
+snyk auth
+
+# Testar vulnerabilidades
+snyk test
+
+# Monitorar o projeto
+snyk monitor
+```
+
+### Manter Dependências Atualizadas
+
+```bash
+# Verificar pacotes desatualizados
+npm outdated
+
+# Atualizar com segurança
+npm update
+
+# Verificar atualizações principais
+npx npm-check-updates
+```
+
+## Cabeçalhos de Segurança
+
+### Content Security Policy
+
+```typescript
+// vite.config.ts
+export default defineConfig({
+  server: {
+    headers: {
+      'Content-Security-Policy': [
+        "default-src 'self'",
+        "script-src 'self'",
+        "style-src 'self' 'unsafe-inline'",
+        "img-src 'self' data: https:",
+        "font-src 'self'",
+        "connect-src 'self' https://api.example.com",
+        "frame-ancestors 'none'",
+      ].join('; '),
+    },
+  },
+});
+```
+
+### Cabeçalhos de Segurança (Nginx)
+
+```nginx
+# nginx.conf
+add_header Content-Security-Policy "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline';" always;
+add_header X-Frame-Options "DENY" always;
+add_header X-Content-Type-Options "nosniff" always;
+add_header X-XSS-Protection "1; mode=block" always;
+add_header Referrer-Policy "strict-origin-when-cross-origin" always;
+```
+
+## Gerenciamento de Segredos
+
+### Variáveis de Ambiente
+
+```bash
+# ❌ RUIM - Segredos no código
+const API_KEY = 'sk-1234567890abcdef';
+
+# ✅ BOM - Variáveis de ambiente
+const API_KEY = import.meta.env.VITE_API_KEY;
+```
+
+### Gerenciamento de Arquivos .env
+
+```bash
+# .gitignore
+.env
+.env.local
+.env.*.local
+
+# .env.example (fazer commit deste arquivo)
+VITE_API_BASE_URL=http://localhost:8000
+VITE_API_KEY=your-api-key-here
+
+# .env (NÃO fazer commit)
+VITE_API_BASE_URL=https://api.production.com
+VITE_API_KEY=sk-real-secret-key
+```
+
+## Vulnerabilidades Comuns
+
+### 1. Redirecionamentos Abertos
+
+```typescript
+// ❌ VULNERÁVEL
+const handleRedirect = () => {
+  const url = new URLSearchParams(window.location.search).get('redirect');
+  window.location.href = url; // Perigoso!
+};
+
+// ✅ SEGURO - Validar URL de redirecionamento
+const ALLOWED_DOMAINS = ['example.com', 'app.example.com'];
+
+const handleRedirect = () => {
+  const url = new URLSearchParams(window.location.search).get('redirect');
+
+  try {
+    const parsed = new URL(url);
+    if (!ALLOWED_DOMAINS.includes(parsed.hostname)) {
+      throw new Error('Domínio de redirecionamento inválido');
+    }
+    window.location.href = url;
+  } catch {
+    window.location.href = '/';
+  }
+};
+```
+
+### 2. Referência Direta a Objetos Inseguros
+
+```typescript
+// ❌ VULNERÁVEL
+const UserProfile = () => {
+  const { userId } = useParams();
+  const { data } = useQuery(['user', userId], () =>
+    fetch(`/api/users/${userId}`).then(r => r.json())
+  );
+  // Sem verificação de autorização!
+};
+
+// ✅ SEGURO - Autorização no lado do servidor
+// O servidor deve verificar: "O usuário autenticado tem acesso a este recurso?"
+```
+
+### 3. Injeção de SQL (Backend)
+
+```typescript
+// Frontend: Sempre usar queries parametrizadas no backend
+// ✅ BOM - Validação com Zod antes de enviar
+const userSchema = z.object({
+  email: z.string().email(),
+  name: z.string().max(100).regex(/^[a-zA-Z\s]+$/),
+});
+```
+
+## Regras ESLint de Segurança
+
+```json
+// .eslintrc.json
+{
+  "plugins": ["security"],
+  "extends": ["plugin:security/recommended"],
+  "rules": {
+    "security/detect-object-injection": "warn",
+    "security/detect-non-literal-regexp": "warn",
+    "security/detect-unsafe-regex": "error",
+    "security/detect-buffer-noassert": "error",
+    "security/detect-child-process": "error",
+    "security/detect-disable-mustache-escape": "error",
+    "security/detect-eval-with-expression": "error",
+    "security/detect-no-csrf-before-method-override": "error",
+    "security/detect-non-literal-fs-filename": "error",
+    "security/detect-non-literal-require": "error",
+    "security/detect-possible-timing-attacks": "error",
+    "security/detect-pseudoRandomBytes": "error"
+  }
+}
+```
+
+## Checklist de Segurança
+
+- [ ] Proteção contra XSS implementada (DOMPurify para HTML)
+- [ ] Validação de entrada em todos os formulários (Zod/Yup)
+- [ ] Autenticação corretamente implementada
 - [ ] Rotas protegidas configuradas
-- [ ] Tokens CSRF usados
-- [ ] Segredos em variaveis de ambiente
-- [ ] Dependencias auditadas (npm audit/Snyk)
-- [ ] Headers de seguranca configurados
-- [ ] HTTPS forcado
-- [ ] Headers CSP definidos
+- [ ] Tokens CSRF utilizados
+- [ ] Segredos em variáveis de ambiente
+- [ ] Dependências auditadas (npm audit/Snyk)
+- [ ] Cabeçalhos de segurança configurados
+- [ ] HTTPS imposto
+- [ ] Cabeçalhos CSP definidos
 - [ ] Sem segredos hardcoded
 - [ ] Links externos usam `rel="noopener noreferrer"`
-- [ ] Uploads de arquivo validados
+- [ ] Uploads de arquivos validados
 - [ ] Rate limiting implementado
-- [ ] Logs nao expoem dados sensiveis
+- [ ] Logs não expõem dados sensíveis
+
+## Testes de Segurança
+
+### Testes Automatizados
+
+```typescript
+// security.test.ts
+describe('Segurança', () => {
+  it('deve sanitizar entrada HTML', () => {
+    const malicious = '<script>alert("xss")</script>';
+    const sanitized = DOMPurify.sanitize(malicious);
+    expect(sanitized).not.toContain('<script>');
+  });
+
+  it('deve validar o formato do e-mail', () => {
+    const result = emailSchema.safeParse('email-invalido');
+    expect(result.success).toBe(false);
+  });
+
+  it('deve proteger as rotas', () => {
+    render(<ProtectedRoute><AdminPage /></ProtectedRoute>);
+    expect(screen.queryByText('Admin')).not.toBeInTheDocument();
+  });
+});
+```
+
+### Testes Manuais
+
+1. Testar vetores XSS em todas as entradas
+2. Tentar acessar rotas não autorizadas
+3. Testar com tokens expirados ou inválidos
+4. Verificar dados sensíveis no console/aba de rede
+5. Confirmar redirecionamento para HTTPS
+6. Testar proteção CSRF
+
+## Ferramentas
+
+- **npm audit**: Scanner de vulnerabilidades integrado
+- **Snyk**: Monitoramento contínuo de segurança
+- **OWASP ZAP**: Scanner de segurança para aplicações web
+- **DOMPurify**: Sanitização de HTML
+- **helmet**: Cabeçalhos de segurança (servidor)
+- **eslint-plugin-security**: Análise estática de segurança
+
+## Recursos
+
+- [OWASP Top 10](https://owasp.org/www-project-top-ten/)
+- [Melhores Práticas de Segurança no React](https://react.dev/learn/escape-hatches#security-pitfalls)
+- [Segurança Web MDN](https://developer.mozilla.org/en-US/docs/Web/Security)
+- [Snyk Advisor](https://snyk.io/advisor/)

--- a/Dev/i18n/pt/React/commands/check-testing.md
+++ b/Dev/i18n/pt/React/commands/check-testing.md
@@ -1,62 +1,492 @@
 ---
-description: Verificacao de Estrategia de Testes
+description: Verificação da Estratégia de Testes
 ---
 
-# Verificacao de Estrategia de Testes
+# Verificação da Estratégia de Testes
 
-Verificar se a aplicacao React tem cobertura de testes abrangente e segue melhores praticas de teste.
+Verifique se a aplicação React possui cobertura de testes abrangente e segue as melhores práticas de teste.
 
 ## O Que Este Comando Faz
 
-1. **Analise de Testes**
-   - Verificar cobertura de testes
-   - Verificar qualidade dos testes
-   - Validar padroes de teste
-   - Verificar organizacao dos testes
-   - Analisar performance dos testes
+1. **Análise de Testes**
+   - Verificar a cobertura de testes
+   - Validar a qualidade dos testes
+   - Confirmar os padrões de teste utilizados
+   - Verificar a organização dos testes
+   - Analisar o desempenho dos testes
 
-2. **Metricas Medidas**
-   - Cobertura de codigo (linhas, funcoes, branches)
-   - Contagem de testes por tipo (unit, integracao, e2e)
-   - Tempo de execucao dos testes
-   - Deteccao de testes instáveis
-   - Caminhos criticos nao testados
+2. **Métricas Medidas**
+   - Cobertura de código (linhas, funções, branches)
+   - Quantidade de testes por tipo (unitário, integração, e2e)
+   - Tempo de execução dos testes
+   - Detecção de testes instáveis (flaky tests)
+   - Caminhos críticos sem cobertura
 
-3. **Relatorio Gerado**
-   - Relatorio de cobertura
-   - Testes faltantes
-   - Score de qualidade dos testes
-   - Recomendacoes
+3. **Relatório Gerado**
+   - Relatório de cobertura
+   - Testes ausentes
+   - Pontuação de qualidade dos testes
+   - Recomendações
+
+## Como Usar
+
+```bash
+# Executar todos os testes com cobertura
+npm run test:coverage
+
+# Modo observação
+npm run test:watch
+
+# Modo UI
+npm run test:ui
+
+# Testes E2E
+npm run test:e2e
+```
 
 ## Modo Plano
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou exige investigação transversal.
 
-## Metas de Cobertura
+## Análise de Cobertura de Testes
+
+### Metas de Cobertura
 
 ```json
-{
-  "coverage": {
-    "lines": 80,
-    "functions": 80,
-    "branches": 75,
-    "statements": 80
+// vitest.config.ts
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+      lines: 80,
+      functions: 80,
+      branches: 75,
+      statements: 80,
+      exclude: [
+        'node_modules/',
+        'src/test/',
+        '**/*.test.{ts,tsx}',
+        '**/*.spec.{ts,tsx}',
+        '**/*.d.ts',
+        'vite.config.ts'
+      ]
+    }
   }
-}
+});
+```
+
+### Verificar Cobertura
+
+```bash
+# Gerar relatório de cobertura
+npm run test:coverage
+
+# Visualizar relatório HTML
+open coverage/index.html
+
+# Verificar limite específico
+npm run test:coverage -- --coverage.lines=90
+```
+
+## Tipos de Testes
+
+### 1. Testes Unitários (70% dos testes)
+
+```typescript
+// Button.test.tsx
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { Button } from './Button';
+
+describe('Button', () => {
+  it('deve renderizar com texto', () => {
+    render(<Button>Clique aqui</Button>);
+    expect(screen.getByRole('button')).toHaveTextContent('Clique aqui');
+  });
+
+  it('deve chamar onClick ao ser clicado', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(<Button onClick={handleClick}>Clique aqui</Button>);
+    await user.click(screen.getByRole('button'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it('deve estar desabilitado quando a prop disabled for true', () => {
+    render(<Button disabled>Clique aqui</Button>);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+});
+```
+
+### 2. Testes de Integração (20% dos testes)
+
+```typescript
+// UserManagement.integration.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { UserManagement } from './UserManagement';
+
+describe('Integração UserManagement', () => {
+  it('deve concluir o fluxo completo de criação de usuário', async () => {
+    const user = userEvent.setup();
+    render(<UserManagement />);
+
+    // Aguardar carregamento
+    await waitFor(() => {
+      expect(screen.getByText('John Doe')).toBeInTheDocument();
+    });
+
+    // Clicar no botão adicionar
+    await user.click(screen.getByRole('button', { name: /add user/i }));
+
+    // Preencher formulário
+    await user.type(screen.getByLabelText(/name/i), 'Novo Usuário');
+    await user.type(screen.getByLabelText(/email/i), 'novo@example.com');
+
+    // Enviar
+    await user.click(screen.getByRole('button', { name: /save/i }));
+
+    // Verificar
+    await waitFor(() => {
+      expect(screen.getByText('Novo Usuário')).toBeInTheDocument();
+    });
+  });
+});
+```
+
+### 3. Testes E2E (10% dos testes)
+
+```typescript
+// auth.spec.ts (Playwright)
+import { test, expect } from '@playwright/test';
+
+test.describe('Autenticação', () => {
+  test('deve fazer login com sucesso', async ({ page }) => {
+    await page.goto('/');
+    await page.click('text=Login');
+
+    await page.fill('input[name="email"]', 'user@example.com');
+    await page.fill('input[name="password"]', 'password123');
+    await page.click('button[type="submit"]');
+
+    await expect(page).toHaveURL('/dashboard');
+    await expect(page.locator('text=Welcome')).toBeVisible();
+  });
+});
+```
+
+## Verificações de Qualidade dos Testes
+
+### 1. Padrão AAA
+
+```typescript
+// ✅ BOM - Arrange, Act, Assert
+it('deve incrementar o contador', async () => {
+  // Arrange (Preparar)
+  const user = userEvent.setup();
+  render(<Counter initialCount={0} />);
+
+  // Act (Agir)
+  await user.click(screen.getByRole('button', { name: /increment/i }));
+
+  // Assert (Verificar)
+  expect(screen.getByText('Count: 1')).toBeInTheDocument();
+});
+```
+
+### 2. Testar Comportamento, Não Implementação
+
+```typescript
+// ❌ RUIM - Testar implementação
+it('deve chamar setState', () => {
+  const setStateSpy = vi.spyOn(React, 'useState');
+  // ...
+});
+
+// ✅ BOM - Testar comportamento
+it('deve exibir o contador incrementado', async () => {
+  const user = userEvent.setup();
+  render(<Counter />);
+
+  await user.click(screen.getByRole('button', { name: /increment/i }));
+
+  expect(screen.getByText('Count: 1')).toBeInTheDocument();
+});
+```
+
+### 3. Nomes de Teste Descritivos
+
+```typescript
+// ❌ RUIM - Nomes vagos
+it('funciona');
+it('teste 1');
+it('deve renderizar');
+
+// ✅ BOM - Nomes descritivos
+it('deve exibir o nome do usuário quando os dados são carregados');
+it('deve mostrar mensagem de erro quando o e-mail é inválido');
+it('deve desabilitar o botão de envio enquanto o formulário está sendo submetido');
+```
+
+### 4. Prioridade de Consultas
+
+```typescript
+// ✅ BOM - Consultas acessíveis (melhor opção)
+screen.getByRole('button', { name: /submit/i });
+screen.getByLabelText(/email/i);
+screen.getByText(/welcome/i);
+
+// ⚠️ OK - Consultas semânticas
+screen.getByAltText(/profile/i);
+screen.getByTitle(/close/i);
+
+// ❌ EVITAR - IDs de teste (último recurso)
+screen.getByTestId('custom-element');
+```
+
+## Organização dos Testes
+
+### Estrutura de Pastas
+
+```
+src/
+├── components/
+│   └── Button/
+│       ├── Button.tsx
+│       ├── Button.test.tsx       # Testes unitários
+│       └── Button.stories.tsx    # Storybook
+│
+├── features/
+│   └── users/
+│       ├── components/
+│       │   └── UserList/
+│       │       ├── UserList.tsx
+│       │       └── UserList.test.tsx
+│       ├── hooks/
+│       │   └── useUsers.test.ts
+│       └── UserManagement.integration.test.tsx  # Integração
+│
+├── test/
+│   ├── setup.ts                  # Configuração dos testes
+│   ├── mocks/
+│   │   └── handlers.ts           # Handlers MSW
+│   └── utils/
+│       └── test-utils.tsx        # Utilitários de teste
+│
+└── e2e/                          # Testes E2E
+    ├── auth.spec.ts
+    └── users.spec.ts
+```
+
+### Utilitários de Teste
+
+```typescript
+// test/utils/test-utils.tsx
+import { render, RenderOptions } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { BrowserRouter } from 'react-router-dom';
+
+const AllProviders = ({ children }: { children: React.ReactNode }) => {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false }
+    }
+  });
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      <BrowserRouter>{children}</BrowserRouter>
+    </QueryClientProvider>
+  );
+};
+
+export const renderWithProviders = (
+  ui: React.ReactElement,
+  options?: Omit<RenderOptions, 'wrapper'>
+) => render(ui, { wrapper: AllProviders, ...options });
+
+export * from '@testing-library/react';
+```
+
+## Problemas Comuns em Testes
+
+### Problema 1: Testes Instáveis (Flaky Tests)
+
+```typescript
+// ❌ RUIM - Condição de corrida
+it('deve carregar dados', () => {
+  render(<DataComponent />);
+  expect(screen.getByText('Dados carregados')).toBeInTheDocument();
+  // Falha aleatoriamente se os dados demoram a carregar
+});
+
+// ✅ BOM - Aguardar os dados
+it('deve carregar dados', async () => {
+  render(<DataComponent />);
+  await waitFor(() => {
+    expect(screen.getByText('Dados carregados')).toBeInTheDocument();
+  });
+});
+```
+
+### Problema 2: Avisos de Act Ausente
+
+```typescript
+// ❌ RUIM - Atualização de estado fora do act
+it('deve atualizar o contador', () => {
+  const { result } = renderHook(() => useCounter());
+  result.current.increment(); // Aviso!
+});
+
+// ✅ BOM - Envolver no act
+it('deve atualizar o contador', () => {
+  const { result } = renderHook(() => useCounter());
+  act(() => {
+    result.current.increment();
+  });
+});
+```
+
+### Problema 3: Limpeza Não Realizada
+
+```typescript
+// ✅ BOM - Limpeza automática
+import { cleanup } from '@testing-library/react';
+
+afterEach(() => {
+  cleanup();
+});
+```
+
+## MSW (Mock Service Worker)
+
+### Configuração
+
+```typescript
+// test/mocks/handlers.ts
+import { http, HttpResponse } from 'msw';
+
+export const handlers = [
+  http.get('/api/users', () => {
+    return HttpResponse.json([
+      { id: '1', name: 'John Doe' },
+      { id: '2', name: 'Jane Smith' }
+    ]);
+  }),
+
+  http.post('/api/users', async ({ request }) => {
+    const newUser = await request.json();
+    return HttpResponse.json({ id: '3', ...newUser }, { status: 201 });
+  })
+];
+
+// test/mocks/server.ts
+import { setupServer } from 'msw/node';
+import { handlers } from './handlers';
+
+export const server = setupServer(...handlers);
+```
+
+### Uso
+
+```typescript
+// test/setup.ts
+import { beforeAll, afterEach, afterAll } from 'vitest';
+import { server } from './mocks/server';
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+```
+
+## Testes de Desempenho
+
+```typescript
+// Verificar desempenho de renderização
+it('deve renderizar a lista de forma eficiente', () => {
+  const start = performance.now();
+
+  render(<LargeList items={items} />);
+
+  const duration = performance.now() - start;
+  expect(duration).toBeLessThan(100); // ms
+});
+```
+
+## Relatórios de Teste
+
+### Relatório de Cobertura
+
+```bash
+# Gerar relatório HTML
+npm run test:coverage
+
+# Visualizar relatório
+open coverage/index.html
+
+# CI: Enviar para o Codecov
+bash <(curl -s https://codecov.io/bash)
+```
+
+### Resultados dos Testes no CI
+
+```yaml
+# .github/workflows/test.yml
+name: Tests
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+
+      - name: Instalar dependências
+        run: npm ci
+
+      - name: Executar testes
+        run: npm run test:coverage
+
+      - name: Enviar cobertura
+        uses: codecov/codecov-action@v3
 ```
 
 ## Checklist de Testes
 
-- [ ] Testes unitarios para todos os componentes
-- [ ] Testes unitarios para todos os hooks
-- [ ] Testes unitarios para todos os utilitarios
-- [ ] Testes de integracao para funcionalidades
-- [ ] Testes E2E para fluxos criticos
+- [ ] Testes unitários para todos os componentes
+- [ ] Testes unitários para todos os hooks
+- [ ] Testes unitários para todos os utilitários
+- [ ] Testes de integração para as features
+- [ ] Testes E2E para os fluxos críticos
 - [ ] Cobertura > 80%
-- [ ] Sem testes instaveis
-- [ ] Testes sao rapidos (< 1s cada)
-- [ ] MSW para mock de API
-- [ ] Utilitarios de teste extraidos
-- [ ] Testes seguem padrao AAA
-- [ ] Testes tem nomes descritivos
-- [ ] Testes usam queries acessiveis
+- [ ] Sem testes instáveis (flaky tests)
+- [ ] Testes rápidos (< 1s cada)
+- [ ] MSW para simulação de API
+- [ ] Utilitários de teste extraídos
+- [ ] Testes seguem o padrão AAA
+- [ ] Testes possuem nomes descritivos
+- [ ] Testes utilizam consultas acessíveis
+
+## Ferramentas
+
+- **Vitest**: Executor de testes unitários
+- **React Testing Library**: Testes de componentes
+- **Playwright**: Testes E2E
+- **MSW**: Simulação de API
+- **Testing Library User Event**: Interações do usuário
+- **Codecov**: Relatório de cobertura
+
+## Recursos
+
+- [React Testing Library](https://testing-library.com/react)
+- [Documentação do Vitest](https://vitest.dev/)
+- [Documentação do Playwright](https://playwright.dev/)
+- [Documentação do MSW](https://mswjs.io/)
+- [Melhores Práticas de Teste](https://kentcdodds.com/blog/common-mistakes-with-react-testing-library)

--- a/Dev/i18n/pt/React/commands/generate-component.md
+++ b/Dev/i18n/pt/React/commands/generate-component.md
@@ -4,22 +4,22 @@ description: Gerar Componente React
 
 # Gerar Componente React
 
-Gerar um novo componente React com TypeScript, testes e boilerplate de estilo.
+Gere um novo componente React com TypeScript, testes e boilerplate de estilização.
 
 ## O Que Este Comando Faz
 
-1. **Geracao de Componente**
+1. **Geração de Componente**
    - Criar arquivo de componente
    - Gerar interfaces TypeScript
    - Criar arquivo de teste
    - Criar arquivo de estilo (CSS Module ou styled-components)
-   - Criar story Storybook (opcional)
-   - Criar barrel export index.ts
+   - Criar story do Storybook (opcional)
+   - Criar exportação barrel index.ts
 
-2. **Templates Usados**
+2. **Templates Utilizados**
    - Componente funcional com TypeScript
-   - Interface de props
-   - Estrutura basica de testes
+   - Interface de Props
+   - Estrutura básica de testes
    - Boilerplate de estilo
 
 3. **Arquivos Gerados**
@@ -41,15 +41,17 @@ npm run generate:component ComponentName
 # Com caminho personalizado
 npm run generate:component features/users/components/UserCard
 
-# Com opcoes
+# Com opções
 npm run generate:component ComponentName --story --styled
 ```
 
-## Modo Plano
+## Modo de Planejamento
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
 
-## Template de Componente Basico
+## Templates de Componente
+
+### 1. Componente Básico
 
 ```typescript
 // ComponentName.tsx
@@ -57,10 +59,20 @@ import { FC } from 'react';
 import styles from './ComponentName.module.css';
 
 export interface ComponentNameProps {
+  /**
+   * Descrição da prop
+   */
   children?: React.ReactNode;
   className?: string;
 }
 
+/**
+ * Descrição do componente ComponentName
+ *
+ * @component
+ * @example
+ * <ComponentName>Conteúdo</ComponentName>
+ */
 export const ComponentName: FC<ComponentNameProps> = ({
   children,
   className
@@ -73,13 +85,436 @@ export const ComponentName: FC<ComponentNameProps> = ({
 };
 ```
 
-## Melhores Praticas
+### 2. Com Estado
+
+```typescript
+// ComponentName.tsx
+import { FC, useState } from 'react';
+import styles from './ComponentName.module.css';
+
+export interface ComponentNameProps {
+  initialValue?: string;
+  onChange?: (value: string) => void;
+}
+
+export const ComponentName: FC<ComponentNameProps> = ({
+  initialValue = '',
+  onChange
+}) => {
+  const [value, setValue] = useState(initialValue);
+
+  const handleChange = (newValue: string) => {
+    setValue(newValue);
+    onChange?.(newValue);
+  };
+
+  return (
+    <div className={styles.container}>
+      <input
+        value={value}
+        onChange={(e) => handleChange(e.target.value)}
+      />
+    </div>
+  );
+};
+```
+
+### 3. Componente Composto
+
+```typescript
+// Card.tsx
+import { FC, ReactNode } from 'react';
+import styles from './Card.module.css';
+
+interface CardProps {
+  children: ReactNode;
+  className?: string;
+}
+
+interface CardHeaderProps {
+  children: ReactNode;
+  className?: string;
+}
+
+interface CardBodyProps {
+  children: ReactNode;
+  className?: string;
+}
+
+interface CardFooterProps {
+  children: ReactNode;
+  className?: string;
+}
+
+export const Card: FC<CardProps> & {
+  Header: FC<CardHeaderProps>;
+  Body: FC<CardBodyProps>;
+  Footer: FC<CardFooterProps>;
+} = ({ children, className }) => {
+  return (
+    <div className={`${styles.card} ${className || ''}`}>
+      {children}
+    </div>
+  );
+};
+
+Card.Header = ({ children, className }) => {
+  return (
+    <div className={`${styles.header} ${className || ''}`}>
+      {children}
+    </div>
+  );
+};
+
+Card.Body = ({ children, className }) => {
+  return (
+    <div className={`${styles.body} ${className || ''}`}>
+      {children}
+    </div>
+  );
+};
+
+Card.Footer = ({ children, className }) => {
+  return (
+    <div className={`${styles.footer} ${className || ''}`}>
+      {children}
+    </div>
+  );
+};
+
+// Uso
+<Card>
+  <Card.Header>Título</Card.Header>
+  <Card.Body>Conteúdo</Card.Body>
+  <Card.Footer>Ações</Card.Footer>
+</Card>
+```
+
+## Template de Teste
+
+```typescript
+// ComponentName.test.tsx
+import { render, screen } from '@testing-library/react';
+import { userEvent } from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+import { ComponentName } from './ComponentName';
+
+describe('ComponentName', () => {
+  it('should render children', () => {
+    render(<ComponentName>Test Content</ComponentName>);
+
+    expect(screen.getByText('Test Content')).toBeInTheDocument();
+  });
+
+  it('should apply custom className', () => {
+    const { container } = render(
+      <ComponentName className="custom">Content</ComponentName>
+    );
+
+    expect(container.firstChild).toHaveClass('custom');
+  });
+
+  it('should handle interactions', async () => {
+    const handleClick = vi.fn();
+    const user = userEvent.setup();
+
+    render(<ComponentName onClick={handleClick}>Click me</ComponentName>);
+
+    await user.click(screen.getByText('Click me'));
+
+    expect(handleClick).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+## Templates de Estilo
+
+### CSS Modules
+
+```css
+/* ComponentName.module.css */
+.container {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.header {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.body {
+  flex: 1;
+}
+
+.footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+}
+```
+
+### Tailwind CSS
+
+```typescript
+// ComponentName.tsx
+import { FC } from 'react';
+import { cn } from '@/utils/cn';
+
+export interface ComponentNameProps {
+  children?: React.ReactNode;
+  variant?: 'default' | 'primary' | 'secondary';
+  className?: string;
+}
+
+export const ComponentName: FC<ComponentNameProps> = ({
+  children,
+  variant = 'default',
+  className
+}) => {
+  return (
+    <div
+      className={cn(
+        'flex flex-col gap-4 p-4 rounded-lg',
+        {
+          'bg-white': variant === 'default',
+          'bg-blue-500 text-white': variant === 'primary',
+          'bg-gray-200': variant === 'secondary'
+        },
+        className
+      )}
+    >
+      {children}
+    </div>
+  );
+};
+```
+
+## Template Storybook
+
+```typescript
+// ComponentName.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { ComponentName } from './ComponentName';
+
+const meta: Meta<typeof ComponentName> = {
+  title: 'Components/ComponentName',
+  component: ComponentName,
+  parameters: {
+    layout: 'centered'
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    variant: {
+      control: 'select',
+      options: ['default', 'primary', 'secondary']
+    }
+  }
+};
+
+export default meta;
+type Story = StoryObj<typeof ComponentName>;
+
+export const Default: Story = {
+  args: {
+    children: 'Component Content'
+  }
+};
+
+export const Primary: Story = {
+  args: {
+    variant: 'primary',
+    children: 'Primary Component'
+  }
+};
+
+export const Secondary: Story = {
+  args: {
+    variant: 'secondary',
+    children: 'Secondary Component'
+  }
+};
+```
+
+## Exportação Barrel Index
+
+```typescript
+// index.ts
+export { ComponentName } from './ComponentName';
+export type { ComponentNameProps } from './ComponentName';
+```
+
+## Script Gerador
+
+```typescript
+// scripts/generate-component.ts
+import fs from 'fs/promises';
+import path from 'path';
+
+interface GenerateComponentOptions {
+  name: string;
+  path?: string;
+  withStory?: boolean;
+  withStyled?: boolean;
+}
+
+async function generateComponent(options: GenerateComponentOptions) {
+  const { name, path: componentPath = 'src/components' } = options;
+  const dir = path.join(componentPath, name);
+
+  // Criar diretório
+  await fs.mkdir(dir, { recursive: true });
+
+  // Gerar arquivo do componente
+  await fs.writeFile(
+    path.join(dir, `${name}.tsx`),
+    getComponentTemplate(name)
+  );
+
+  // Gerar arquivo de teste
+  await fs.writeFile(
+    path.join(dir, `${name}.test.tsx`),
+    getTestTemplate(name)
+  );
+
+  // Gerar arquivo de estilo
+  await fs.writeFile(
+    path.join(dir, `${name}.module.css`),
+    getStyleTemplate()
+  );
+
+  // Gerar arquivo index
+  await fs.writeFile(
+    path.join(dir, 'index.ts'),
+    getIndexTemplate(name)
+  );
+
+  // Gerar story se solicitado
+  if (options.withStory) {
+    await fs.writeFile(
+      path.join(dir, `${name}.stories.tsx`),
+      getStoryTemplate(name)
+    );
+  }
+
+  console.log(`✅ Component ${name} created at ${dir}`);
+}
+
+// Executar
+const [,, name, ...args] = process.argv;
+const options = {
+  name,
+  withStory: args.includes('--story'),
+  withStyled: args.includes('--styled')
+};
+
+generateComponent(options);
+```
+
+## Exemplos de Uso
+
+### Componente Simples
+
+```bash
+npm run generate:component Button
+```
+
+Gera:
+```
+src/components/Button/
+├── Button.tsx
+├── Button.test.tsx
+├── Button.module.css
+└── index.ts
+```
+
+### Componente de Feature com Story
+
+```bash
+npm run generate:component features/users/components/UserCard --story
+```
+
+Gera:
+```
+src/features/users/components/UserCard/
+├── UserCard.tsx
+├── UserCard.test.tsx
+├── UserCard.module.css
+├── UserCard.stories.tsx
+└── index.ts
+```
+
+## Boas Práticas
 
 1. **PascalCase** para nomes de componentes
-2. **Colocalizacao** de arquivos relacionados
-3. **Interfaces TypeScript** para props
-4. **Comentarios JSDoc** para documentacao
-5. **Evitar exports default** (usar exports nomeados)
-6. **Interface de props** exportada separadamente
-7. **Arquivo de teste** junto com componente
-8. **Barrel exports** para imports limpos
+2. **Colocation** de arquivos relacionados
+3. Interfaces **TypeScript** para props
+4. Comentários **JSDoc** para documentação
+5. **Evitar exports padrão** (usar exports nomeados)
+6. **Interface de Props** exportada separadamente
+7. **Arquivo de teste** ao lado do componente
+8. **Exportações barrel** para imports limpos
+
+## Padrões de Componente
+
+### Componente Presentacional
+
+```typescript
+// Interface pura, sem lógica
+export const UserCard: FC<UserCardProps> = ({ user }) => {
+  return (
+    <div>
+      <h3>{user.name}</h3>
+      <p>{user.email}</p>
+    </div>
+  );
+};
+```
+
+### Componente Container
+
+```typescript
+// Lógica e busca de dados
+export const UserCardContainer: FC<{ userId: string }> = ({ userId }) => {
+  const { data: user, isLoading } = useUser(userId);
+
+  if (isLoading) return <Spinner />;
+  if (!user) return <NotFound />;
+
+  return <UserCard user={user} />;
+};
+```
+
+### Higher-Order Component (HOC)
+
+```typescript
+// Padrão wrapper
+export const withAuth = <P extends object>(
+  Component: ComponentType<P>
+) => {
+  return (props: P) => {
+    const { isAuthenticated } = useAuth();
+
+    if (!isAuthenticated) {
+      return <Navigate to="/login" />;
+    }
+
+    return <Component {...props} />;
+  };
+};
+```
+
+## Ferramentas
+
+- Plop.js para geradores avançados
+- Yeoman para scaffolding
+- Scripts Node.js personalizados
+- Snippets do VS Code
+
+## Recursos
+
+- [React Component Patterns](https://react.dev/learn/your-first-component)
+- [TypeScript with React](https://react-typescript-cheatsheet.netlify.app/)
+- [Testing Library](https://testing-library.com/docs/react-testing-library/intro/)

--- a/Dev/i18n/pt/React/commands/generate-hook.md
+++ b/Dev/i18n/pt/React/commands/generate-hook.md
@@ -4,21 +4,21 @@ description: Gerar Hook Personalizado
 
 # Gerar Hook Personalizado
 
-Gerar um novo hook React personalizado com TypeScript e testes.
+Gere um novo hook React personalizado com TypeScript e testes.
 
 ## O Que Este Comando Faz
 
-1. **Geracao de Hook**
-   - Criar arquivo de hook
+1. **Geração de Hook**
+   - Criar arquivo do hook
    - Gerar tipos TypeScript
    - Criar arquivo de teste
-   - Adicionar exemplos de uso em comentarios
+   - Adicionar exemplos de uso nos comentários
 
-2. **Templates Usados**
-   - Funcao de hook personalizado
-   - Definicoes de tipos
+2. **Templates Utilizados**
+   - Função de hook personalizado
+   - Definições de tipos
    - Estrutura de teste com renderHook
-   - Documentacao JSDoc
+   - Documentação JSDoc
 
 3. **Arquivos Gerados**
    ```
@@ -36,15 +36,17 @@ npm run generate:hook useHookName
 # Com caminho personalizado
 npm run generate:hook features/users/hooks/useUserData
 
-# Hook especifico de funcionalidade
+# Hook específico de feature
 npm run generate:hook features/auth/hooks/useLogin
 ```
 
-## Modo Plano
+## Modo de Planejamento
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
 
-## Template de Hook Simples
+## Templates de Hook
+
+### 1. Hook de Estado Simples
 
 ```typescript
 // useCounter.ts
@@ -67,8 +69,8 @@ export interface UseCounterReturn {
 /**
  * Hook para gerenciar estado de contador
  *
- * @param options - Opcoes de configuracao
- * @returns Estado e metodos do contador
+ * @param options - Opções de configuração
+ * @returns Estado e métodos do contador
  *
  * @example
  * const { count, increment, decrement } = useCounter({ initialValue: 0 });
@@ -107,6 +109,251 @@ export const useCounter = (
 };
 ```
 
+### 2. Hook de Busca de Dados
+
+```typescript
+// useUser.ts
+import { useQuery } from '@tanstack/react-query';
+import { userService } from '@/services/user.service';
+import type { User } from '@/types/user.types';
+
+export interface UseUserOptions {
+  enabled?: boolean;
+  refetchInterval?: number;
+}
+
+export interface UseUserReturn {
+  user: User | undefined;
+  isLoading: boolean;
+  error: Error | null;
+  refetch: () => void;
+}
+
+/**
+ * Hook para buscar dados de um usuário
+ *
+ * @param userId - O ID do usuário a buscar
+ * @param options - Opções de query
+ * @returns Dados do usuário e estado da query
+ *
+ * @example
+ * const { user, isLoading } = useUser('123');
+ */
+export const useUser = (
+  userId: string,
+  options: UseUserOptions = {}
+): UseUserReturn => {
+  const { data, isLoading, error, refetch } = useQuery({
+    queryKey: ['user', userId],
+    queryFn: () => userService.getById(userId),
+    enabled: options.enabled !== false,
+    refetchInterval: options.refetchInterval
+  });
+
+  return {
+    user: data,
+    isLoading,
+    error: error as Error | null,
+    refetch
+  };
+};
+```
+
+### 3. Hook de Armazenamento Local
+
+```typescript
+// useLocalStorage.ts
+import { useState, useEffect } from 'react';
+
+export interface UseLocalStorageOptions<T> {
+  serializer?: (value: T) => string;
+  deserializer?: (value: string) => T;
+}
+
+/**
+ * Hook para sincronizar estado com o localStorage
+ *
+ * @param key - A chave do localStorage
+ * @param initialValue - Valor inicial caso a chave não exista
+ * @param options - Opções de serialização
+ * @returns Valor do estado e setter
+ *
+ * @example
+ * const [theme, setTheme] = useLocalStorage('theme', 'light');
+ */
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T,
+  options: UseLocalStorageOptions<T> = {}
+): [T, (value: T | ((val: T) => T)) => void] {
+  const {
+    serializer = JSON.stringify,
+    deserializer = JSON.parse
+  } = options;
+
+  // Obter o valor inicial do localStorage ou usar initialValue
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    try {
+      const item = window.localStorage.getItem(key);
+      return item ? deserializer(item) : initialValue;
+    } catch (error) {
+      console.error(`Error reading localStorage key "${key}":`, error);
+      return initialValue;
+    }
+  });
+
+  // Atualizar localStorage quando o valor mudar
+  const setValue = (value: T | ((val: T) => T)) => {
+    try {
+      const valueToStore = value instanceof Function ? value(storedValue) : value;
+      setStoredValue(valueToStore);
+      window.localStorage.setItem(key, serializer(valueToStore));
+    } catch (error) {
+      console.error(`Error setting localStorage key "${key}":`, error);
+    }
+  };
+
+  return [storedValue, setValue];
+}
+```
+
+### 4. Hook de Formulário
+
+```typescript
+// useForm.ts
+import { useState, useCallback, FormEvent } from 'react';
+
+export interface UseFormOptions<T> {
+  initialValues: T;
+  onSubmit: (values: T) => void | Promise<void>;
+  validate?: (values: T) => Partial<Record<keyof T, string>>;
+}
+
+export interface UseFormReturn<T> {
+  values: T;
+  errors: Partial<Record<keyof T, string>>;
+  isSubmitting: boolean;
+  handleChange: (name: keyof T, value: unknown) => void;
+  handleSubmit: (e: FormEvent) => Promise<void>;
+  reset: () => void;
+}
+
+/**
+ * Hook para gerenciar estado e validação de formulário
+ *
+ * @param options - Configuração do formulário
+ * @returns Estado e handlers do formulário
+ *
+ * @example
+ * const form = useForm({
+ *   initialValues: { email: '', password: '' },
+ *   onSubmit: async (values) => { ... },
+ *   validate: (values) => { ... }
+ * });
+ */
+export function useForm<T extends Record<string, unknown>>(
+  options: UseFormOptions<T>
+): UseFormReturn<T> {
+  const { initialValues, onSubmit, validate } = options;
+
+  const [values, setValues] = useState<T>(initialValues);
+  const [errors, setErrors] = useState<Partial<Record<keyof T, string>>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleChange = useCallback((name: keyof T, value: unknown) => {
+    setValues((prev) => ({ ...prev, [name]: value }));
+    // Limpar erro deste campo
+    setErrors((prev) => ({ ...prev, [name]: undefined }));
+  }, []);
+
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      setIsSubmitting(true);
+
+      // Validar
+      if (validate) {
+        const validationErrors = validate(values);
+        if (Object.keys(validationErrors).length > 0) {
+          setErrors(validationErrors);
+          setIsSubmitting(false);
+          return;
+        }
+      }
+
+      try {
+        await onSubmit(values);
+      } catch (error) {
+        console.error('Form submission error:', error);
+      } finally {
+        setIsSubmitting(false);
+      }
+    },
+    [values, validate, onSubmit]
+  );
+
+  const reset = useCallback(() => {
+    setValues(initialValues);
+    setErrors({});
+    setIsSubmitting(false);
+  }, [initialValues]);
+
+  return {
+    values,
+    errors,
+    isSubmitting,
+    handleChange,
+    handleSubmit,
+    reset
+  };
+}
+```
+
+### 5. Hook de Media Query
+
+```typescript
+// useMediaQuery.ts
+import { useState, useEffect } from 'react';
+
+/**
+ * Hook para monitorar correspondência de media query
+ *
+ * @param query - A string de media query
+ * @returns Se a media query corresponde ou não
+ *
+ * @example
+ * const isMobile = useMediaQuery('(max-width: 768px)');
+ */
+export const useMediaQuery = (query: string): boolean => {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window !== 'undefined') {
+      return window.matchMedia(query).matches;
+    }
+    return false;
+  });
+
+  useEffect(() => {
+    const mediaQuery = window.matchMedia(query);
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setMatches(event.matches);
+    };
+
+    // Definir valor inicial
+    setMatches(mediaQuery.matches);
+
+    // Escutar mudanças
+    mediaQuery.addEventListener('change', handleChange);
+
+    return () => {
+      mediaQuery.removeEventListener('change', handleChange);
+    };
+  }, [query]);
+
+  return matches;
+};
+```
+
 ## Template de Teste
 
 ```typescript
@@ -116,28 +363,182 @@ import { describe, it, expect } from 'vitest';
 import { useCounter } from './useCounter';
 
 describe('useCounter', () => {
-  it('deve inicializar com valor padrao', () => {
+  it('should initialize with default value', () => {
     const { result } = renderHook(() => useCounter());
+
     expect(result.current.count).toBe(0);
   });
 
-  it('deve incrementar contador', () => {
+  it('should initialize with custom value', () => {
+    const { result } = renderHook(() => useCounter({ initialValue: 10 }));
+
+    expect(result.current.count).toBe(10);
+  });
+
+  it('should increment count', () => {
     const { result } = renderHook(() => useCounter());
+
     act(() => {
       result.current.increment();
     });
+
     expect(result.current.count).toBe(1);
+  });
+
+  it('should decrement count', () => {
+    const { result } = renderHook(() => useCounter({ initialValue: 5 }));
+
+    act(() => {
+      result.current.decrement();
+    });
+
+    expect(result.current.count).toBe(4);
+  });
+
+  it('should reset to initial value', () => {
+    const { result } = renderHook(() => useCounter({ initialValue: 0 }));
+
+    act(() => {
+      result.current.increment();
+      result.current.increment();
+      result.current.reset();
+    });
+
+    expect(result.current.count).toBe(0);
+  });
+
+  it('should respect max value', () => {
+    const { result } = renderHook(() => useCounter({ initialValue: 9, max: 10 }));
+
+    act(() => {
+      result.current.increment();
+      result.current.increment(); // Não deve ultrapassar o max
+    });
+
+    expect(result.current.count).toBe(10);
+  });
+
+  it('should respect min value', () => {
+    const { result } = renderHook(() => useCounter({ initialValue: 1, min: 0 }));
+
+    act(() => {
+      result.current.decrement();
+      result.current.decrement(); // Não deve ficar abaixo do min
+    });
+
+    expect(result.current.count).toBe(0);
   });
 });
 ```
 
-## Melhores Praticas
+## Padrões de Hook
 
-1. **Nomenclatura**: Sempre comecar com prefixo `use`
-2. **Responsabilidade Unica**: Um hook, um proposito
-3. **Dependencias**: Listar todas as dependencias em useEffect/useCallback
-4. **TypeScript**: Tipar fortemente valores de retorno e parametros
-5. **Documentacao**: Comentarios JSDoc com exemplos
+### Composição
+
+```typescript
+// useAuth.ts
+export const useAuth = () => {
+  const user = useUser();
+  const permissions = usePermissions(user?.id);
+  const logout = useLogout();
+
+  return {
+    user,
+    permissions,
+    logout,
+    isAuthenticated: !!user
+  };
+};
+```
+
+### Injeção de Dependência
+
+```typescript
+// useRepository.ts
+export const useUserRepository = () => {
+  const apiClient = useApiClient();
+
+  return useMemo(
+    () => createUserRepository(apiClient),
+    [apiClient]
+  );
+};
+```
+
+### Handlers de Eventos
+
+```typescript
+// useClickOutside.ts
+export const useClickOutside = (
+  ref: RefObject<HTMLElement>,
+  handler: () => void
+) => {
+  useEffect(() => {
+    const listener = (event: MouseEvent | TouchEvent) => {
+      if (!ref.current || ref.current.contains(event.target as Node)) {
+        return;
+      }
+      handler();
+    };
+
+    document.addEventListener('mousedown', listener);
+    document.addEventListener('touchstart', listener);
+
+    return () => {
+      document.removeEventListener('mousedown', listener);
+      document.removeEventListener('touchstart', listener);
+    };
+  }, [ref, handler]);
+};
+```
+
+## Script Gerador
+
+```typescript
+// scripts/generate-hook.ts
+import fs from 'fs/promises';
+import path from 'path';
+
+async function generateHook(name: string, hookPath = 'src/hooks') {
+  const fileName = name.startsWith('use') ? name : `use${name}`;
+  const dir = path.join(hookPath);
+
+  await fs.mkdir(dir, { recursive: true });
+
+  // Gerar arquivo do hook
+  await fs.writeFile(
+    path.join(dir, `${fileName}.ts`),
+    getHookTemplate(fileName)
+  );
+
+  // Gerar arquivo de teste
+  await fs.writeFile(
+    path.join(dir, `${fileName}.test.ts`),
+    getTestTemplate(fileName)
+  );
+
+  console.log(`✅ Hook ${fileName} created at ${dir}`);
+}
+
+// Executar
+const [,, name] = process.argv;
+generateHook(name);
+```
+
+## Boas Práticas
+
+1. **Nomenclatura**: Sempre iniciar com o prefixo `use`
+2. **Responsabilidade Única**: Um hook, um propósito
+3. **Dependências**: Listar todas as dependências em useEffect/useCallback
+4. **TypeScript**: Tipagem forte para valores de retorno e parâmetros
+5. **Documentação**: Comentários JSDoc com exemplos
 6. **Testes**: Testar todos os casos de uso e casos extremos
-7. **Memoizacao**: Usar useMemo/useCallback apropriadamente
-8. **Tratamento de Erros**: Tratar erros graciosamente
+7. **Memoização**: Usar useMemo/useCallback de forma adequada
+8. **Tratamento de Erros**: Tratar erros de forma elegante
+
+## Recursos
+
+- [Documentação React Hooks](https://react.dev/reference/react)
+- [Guia de Hooks Personalizados](https://react.dev/learn/reusing-logic-with-custom-hooks)
+- [Testing Library Hooks](https://react-hooks-testing-library.com/)
+- [usehooks.com](https://usehooks.com/)

--- a/Dev/i18n/pt/React/commands/storybook-story.md
+++ b/Dev/i18n/pt/React/commands/storybook-story.md
@@ -1,21 +1,21 @@
 ---
-description: Gerar Story Storybook
+description: Gerar Story do Storybook
 ---
 
-# Gerar Story Storybook
+# Gerar Story do Storybook
 
-Gerar uma story Storybook para um componente React existente.
+Gere uma story do Storybook para um componente React existente.
 
 ## O Que Este Comando Faz
 
-1. **Geracao de Story**
-   - Criar arquivo de story para componente
+1. **Geração de Story**
+   - Criar arquivo de story para o componente
    - Gerar todas as variantes do componente
    - Adicionar controles interativos (args)
-   - Configurar parametros da story
-   - Adicionar documentacao
+   - Configurar parâmetros da story
+   - Adicionar documentação
 
-2. **Templates Usados**
+2. **Templates Utilizados**
    - Formato CSF 3.0 (Component Story Format)
    - Tipos TypeScript
    - Args e argTypes
@@ -30,18 +30,20 @@ Gerar uma story Storybook para um componente React existente.
 ## Como Usar
 
 ```bash
-# Gerar story para componente existente
+# Gerar story para um componente existente
 npm run generate:story ComponentName
 
 # Com caminho personalizado
 npm run generate:story features/users/components/UserCard
 ```
 
-## Modo Plano
+## Modo de Planejamento
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
 
-## Template de Story Basica
+## Templates de Story
+
+### 1. Story Básica
 
 ```typescript
 // Button.stories.tsx
@@ -59,16 +61,16 @@ const meta: Meta<typeof Button> = {
     variant: {
       control: 'select',
       options: ['primary', 'secondary', 'danger'],
-      description: 'Estilo da variante do botao',
+      description: 'Estilo da variante do botão',
     },
     size: {
       control: 'select',
       options: ['sm', 'md', 'lg'],
-      description: 'Tamanho do botao',
+      description: 'Tamanho do botão',
     },
     disabled: {
       control: 'boolean',
-      description: 'Desabilitar o botao',
+      description: 'Desabilitar o botão',
     },
   },
 };
@@ -76,10 +78,10 @@ const meta: Meta<typeof Button> = {
 export default meta;
 type Story = StoryObj<typeof Button>;
 
-// Story padrao
+// Story padrão
 export const Default: Story = {
   args: {
-    children: 'Botao',
+    children: 'Button',
     variant: 'primary',
     size: 'md',
   },
@@ -88,50 +90,533 @@ export const Default: Story = {
 // Todas as variantes
 export const Primary: Story = {
   args: {
-    children: 'Botao Primario',
+    children: 'Primary Button',
     variant: 'primary',
   },
 };
 
 export const Secondary: Story = {
   args: {
-    children: 'Botao Secundario',
+    children: 'Secondary Button',
     variant: 'secondary',
   },
 };
 
 export const Danger: Story = {
   args: {
-    children: 'Botao de Perigo',
+    children: 'Danger Button',
     variant: 'danger',
+  },
+};
+
+// Variantes de tamanho
+export const Small: Story = {
+  args: {
+    children: 'Small Button',
+    size: 'sm',
+  },
+};
+
+export const Large: Story = {
+  args: {
+    children: 'Large Button',
+    size: 'lg',
   },
 };
 
 // Variantes de estado
 export const Disabled: Story = {
   args: {
-    children: 'Botao Desabilitado',
+    children: 'Disabled Button',
     disabled: true,
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    children: 'Loading Button',
+    isLoading: true,
   },
 };
 ```
 
-## Melhores Praticas
+### 2. Story de Componente de Formulário
 
-1. **Nomenclatura de Story**: Usar nomes descritivos (Default, Primary, WithError)
-2. **Args**: Fornecer padroes sensiveis
-3. **ArgTypes**: Documentar todas as props
-4. **Actions**: Usar para manipuladores de eventos
-5. **Decorators**: Adicionar contexto quando necessario
-6. **MSW**: Mockar chamadas de API
-7. **Acessibilidade**: Testar com addon a11y
-8. **Documentacao**: Adicionar MDX para componentes complexos
-9. **Variantes**: Cobrir todos os estados visuais
-10. **Casos Extremos**: Incluir estados de erro, carregamento, vazio
+```typescript
+// Input.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { Input } from './Input';
+
+const meta: Meta<typeof Input> = {
+  title: 'Forms/Input',
+  component: Input,
+  parameters: {
+    layout: 'padded',
+  },
+  tags: ['autodocs'],
+  argTypes: {
+    type: {
+      control: 'select',
+      options: ['text', 'email', 'password', 'number'],
+    },
+    error: {
+      control: 'text',
+    },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Input>;
+
+export const Default: Story = {
+  args: {
+    label: 'Email',
+    placeholder: 'Digite seu e-mail',
+  },
+};
+
+export const WithError: Story = {
+  args: {
+    label: 'Email',
+    value: 'invalid-email',
+    error: 'Formato de e-mail inválido',
+  },
+};
+
+export const Password: Story = {
+  args: {
+    label: 'Senha',
+    type: 'password',
+    placeholder: 'Digite a senha',
+  },
+};
+
+export const Disabled: Story = {
+  args: {
+    label: 'Email',
+    disabled: true,
+    value: 'disabled@example.com',
+  },
+};
+```
+
+### 3. Componente Complexo com Actions
+
+```typescript
+// UserCard.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { action } from '@storybook/addon-actions';
+import { UserCard } from './UserCard';
+
+const meta: Meta<typeof UserCard> = {
+  title: 'Features/UserCard',
+  component: UserCard,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div style={{ maxWidth: '400px' }}>
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof UserCard>;
+
+const mockUser = {
+  id: '1',
+  name: 'John Doe',
+  email: 'john@example.com',
+  avatar: 'https://i.pravatar.cc/150?img=1',
+  role: 'admin' as const,
+};
+
+export const Default: Story = {
+  args: {
+    user: mockUser,
+    onEdit: action('onEdit'),
+    onDelete: action('onDelete'),
+  },
+};
+
+export const WithoutAvatar: Story = {
+  args: {
+    user: { ...mockUser, avatar: undefined },
+    onEdit: action('onEdit'),
+    onDelete: action('onDelete'),
+  },
+};
+
+export const Loading: Story = {
+  args: {
+    isLoading: true,
+  },
+};
+```
+
+### 4. Story com Múltiplas Composições
+
+```typescript
+// Card.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { Card } from './Card';
+
+const meta: Meta<typeof Card> = {
+  title: 'Components/Card',
+  component: Card,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof Card>;
+
+export const Default: Story = {
+  args: {
+    children: 'Conteúdo do card',
+  },
+};
+
+export const WithHeader: Story = {
+  render: () => (
+    <Card>
+      <Card.Header>Título do Card</Card.Header>
+      <Card.Body>Conteúdo do card aqui</Card.Body>
+    </Card>
+  ),
+};
+
+export const Complete: Story = {
+  render: () => (
+    <Card>
+      <Card.Header>
+        <h3>Perfil do Usuário</h3>
+      </Card.Header>
+      <Card.Body>
+        <p>Nome: John Doe</p>
+        <p>Email: john@example.com</p>
+      </Card.Body>
+      <Card.Footer>
+        <button>Editar</button>
+        <button>Excluir</button>
+      </Card.Footer>
+    </Card>
+  ),
+};
+```
+
+### 5. Story com MSW (Mock de API)
+
+```typescript
+// UserList.stories.tsx
+import type { Meta, StoryObj } from '@storybook/react';
+import { http, HttpResponse } from 'msw';
+import { UserList } from './UserList';
+
+const meta: Meta<typeof UserList> = {
+  title: 'Features/UserList',
+  component: UserList,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  tags: ['autodocs'],
+};
+
+export default meta;
+type Story = StoryObj<typeof UserList>;
+
+export const Default: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/users', () => {
+          return HttpResponse.json([
+            { id: '1', name: 'John Doe', email: 'john@example.com' },
+            { id: '2', name: 'Jane Smith', email: 'jane@example.com' },
+          ]);
+        }),
+      ],
+    },
+  },
+};
+
+export const Empty: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/users', () => {
+          return HttpResponse.json([]);
+        }),
+      ],
+    },
+  },
+};
+
+export const Error: Story = {
+  parameters: {
+    msw: {
+      handlers: [
+        http.get('/api/users', () => {
+          return new HttpResponse(null, { status: 500 });
+        }),
+      ],
+    },
+  },
+};
+```
+
+## Configuração de Story
+
+### Parâmetros Globais
+
+```typescript
+// .storybook/preview.ts
+import type { Preview } from '@storybook/react';
+import '../src/index.css';
+
+const preview: Preview = {
+  parameters: {
+    actions: { argTypesRegex: '^on[A-Z].*' },
+    controls: {
+      matchers: {
+        color: /(background|color)$/i,
+        date: /Date$/,
+      },
+    },
+    backgrounds: {
+      default: 'light',
+      values: [
+        { name: 'light', value: '#ffffff' },
+        { name: 'dark', value: '#1a1a1a' },
+      ],
+    },
+  },
+};
+
+export default preview;
+```
+
+### Decorators
+
+```typescript
+// Decorator global
+export const decorators = [
+  (Story) => (
+    <div style={{ padding: '3rem' }}>
+      <Story />
+    </div>
+  ),
+];
+
+// Decorator específico de story
+export const WithPadding: Story = {
+  decorators: [
+    (Story) => (
+      <div style={{ padding: '2rem', backgroundColor: '#f0f0f0' }}>
+        <Story />
+      </div>
+    ),
+  ],
+  args: {
+    children: 'Conteúdo com padding',
+  },
+};
+```
+
+## Controles Interativos
+
+### Configuração de ArgTypes
+
+```typescript
+const meta: Meta<typeof Component> = {
+  argTypes: {
+    // Select
+    variant: {
+      control: 'select',
+      options: ['primary', 'secondary'],
+      description: 'Variante do componente',
+      table: {
+        defaultValue: { summary: 'primary' },
+      },
+    },
+
+    // Radio
+    size: {
+      control: 'radio',
+      options: ['sm', 'md', 'lg'],
+    },
+
+    // Boolean
+    disabled: {
+      control: 'boolean',
+    },
+
+    // Number
+    count: {
+      control: { type: 'number', min: 0, max: 100, step: 1 },
+    },
+
+    // Range
+    opacity: {
+      control: { type: 'range', min: 0, max: 1, step: 0.1 },
+    },
+
+    // Color
+    color: {
+      control: 'color',
+    },
+
+    // Date
+    date: {
+      control: 'date',
+    },
+
+    // Text
+    label: {
+      control: 'text',
+    },
+
+    // Object
+    user: {
+      control: 'object',
+    },
+
+    // Function (desabilitar controle)
+    onClick: {
+      action: 'clicked',
+      table: {
+        category: 'Events',
+      },
+    },
+  },
+};
+```
+
+## Documentação
+
+### Documentação MDX
+
+```mdx
+<!-- Button.stories.mdx -->
+import { Canvas, Meta, Story } from '@storybook/blocks';
+import * as ButtonStories from './Button.stories';
+
+<Meta of={ButtonStories} />
+
+# Button
+
+Componente de botão com múltiplas variantes e tamanhos.
+
+## Uso
+
+```tsx
+import { Button } from '@/components/Button';
+
+<Button variant="primary" onClick={handleClick}>
+  Clique aqui
+</Button>
+```
+
+## Variantes
+
+<Canvas of={ButtonStories.Primary} />
+<Canvas of={ButtonStories.Secondary} />
+<Canvas of={ButtonStories.Danger} />
+
+## Tamanhos
+
+<Canvas of={ButtonStories.Small} />
+<Canvas of={ButtonStories.Large} />
+```
+
+## Boas Práticas
+
+1. **Nomenclatura de Story**: Use nomes descritivos (Default, Primary, WithError)
+2. **Args**: Forneça valores padrão sensatos
+3. **ArgTypes**: Documente todas as props
+4. **Actions**: Use para manipuladores de eventos
+5. **Decorators**: Adicione contexto quando necessário
+6. **MSW**: Simule chamadas de API
+7. **Acessibilidade**: Teste com o addon a11y
+8. **Documentação**: Adicione MDX para componentes complexos
+9. **Variantes**: Cubra todos os estados visuais
+10. **Casos Extremos**: Inclua estados de erro, carregamento e vazio
+
+## Testes com Storybook
+
+### Teste de Interação
+
+```typescript
+// Button.stories.tsx
+import { expect } from '@storybook/jest';
+import { userEvent, within } from '@storybook/testing-library';
+
+export const ClickTest: Story = {
+  args: {
+    children: 'Clique aqui',
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const button = canvas.getByRole('button');
+
+    await userEvent.click(button);
+    await expect(button).toHaveAttribute('aria-pressed', 'true');
+  },
+};
+```
+
+### Teste Visual
+
+```typescript
+// Configurar Chromatic
+export const parameters = {
+  chromatic: {
+    viewports: [320, 768, 1200],
+    delay: 300,
+  },
+};
+```
+
+## Script de Geração
+
+```typescript
+// scripts/generate-story.ts
+import fs from 'fs/promises';
+import path from 'path';
+
+async function generateStory(componentName: string, componentPath: string) {
+  const storyPath = path.join(componentPath, `${componentName}.stories.tsx`);
+
+  await fs.writeFile(storyPath, getStoryTemplate(componentName));
+
+  console.log(`✅ Story criada: ${storyPath}`);
+}
+
+// Executar
+const [,, name, pathArg] = process.argv;
+generateStory(name, pathArg || `src/components/${name}`);
+```
+
+## Addons do Storybook
+
+Addons essenciais para instalar:
+
+```bash
+npm install -D @storybook/addon-essentials
+npm install -D @storybook/addon-interactions
+npm install -D @storybook/addon-a11y
+npm install -D msw-storybook-addon
+```
 
 ## Recursos
 
-- [Documentacao Storybook](https://storybook.js.org/docs/react/get-started/introduction)
+- [Documentação do Storybook](https://storybook.js.org/docs/react/get-started/introduction)
 - [CSF 3.0](https://storybook.js.org/docs/react/api/csf)
-- [Testes de Interacao](https://storybook.js.org/docs/react/writing-tests/interaction-testing)
-- [Addon MSW](https://storybook.js.org/addons/msw-storybook-addon)
+- [Teste de Interação](https://storybook.js.org/docs/react/writing-tests/interaction-testing)
+- [MSW Addon](https://storybook.js.org/addons/msw-storybook-addon)

--- a/Dev/i18n/pt/ReactNative/commands/app-size.md
+++ b/Dev/i18n/pt/ReactNative/commands/app-size.md
@@ -1,498 +1,469 @@
 ---
-description: Comando: Analisar Tamanho do App
+description: Análise do Tamanho da Aplicação React Native
+argument-hint: [arguments]
 ---
 
-# Comando: Analisar Tamanho do App
+# Análise do Tamanho da Aplicação React Native
 
-Analise o tamanho do bundle e identifique oportunidades de otimização para aplicações React Native.
+Você é um especialista em performance React Native. Você deve analisar o tamanho da aplicação, identificar elementos volumosos e propor otimizações.
 
----
+## Argumentos
+$ARGUMENTS
 
-## Objetivo
+Argumentos:
+- (Opcional) Plataforma: ios, android, both
+- (Opcional) Modo: full, assets, code, native
 
-Este comando analisa o tamanho do seu aplicativo React Native e fornece recomendações para reduzir o tamanho do bundle, melhorando tempos de download e instalação.
+Exemplo: `/reactnative:app-size android` ou `/reactnative:app-size both full`
 
----
+## Modo de Planejamento
 
-## Modo Plano
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer uma investigação transversal.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+## MISSÃO
 
-## Etapas de Análise
-
-### 1. Análise do Bundle
-
-**Execute a análise do bundle:**
+### Etapa 1: Gerar Builds de Análise
 
 ```bash
-# Para Expo
-npx expo export --platform ios --output-dir dist/ios
-npx expo export --platform android --output-dir dist/android
+# Android - APK de Release
+cd android
+./gradlew assembleRelease
 
-# Analizar tamanho
-du -sh dist/ios
-du -sh dist/android
+# Android - Bundle AAB
+./gradlew bundleRelease
 
-# Para análise detalhada com webpack-bundle-analyzer (se usando)
+# iOS - Archive
+cd ios
+xcodebuild -workspace {App}.xcworkspace \
+  -scheme {App} \
+  -configuration Release \
+  -archivePath build/{App}.xcarchive \
+  archive
+
+# Tamanho do bundle JS
+npx react-native bundle \
+  --platform android \
+  --dev false \
+  --entry-file index.js \
+  --bundle-output /tmp/bundle.js \
+  --sourcemap-output /tmp/bundle.js.map
+```
+
+### Etapa 2: Ferramentas de Análise
+
+#### Android
+
+```bash
+# APK Analyzer (Android Studio)
+# Build > Analyze APK...
+
+# Linha de comando
+bundletool build-apks --bundle=app.aab --output=app.apks
+bundletool get-size total --apks=app.apks
+
+# Detalhe por ABI
+bundletool get-size total --apks=app.apks --dimensions=ABI
+
+# Analisar com apkanalyzer
+apkanalyzer apk summary app-release.apk
+apkanalyzer dex list app-release.apk
+apkanalyzer files list app-release.apk | sort -k2 -n -r | head -20
+```
+
+#### iOS
+
+```bash
+# Tamanho estimado na App Store
+xcrun altool --validate-app -f {App}.ipa -t ios
+
+# Com app-size-report
+npx react-native-bundle-visualizer
+
+# Tamanho do .ipa
+ls -lh build/{App}.ipa
+```
+
+#### Bundle JavaScript
+
+```bash
+# Analisar bundle
+npx source-map-explorer /tmp/bundle.js /tmp/bundle.js.map
+
+# Ou com react-native-bundle-visualizer
 npx react-native-bundle-visualizer
 ```
 
-**Coisas a verificar:**
+### Etapa 3: Pontos de Atenção
 
-- [ ] Tamanho total do bundle iOS
-- [ ] Tamanho total do bundle Android
-- [ ] Tamanho dos assets (imagens, fontes, etc.)
-- [ ] Tamanho do código JavaScript
-- [ ] Dependências mais pesadas
-
-### 2. Análise de Dependências
-
-**Verificar tamanhos de dependências:**
+#### Assets (Imagens, Fontes, etc.)
 
 ```bash
-# Instalar ferramenta de análise
-npm install -g cost-of-modules
+# Listar imagens por tamanho
+find android/app/src/main/res -name "*.png" -o -name "*.jpg" | \
+  xargs ls -la | sort -k5 -n -r | head -20
 
-# Analisar node_modules
-cost-of-modules
+find ios/{App}/Images.xcassets -name "*.png" | \
+  xargs ls -la | sort -k5 -n -r | head -20
 
-# Ou usar
-npx package-size
-
-# Verificar dependências não utilizadas
-npx depcheck
+# Verificar assets no bundle
+find assets -type f | xargs ls -la | sort -k5 -n -r | head -20
 ```
 
-**Reportar:**
-
-```markdown
-## Análise de Dependências
-
-### Top 10 Maiores Dependências
-1. [nome] - [tamanho] - [justificada? sim/não]
-2. [nome] - [tamanho] - [justificada? sim/não]
-...
-
-### Dependências não Utilizadas
-- [lista de dependências que podem ser removidas]
-
-### Duplicatas
-- [pacotes com múltiplas versões instaladas]
-```
-
-### 3. Análise de Assets
-
-**Verificar assets:**
+#### Dependências NPM
 
 ```bash
-# Listar assets por tamanho
-find src/assets -type f -exec du -h {} + | sort -rh | head -20
+# Tamanho do node_modules
+du -sh node_modules/* | sort -h -r | head -20
 
-# Verificar imagens grandes
-find src/assets/images -type f -size +500k -exec ls -lh {} \;
+# Analisar com npm
+npm ls --depth=0
+
+# Custo dos módulos (aproximado)
+npx bundlephobia-cli react-native-maps
 ```
 
-**Verificar:**
-
-- [ ] Imagens não otimizadas
-- [ ] Imagens não usadas
-- [ ] Imagens muito grandes
-- [ ] Fontes não usadas
-- [ ] Assets duplicados
-- [ ] Vídeos ou animações pesados
-
-### 4. Análise de Código
-
-**Verificar código não utilizado:**
+#### Código Nativo
 
 ```bash
-# Usar ferramenta de análise
-npx unimported
+# Android - Bibliotecas nativas
+find android -name "*.so" | xargs ls -la | sort -k5 -n -r
 
-# Verificar imports não utilizados
-npx eslint . --ext .ts,.tsx --no-eslintrc --plugin unused-imports
+# iOS - Frameworks
+find ios/Pods -name "*.a" -o -name "*.framework" | \
+  xargs du -sh 2>/dev/null | sort -h -r | head -20
 ```
 
-**Identificar:**
+### Etapa 4: Otimizações
 
-- [ ] Arquivos não importados
-- [ ] Exports não utilizados
-- [ ] Componentes não utilizados
-- [ ] Hooks não utilizados
-- [ ] Utils não utilizados
-
----
-
-## Relatório de Análise
-
-### Métricas Atuais
-
-```markdown
-## Tamanho do App
-
-### iOS
-- Bundle JavaScript: [X] MB
-- Assets: [X] MB
-- Total: [X] MB
-- Tamanho de instalação estimado: [X] MB
-
-### Android
-- Bundle JavaScript: [X] MB
-- Assets: [X] MB
-- Total APK: [X] MB
-- AAB: [X] MB
-
-### Comparação com Limites Recomendados
-- iOS: [X] MB / 4 MB (alerta se > 4MB)
-- Android: [X] MB / 15 MB (alerta se > 15MB)
-```
-
-### Problemas Identificados
-
-```markdown
-## Problemas Encontrados
-
-### 🔴 Críticos
-1. **[Nome do problema]**
-   - Impacto: [+X] MB
-   - Descrição: [detalhes]
-   - Ação recomendada: [ação]
-
-### 🟡 Avisos
-1. **[Nome do problema]**
-   - Impacto: [+X] KB
-   - Descrição: [detalhes]
-   - Ação recomendada: [ação]
-
-### 🟢 Otimizações Sugeridas
-1. **[Sugestão]**
-   - Economia potencial: [~X] KB
-   - Esforço: [Baixo/Médio/Alto]
-   - Prioridade: [Alta/Média/Baixa]
-```
-
----
-
-## Recomendações de Otimização
-
-### 1. Dependências
-
-**Ações:**
-
-- [ ] **Remover dependências não utilizadas**
-  ```bash
-  npm uninstall [pacote-não-usado]
-  ```
-
-- [ ] **Substituir dependências pesadas por alternativas leves**
-  ```
-  Exemplo:
-  - moment.js (232KB) → date-fns (13KB) ou Day.js (2KB)
-  - lodash (530KB) → lodash-es com tree-shaking
-  - axios (52KB) → fetch nativo
-  ```
-
-- [ ] **Usar imports nomeados para tree-shaking**
-  ```typescript
-  // ❌ Importa tudo
-  import _ from 'lodash';
-
-  // ✅ Importa apenas o necessário
-  import { debounce } from 'lodash-es';
-  ```
-
-- [ ] **Lazy load de dependências pesadas**
-  ```typescript
-  // Carregar apenas quando necessário
-  const HeavyComponent = lazy(() => import('./HeavyComponent'));
-  ```
-
-### 2. Imagens e Assets
-
-**Ações:**
-
-- [ ] **Otimizar imagens**
-  ```bash
-  # Instalar ferramenta
-  npm install -g sharp-cli
-
-  # Otimizar PNGs
-  npx sharp-cli -i input.png -o output.png --quality 85
-
-  # Converter para WebP (melhor compressão)
-  npx sharp-cli -i input.png -o output.webp
-  ```
-
-- [ ] **Usar formato apropriado**
-  ```
-  - Ícones: SVG (escala infinita, pequeno)
-  - Fotos: WebP ou JPG otimizado
-  - Transparência: PNG ou WebP
-  - Animações: Lottie ao invés de GIF/vídeo
-  ```
-
-- [ ] **Implementar lazy loading de imagens**
-  ```typescript
-  import { Image } from 'expo-image';
-
-  <Image
-    source={{ uri: imageUrl }}
-    placeholder={placeholderImage}
-    contentFit="cover"
-    transition={200}
-  />
-  ```
-
-- [ ] **Usar CDN para assets grandes**
-  ```typescript
-  // ❌ Assets locais pesados
-  import largeImage from './assets/large-image.png';
-
-  // ✅ Servir de CDN
-  const imageUrl = 'https://cdn.example.com/large-image.webp';
-  ```
-
-### 3. Code Splitting
-
-**Ações:**
-
-- [ ] **Lazy load de telas**
-  ```typescript
-  // app/(tabs)/settings.tsx
-  import { lazy } from 'react';
-
-  const SettingsScreen = lazy(() => import('@/features/settings/SettingsScreen'));
-
-  export default function Settings() {
-    return (
-      <Suspense fallback={<LoadingScreen />}>
-        <SettingsScreen />
-      </Suspense>
-    );
-  }
-  ```
-
-- [ ] **Separar vendor chunks**
-  ```javascript
-  // metro.config.js
-  module.exports = {
-    transformer: {
-      getTransformOptions: async () => ({
-        transform: {
-          experimentalImportSupport: false,
-          inlineRequires: true, // Reduz tamanho inicial
-        },
-      }),
-    },
-  };
-  ```
-
-### 4. Hermes Engine
-
-**Habilitar Hermes (se ainda não habilitado):**
+#### 1. Otimizar Imagens
 
 ```javascript
-// android/app/build.gradle
-project.ext.react = [
-    enableHermes: true  // Reduz bundle size em ~30%
-]
+// metro.config.js - Compressão automática
+const { getDefaultConfig } = require('metro-config');
 
-// ios/Podfile
-use_react_native!(
-  :hermes_enabled => true
-)
+module.exports = (async () => {
+  const {
+    resolver: { sourceExts, assetExts },
+  } = await getDefaultConfig();
+
+  return {
+    transformer: {
+      // Compressão de imagens
+      assetPlugins: ['react-native-asset-optimizer/plugin'],
+    },
+  };
+})();
 ```
 
-**Benefícios:**
-- Menor tamanho do bundle (~30% de redução)
-- Startup mais rápido
-- Menor uso de memória
+```bash
+# Converter PNG para WebP (Android)
+cwebp image.png -o image.webp -q 80
 
-### 5. ProGuard / R8 (Android)
+# Otimizar PNG
+pngquant --quality=65-80 --ext=.png --force image.png
 
-**Habilitar minificação:**
+# Remover metadados
+exiftool -all= image.jpg
+```
 
-```gradle
+#### 2. Reduzir o Bundle JS
+
+```javascript
+// babel.config.js
+module.exports = {
+  presets: ['module:@react-native/babel-preset'],
+  plugins: [
+    // Tree shaking para lodash
+    ['lodash', { id: ['lodash'] }],
+    // Remover console.log em produção
+    'transform-remove-console',
+  ],
+  env: {
+    production: {
+      plugins: ['transform-remove-console'],
+    },
+  },
+};
+```
+
+```typescript
+// Carregamento preguiçoso de telas
+const HeavyScreen = React.lazy(() => import('./screens/HeavyScreen'));
+
+// Importação seletiva
+// ❌
+import _ from 'lodash';
+// ✅
+import debounce from 'lodash/debounce';
+```
+
+#### 3. Otimizar Código Nativo
+
+```groovy
 // android/app/build.gradle
+
 android {
     buildTypes {
         release {
+            // Habilitar Proguard/R8
             minifyEnabled true
             shrinkResources true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
         }
     }
+
+    // Divisão por ABI
+    splits {
+        abi {
+            enable true
+            reset()
+            include 'armeabi-v7a', 'arm64-v8a', 'x86', 'x86_64'
+            universalApk false
+        }
+    }
+
+    // Remover recursos não utilizados
+    defaultConfig {
+        resConfigs "en", "fr"  // Manter apenas esses idiomas
+    }
 }
 ```
 
-### 6. Remove Dead Code
-
-**Configurar:**
-
-```json
-// tsconfig.json
-{
-  "compilerOptions": {
-    "removeComments": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true
-  }
-}
+```ruby
+# ios/Podfile
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      # Remover símbolos de debug na versão release
+      config.build_settings['STRIP_STYLE'] = 'non-global'
+      config.build_settings['DEPLOYMENT_POSTPROCESSING'] = 'YES'
+    end
+  end
+end
 ```
+
+#### 4. Remover Dependências Não Utilizadas
+
+```bash
+# Encontrar dependências não utilizadas
+npx depcheck
+
+# Analisar importações
+npx madge --circular --extensions ts,tsx src/
+
+# Remover uma dependência
+npm uninstall package-name
+cd ios && pod install
+```
+
+### Etapa 5: Gerar Relatório
+
+```
+══════════════════════════════════════════════════════════════
+📱 RELATÓRIO DE TAMANHO DA APLICAÇÃO
+══════════════════════════════════════════════════════════════
+
+──────────────────────────────────────────────────────────────
+📊 TAMANHO GERAL
+──────────────────────────────────────────────────────────────
+
+| Plataforma     | Download | Instalado | Limite   | Status |
+|----------------|----------|-----------|----------|--------|
+| Android (APK)  | 45 MB    | 120 MB    | < 50 MB  | ✅     |
+| Android (AAB)  | 35 MB    | 95 MB     | < 40 MB  | ✅     |
+| iOS            | 55 MB    | 150 MB    | < 60 MB  | ✅     |
+
+──────────────────────────────────────────────────────────────
+📦 DETALHAMENTO ANDROID
+──────────────────────────────────────────────────────────────
+
+| Componente        | Tamanho | % Total |
+|-------------------|---------|---------|
+| classes.dex       | 15 MB   | 33%     |
+| lib/ (nativo)     | 12 MB   | 27%     |
+| res/ (recursos)   | 8 MB    | 18%     |
+| assets/           | 6 MB    | 13%     |
+| META-INF/         | 2 MB    | 4%      |
+| outros            | 2 MB    | 5%      |
+
+### Detalhe de lib/ (bibliotecas nativas)
+| Arquivo                       | Tamanho |
+|-------------------------------|---------|
+| libhermes.so                  | 4,2 MB  |
+| libreact_nativemodule.so      | 3,1 MB  |
+| libmaps.so                    | 2,8 MB  |
+| libreactnativejni.so          | 1,5 MB  |
+
+### Detalhe de assets/
+| Pasta    | Tamanho | Arquivos |
+|----------|---------|----------|
+| fonts/   | 2,5 MB  | 8        |
+| images/  | 2,0 MB  | 45       |
+| lottie/  | 1,5 MB  | 12       |
+
+──────────────────────────────────────────────────────────────
+🍎 DETALHAMENTO iOS
+──────────────────────────────────────────────────────────────
+
+| Componente      | Tamanho | % Total |
+|-----------------|---------|---------|
+| Frameworks/     | 28 MB   | 51%     |
+| main.jsbundle   | 8 MB    | 15%     |
+| Assets.car      | 12 MB   | 22%     |
+| outros          | 7 MB    | 12%     |
+
+### Principais Frameworks
+| Framework              | Tamanho |
+|------------------------|---------|
+| Hermes.framework       | 8,5 MB  |
+| React.framework        | 6,2 MB  |
+| GoogleMaps.framework   | 5,8 MB  |
+| Firebase.framework     | 3,2 MB  |
+
+──────────────────────────────────────────────────────────────
+📜 BUNDLE JAVASCRIPT
+──────────────────────────────────────────────────────────────
+
+Tamanho total: 4,2 MB (minificado)
+Tamanho gzipado: 1,1 MB
+
+### Principais Dependências
+| Pacote              | Tamanho | % Bundle |
+|---------------------|---------|----------|
+| react-native        | 1,2 MB  | 29%      |
+| @react-navigation   | 450 KB  | 11%      |
+| moment              | 320 KB  | 8%       |
+| lodash              | 280 KB  | 7%       |
+| axios               | 95 KB   | 2%       |
+| código da app       | 850 KB  | 20%      |
+| outros              | 1,0 MB  | 23%      |
+
+──────────────────────────────────────────────────────────────
+⚠️ PROBLEMAS DETECTADOS
+──────────────────────────────────────────────────────────────
+
+### 1. Moment.js incluído com todos os locales
+
+**Impacto:** +280 KB
+**Solução:** Substituir por date-fns ou dayjs
 
 ```javascript
-// .eslintrc.js
-{
-  "rules": {
-    "no-unused-vars": "error",
-    "@typescript-eslint/no-unused-vars": "error"
-  }
-}
+// Antes
+import moment from 'moment';
+
+// Depois
+import { format, parseISO } from 'date-fns';
+import { fr } from 'date-fns/locale';
 ```
 
----
+### 2. Imagens PNG não otimizadas
 
-## Plano de Ação
+**Arquivos afetados:**
+| Imagem            | Tamanho atual | Tamanho otimizado |
+|-------------------|---------------|-------------------|
+| hero-banner.png   | 850 KB        | ~200 KB           |
+| background.png    | 620 KB        | ~150 KB           |
+| splash.png        | 480 KB        | ~120 KB           |
 
-### Prioridade Alta (Economia > 500KB)
+**Impacto total:** -1,5 MB possível
 
-1. **[Ação 1]**
-   - Economia: [X] MB
-   - Esforço: [horas]
-   - Owner: [pessoa]
-   - Prazo: [data]
+### 3. Bibliotecas nativas não utilizadas
 
-2. **[Ação 2]**
-   - Economia: [X] KB
-   - Esforço: [horas]
-   - Owner: [pessoa]
-   - Prazo: [data]
+**Detectadas:**
+- react-native-camera (não utilizado): +2,1 MB
+- react-native-video (não utilizado): +1,8 MB
 
-### Prioridade Média (Economia 100KB - 500KB)
+### 4. Sem divisão por ABI para Android
 
-1. **[Ação]**
-   - Economia: [X] KB
-   - Esforço: [horas]
-   - Owner: [pessoa]
-   - Prazo: [data]
+**Impacto:** APK universal de 45 MB vs ~25 MB por ABI
 
-### Prioridade Baixa (Economia < 100KB)
+──────────────────────────────────────────────────────────────
+💡 OTIMIZAÇÕES RECOMENDADAS
+──────────────────────────────────────────────────────────────
 
-1. **[Ação]**
-   - Economia: [X] KB
-   - Esforço: [horas]
-   - Owner: [pessoa]
-   - Prazo: [data]
+### Impacto ALTO
 
----
-
-## Metas de Otimização
-
-```markdown
-## Objetivos
-
-### Metas de Curto Prazo (1 semana)
-- Reduzir bundle de [X] MB para [Y] MB
-- Remover [N] dependências não utilizadas
-- Otimizar [N] imagens
-
-### Metas de Médio Prazo (1 mês)
-- Implementar code splitting para rotas principais
-- Migrar assets grandes para CDN
-- Atingir tamanho de bundle < [X] MB
-
-### Metas de Longo Prazo (3 meses)
-- Bundle size otimizado consistentemente
-- Processo de CI/CD verificando tamanho de bundle
-- Budget de performance configurado
-```
-
----
-
-## Monitoramento Contínuo
-
-### Configurar Budget de Bundle
-
-```javascript
-// app.json
-{
-  "expo": {
-    "packagerOpts": {
-      "config": "metro.config.js"
+1. **Habilitar divisão por ABI** (-15-20 MB Android)
+```groovy
+splits {
+    abi {
+        enable true
+        universalApk false
     }
-  }
-}
-
-// Adicionar ao CI/CD
-"scripts": {
-  "check-size": "bundlesize"
-}
-
-// .bundlesizerc
-{
-  "files": [
-    {
-      "path": "./dist/**/*.js",
-      "maxSize": "4 MB"
-    }
-  ]
 }
 ```
 
-### Alertas Automáticos
-
-```yaml
-# .github/workflows/bundle-size.yml
-name: Bundle Size Check
-
-on: [pull_request]
-
-jobs:
-  check-size:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v2
-      - name: Check bundle size
-        run: npm run check-size
-      - name: Comment on PR
-        if: failure()
-        uses: actions/github-script@v5
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: '⚠️ Bundle size exceeded! Please optimize.'
-            })
+2. **Remover dependências não utilizadas** (-4 MB)
+```bash
+npm uninstall react-native-camera react-native-video
+cd ios && pod install
 ```
 
----
+3. **Migrar de Moment.js para date-fns** (-280 KB no bundle)
 
-## Ferramentas Úteis
+### Impacto MÉDIO
 
-- **Análise de Bundle**: webpack-bundle-analyzer, source-map-explorer
-- **Análise de Dependências**: cost-of-modules, package-size, bundlephobia.com
-- **Otimização de Imagens**: sharp, imagemin, squoosh
-- **Dead Code**: unimported, depcheck, knip
-- **Monitoramento**: bundlesize, size-limit
+4. **Otimizar imagens PNG** (-1,5 MB)
+```bash
+# Converter para WebP no Android
+cwebp image.png -o image.webp -q 80
+```
 
----
+5. **Habilitar Hermes para iOS** (-1-2 MB, +performance)
+```ruby
+# Podfile
+:hermes_enabled => true
+```
 
-## Checklist Final
+6. **Limitar locales** (-500 KB)
+```groovy
+resConfigs "en", "fr"
+```
 
-- [ ] Bundle size analisado
-- [ ] Dependências otimizadas
-- [ ] Assets otimizados
-- [ ] Code splitting implementado
-- [ ] Hermes habilitado
-- [ ] ProGuard/R8 configurado
-- [ ] Dead code removido
-- [ ] Monitoramento contínuo configurado
-- [ ] Metas definidas
-- [ ] Plano de ação criado
-- [ ] CI/CD verificando bundle size
+### Impacto BAIXO
 
----
+7. **Tree-shaking do lodash** (-150 KB)
+8. **Remover console.log em produção** (-50 KB)
 
-**O tamanho do app impacta diretamente a taxa de download e retenção de usuários. Monitore constantemente!**
+──────────────────────────────────────────────────────────────
+📈 IMPACTO ESTIMADO
+──────────────────────────────────────────────────────────────
+
+| Otimização          | Antes   | Depois  | Ganho  |
+|---------------------|---------|---------|--------|
+| Divisão por ABI     | 45 MB   | 28 MB   | -38%   |
+| Deps não utilizadas | 45 MB   | 41 MB   | -9%    |
+| Imagens             | 45 MB   | 43,5 MB | -3%    |
+| Bundle JS           | 4,2 MB  | 3,5 MB  | -17%   |
+| **Total Android**   | **45 MB** | **~25 MB** | **-44%** |
+
+──────────────────────────────────────────────────────────────
+🔧 COMANDOS
+──────────────────────────────────────────────────────────────
+
+# Gerar APK de release
+cd android && ./gradlew assembleRelease
+
+# Analisar APK
+apkanalyzer apk summary app-release.apk
+
+# Analisar bundle JS
+npx react-native-bundle-visualizer
+
+# Encontrar dependências não utilizadas
+npx depcheck
+
+# Otimizar imagens
+find . -name "*.png" -exec pngquant --ext=.png --force {} \;
+
+──────────────────────────────────────────────────────────────
+🎯 PRIORIDADES
+──────────────────────────────────────────────────────────────
+
+1. [ ] Habilitar divisão por ABI (Ganho rápido)
+2. [ ] Remover react-native-camera e react-native-video
+3. [ ] Otimizar as 3 maiores imagens
+4. [ ] Migrar Moment.js → date-fns
+5. [ ] Habilitar Hermes no iOS
+6. [ ] Limitar locales no Android
+```

--- a/Dev/i18n/pt/ReactNative/commands/check-code-quality.md
+++ b/Dev/i18n/pt/ReactNative/commands/check-code-quality.md
@@ -1,120 +1,291 @@
 ---
-description: Comando: Verificar Qualidade do Código
+description: Verificar Qualidade de Código React Native
+argument-hint: [arguments]
 ---
 
-# Comando: Verificar Qualidade do Código
+# Verificar Qualidade de Código React Native
 
-Avalie a qualidade geral do código React Native incluindo legibilidade, manutenibilidade e aderência às melhores práticas.
+## Argumentos
 
----
+$ARGUMENTS
 
-## Objetivo
+## Modo de Planejamento
 
-Este comando realiza uma análise abrangente da qualidade do código, identificando áreas de melhoria e garantindo que o código atende aos padrões de qualidade.
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer uma investigação transversal.
 
----
+## MISSÃO
 
-## Modo Plano
+Você é um especialista em auditoria de qualidade de código React Native. Sua missão é analisar a conformidade do código de acordo com os padrões definidos em `.claude/rules/03-coding-standards.md`, `.claude/rules/04-solid-principles.md` e `.claude/rules/05-kiss-dry-yagni.md`.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+### Etapa 1: Análise da configuração
 
-## Análise
+1. Verificar a presença e configuração do TypeScript
+2. Verificar a presença e configuração do ESLint
+3. Verificar a presença e configuração do Prettier
+4. Analisar os arquivos de configuração do package.json
 
-### 1. Ferramentas Automáticas
+### Etapa 2: Verificação do TypeScript (7 pontos)
 
-**Executar:**
+Verificar a configuração do TypeScript:
+
+#### 🔧 Configuração do tsconfig.json
+
+- [ ] **(2 pts)** `"strict": true` habilitado
+- [ ] **(1 pt)** `"noImplicitAny": true`
+- [ ] **(1 pt)** `"strictNullChecks": true`
+- [ ] **(1 pt)** `"noUnusedLocals": true` e `"noUnusedParameters": true`
+- [ ] **(1 pt)** Aliases de caminho configurados (ex.: `@/components`, `@/utils`)
+- [ ] **(1 pt)** Tipos corretos para React Native (`@types/react`, `@types/react-native`)
+
+**Arquivos a verificar:**
+```bash
+tsconfig.json
+package.json
+```
+
+#### 📝 Uso do TypeScript no Código
+
+Verificar de 5 a 10 arquivos TypeScript aleatórios:
+
+- [ ] Sem uso de `any` (exceto casos justificados e documentados)
+- [ ] Interfaces/Tipos bem definidos para props
+- [ ] Tipos para funções (parâmetros e retorno)
+- [ ] Sem `@ts-ignore` ou `@ts-nocheck` (exceto exceções documentadas)
+- [ ] Uso de generics quando apropriado
+
+**Arquivos a verificar:**
+```bash
+src/**/*.tsx
+src/**/*.ts
+```
+
+### Etapa 3: Verificação do ESLint (6 pontos)
+
+#### 🔍 Configuração do ESLint
+
+- [ ] **(2 pts)** `.eslintrc.js` ou `.eslintrc.json` presente e configurado
+- [ ] **(1 pt)** Plugin `@react-native` ou equivalente configurado
+- [ ] **(1 pt)** Plugin `@typescript-eslint` configurado
+- [ ] **(1 pt)** Regras de React Hooks habilitadas (`react-hooks/rules-of-hooks`, `react-hooks/exhaustive-deps`)
+- [ ] **(1 pt)** Scripts ESLint no package.json (`lint`, `lint:fix`)
+
+**Arquivos a verificar:**
+```bash
+.eslintrc.js
+.eslintrc.json
+package.json
+```
+
+#### ⚠️ Verificação de Erros do ESLint
+
+Executar o ESLint e analisar os resultados:
 
 ```bash
-# ESLint
-npx eslint src --ext .ts,.tsx --max-warnings 0
-
-# TypeScript
-npx tsc --noEmit
-
-# Prettier
-npx prettier --check "src/**/*.{ts,tsx}"
-
-# Análise de complexidade
-npx ts-complex src/**/*.{ts,tsx}
+npm run lint
+# ou
+yarn lint
 ```
 
-### 2. Métricas de Código
+- [ ] 0 erros ESLint
+- [ ] < 10 avisos ESLint
+- [ ] Sem regras desabilitadas sem justificativa
 
-**Avaliar:**
+### Etapa 4: Verificação do Prettier (3 pontos)
 
-- [ ] Complexidade ciclomática < 10
-- [ ] Profundidade de aninhamento < 4
-- [ ] Comprimento de funções < 50 linhas
-- [ ] Comprimento de arquivos < 300 linhas
-- [ ] Duplicação de código < 3%
+- [ ] **(1 pt)** `.prettierrc` presente com configuração consistente
+- [ ] **(1 pt)** Integração ESLint + Prettier (sem conflitos)
+- [ ] **(1 pt)** Script de formatação no package.json
 
-### 3. Code Smells
-
-**Identificar:**
-
-- [ ] Funções muito longas
-- [ ] Classes/componentes muito grandes
-- [ ] Muitos parâmetros (> 4)
-- [ ] Condições aninhadas profundamente
-- [ ] Código duplicado
-- [ ] Magic numbers
-- [ ] Variáveis globais
-- [ ] Código morto
-
-### 4. TypeScript
-
-**Verificar:**
-
-- [ ] Sem uso de `any`
-- [ ] Tipos explícitos em funções públicas
-- [ ] Interfaces bem definidas
-- [ ] Generics usados apropriadamente
-- [ ] Type guards implementados
-
-### 5. Componentes React Native
-
-**Avaliar:**
-
-- [ ] Componentes pequenos e focados
-- [ ] Props bem tipadas
-- [ ] Hooks usados corretamente
-- [ ] Memoization apropriada
-- [ ] Event handlers otimizados
-
----
-
-## Relatório
-
-```markdown
-## Qualidade de Código
-
-### Métricas Gerais
-- Complexidade média: [X]
-- Duplicação: [X]%
-- Cobertura de testes: [X]%
-- Dívida técnica: [horas estimadas]
-
-### Problemas Principais
-1. [Problema] - [localização] - [severidade]
-2. [Problema] - [localização] - [severidade]
-
-### Recomendações
-1. [Ação prioritária]
-2. [Ação média prioridade]
-3. [Melhoria sugerida]
+**Arquivos a verificar:**
+```bash
+.prettierrc
+.prettierrc.js
+.prettierrc.json
+package.json
 ```
 
+### Etapa 5: Princípios SOLID (4 pontos)
+
+Referência: `.claude/rules/04-solid-principles.md`
+
+Analisar de 3 a 5 componentes ou módulos principais:
+
+- [ ] **(1 pt)** **S - Responsabilidade Única**: Cada componente/função tem uma única responsabilidade
+- [ ] **(1 pt)** **O - Aberto/Fechado**: Extensões possíveis sem modificar o código existente
+- [ ] **(1 pt)** **L - Substituição de Liskov**: Componentes são intercambiáveis
+- [ ] **(1 pt)** **D - Inversão de Dependência**: Dependências via props/injeção, sem acoplamento forte
+
+**Arquivos a analisar:**
+```bash
+src/components/**/*.tsx
+src/features/**/*.tsx
+src/hooks/**/*.ts
+```
+
+### Etapa 6: Princípios KISS, DRY, YAGNI (5 pontos)
+
+Referência: `.claude/rules/05-kiss-dry-yagni.md`
+
+- [ ] **(2 pts)** **KISS (Keep It Simple)**: Código simples e legível, sem engenharia excessiva
+- [ ] **(2 pts)** **DRY (Don't Repeat Yourself)**: Sem duplicação de código, reutilização via hooks/utils
+- [ ] **(1 pt)** **YAGNI (You Aren't Gonna Need It)**: Sem código não utilizado ou funcionalidades especulativas
+
+Verificar:
+- Funções duplicadas que poderiam ser fatoradas
+- Lógica complexa que poderia ser simplificada
+- Código morto ou comentado que deveria ser removido
+
+**Arquivos a analisar:**
+```bash
+src/**/*.ts
+src/**/*.tsx
+```
+
+### Etapa 7: Padrões de Código React Native
+
+Referência: `.claude/rules/03-coding-standards.md`
+
+#### 📱 Boas Práticas Específicas
+
+- [ ] Uso correto de `StyleSheet.create()` (não estilos inline em todo lugar)
+- [ ] Constantes para cores, espaçamentos, tipografia
+- [ ] Componentes funcionais com hooks (sem componentes de classe)
+- [ ] Gerenciamento de estado correto (useState, useReducer conforme necessário)
+- [ ] Uso de `useCallback` para handlers passados como props
+- [ ] Uso de `useMemo` para cálculos custosos
+
+**Arquivos a verificar:**
+```bash
+src/components/**/*.tsx
+src/theme/
+src/constants/
+```
+
+### Etapa 8: Calcular pontuação
+
+```
+┌──────────────────────────────────┬─────────┬────────┐
+│ Critério                         │ Pontos  │ Status │
+├──────────────────────────────────┼─────────┼────────┤
+│ Configuração TypeScript          │ XX/7    │ ✅/⚠️/❌│
+│ ESLint                           │ XX/6    │ ✅/⚠️/❌│
+│ Prettier                         │ XX/3    │ ✅/⚠️/❌│
+│ Princípios SOLID                 │ XX/4    │ ✅/⚠️/❌│
+│ KISS, DRY, YAGNI                 │ XX/5    │ ✅/⚠️/❌│
+├──────────────────────────────────┼─────────┼────────┤
+│ TOTAL QUALIDADE DE CÓDIGO        │ XX/25   │ ✅/⚠️/❌│
+└──────────────────────────────────┴─────────┴────────┘
+```
+
+**Legenda:**
+- ✅ Excelente (≥ 20/25)
+- ⚠️ Atenção (15-19/25)
+- ❌ Crítico (< 15/25)
+
+### Etapa 9: Relatório detalhado
+
+## 📊 RESULTADOS DA AUDITORIA DE QUALIDADE DE CÓDIGO
+
+### ✅ Pontos Fortes
+
+Liste as boas práticas identificadas:
+- [Prática 1 com exemplo de código]
+- [Prática 2 com exemplo de código]
+
+### ⚠️ Pontos de Melhoria
+
+Liste os problemas identificados por prioridade:
+
+1. **[Problema 1]**
+   - **Severidade:** Crítica/Alta/Média
+   - **Localização:** [Arquivos afetados]
+   - **Exemplo:**
+   ```typescript
+   // Código problemático
+   ```
+   - **Recomendação:**
+   ```typescript
+   // Código corrigido
+   ```
+
+2. **[Problema 2]**
+   - **Severidade:** Crítica/Alta/Média
+   - **Localização:** [Arquivos afetados]
+   - **Exemplo:**
+   ```typescript
+   // Código problemático
+   ```
+   - **Recomendação:**
+   ```typescript
+   // Código corrigido
+   ```
+
+### 📈 Métricas de Qualidade
+
+Executar e reportar as seguintes métricas:
+
+#### Erros ESLint
+```bash
+npm run lint
+```
+- **Erros:** XX
+- **Avisos:** XX
+- **Arquivos analisados:** XX
+
+#### Complexidade de Código
+
+Se SonarQube ou outra ferramenta estiver disponível:
+- **Complexidade ciclomática média:** XX (alvo: < 10)
+- **Linhas de código:** XX
+- **Duplicação:** XX% (alvo: < 5%)
+- **Dívida técnica:** XX horas
+
+#### TypeScript
+
+- **Percentual de tipagem estrita:** XX% (alvo: 100%)
+- **Uso de `any`:** XX ocorrências (alvo: 0)
+- **Erros TypeScript:** XX (alvo: 0)
+
+### 🎯 TOP 3 AÇÕES PRIORITÁRIAS
+
+#### 1. [AÇÃO #1]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** Crítico/Alto/Médio
+- **Descrição:** [Detalhe do problema]
+- **Solução:** [Ação concreta]
+- **Arquivos:** [Lista de arquivos]
+- **Exemplo:**
+```typescript
+// Antes
+[código problemático]
+
+// Depois
+[código corrigido]
+```
+
+#### 2. [AÇÃO #2]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** Crítico/Alto/Médio
+- **Descrição:** [Detalhe do problema]
+- **Solução:** [Ação concreta]
+- **Arquivos:** [Lista de arquivos]
+
+#### 3. [AÇÃO #3]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** Crítico/Alto/Médio
+- **Descrição:** [Detalhe do problema]
+- **Solução:** [Ação concreta]
+- **Arquivos:** [Lista de arquivos]
+
 ---
 
-## Ações
+## 📚 Referências
 
-- [ ] Refatorar funções complexas
-- [ ] Dividir componentes grandes
-- [ ] Eliminar código duplicado
-- [ ] Adicionar testes faltantes
-- [ ] Atualizar documentação
-- [ ] Configurar qualidade gates em CI/CD
+- `.claude/rules/03-coding-standards.md` - Padrões de código
+- `.claude/rules/04-solid-principles.md` - Princípios SOLID
+- `.claude/rules/05-kiss-dry-yagni.md` - Princípios KISS, DRY, YAGNI
+- `.claude/rules/06-tooling.md` - Configuração de ferramentas
 
 ---
 
-**Qualidade de código não é luxo, é necessidade para manutenibilidade a longo prazo.**
+**Pontuação final: XX/25**

--- a/Dev/i18n/pt/ReactNative/commands/check-compliance.md
+++ b/Dev/i18n/pt/ReactNative/commands/check-compliance.md
@@ -1,133 +1,239 @@
 ---
-description: Comando: Verificar Conformidade
+description: Verificação Global de Conformidade do Projeto React Native
+argument-hint: [arguments]
 ---
 
-# Comando: Verificar Conformidade
+# Verificação Global de Conformidade do Projeto React Native
 
-Verifique a conformidade do código React Native com padrões, convenções e melhores práticas do projeto.
+## Argumentos
 
----
+$ARGUMENTS
 
-## Objetivo
+## Modo de Planejamento
 
-Este comando verifica se o código segue os padrões estabelecidos do projeto, incluindo estilo de código, convenções de nomenclatura e princípios de design.
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer uma investigação transversal.
 
----
+## MISSÃO
 
-## Modo Plano
+Você é um especialista em conformidade de projetos React Native. Sua missão é orquestrar uma auditoria completa combinando as auditorias especializadas: arquitetura, qualidade de código, testes e segurança.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+Este comando agrega os resultados de:
+1. `/reactnative:check-architecture` (25 pontos)
+2. `/reactnative:check-code-quality` (25 pontos)
+3. `/reactnative:check-testing` (25 pontos)
+4. `/reactnative:check-security` (25 pontos)
 
-## Verificações
+### Etapa 1: Executar as 4 auditorias especializadas
 
-### 1. Estilo de Código
-
-**Executar ferramentas:**
+Executar sequencialmente (ou exibir os comandos a executar):
 
 ```bash
-# Prettier
-npx prettier --check "src/**/*.{ts,tsx}"
+# 1. Auditoria de Arquitetura
+/reactnative:check-architecture
 
-# ESLint
-npx eslint "src/**/*.{ts,tsx}"
+# 2. Auditoria de Qualidade de Código
+/reactnative:check-code-quality
 
-# TypeScript
-npx tsc --noEmit
+# 3. Auditoria de Testes
+/reactnative:check-testing
+
+# 4. Auditoria de Segurança
+/reactnative:check-security
 ```
 
-**Verificar:**
+### Etapa 2: Agregar resultados
 
-- [ ] Código formatado com Prettier
-- [ ] Sem erros de ESLint
-- [ ] Sem erros de TypeScript
-- [ ] Convenções de nomenclatura seguidas
-- [ ] Imports organizados
+Coletar as pontuações de cada auditoria:
 
-### 2. Convenções de Nomenclatura
-
-**Verificar:**
-
-- [ ] Componentes: PascalCase (UserProfile.tsx)
-- [ ] Hooks: camelCase com prefixo use (useAuth.ts)
-- [ ] Arquivos utils: camelCase (formatDate.ts)
-- [ ] Constantes: UPPER_SNAKE_CASE
-- [ ] Variáveis/funções: camelCase
-- [ ] Interfaces: PascalCase com sufixo Props/State (ButtonProps)
-- [ ] Types: PascalCase
-
-### 3. Estrutura de Arquivos
-
-**Verificar:**
-
-- [ ] Um componente por arquivo
-- [ ] Arquivos nomeados como o componente exportado
-- [ ] Barrel exports (index.ts) em pastas de componentes
-- [ ] Arquivos de teste co-localizados (.test.tsx)
-- [ ] Arquivos de estilo co-localizados (.styles.ts)
-
-### 4. Princípios SOLID
-
-**Avaliar:**
-
-- [ ] Single Responsibility: um componente, uma responsabilidade
-- [ ] Open/Closed: extensível sem modificação
-- [ ] Liskov Substitution: contratos respeitados
-- [ ] Interface Segregation: sem props não utilizadas
-- [ ] Dependency Inversion: depende de abstrações
-
-### 5. Testes
-
-**Verificar:**
-
-- [ ] Cobertura de testes > 80%
-- [ ] Testes unitários para hooks e utils
-- [ ] Testes de componentes para UI
-- [ ] Testes de integração para fluxos críticos
-- [ ] Convenções de nomenclatura de testes
-
-### 6. Documentação
-
-**Verificar:**
-
-- [ ] JSDoc para funções públicas
-- [ ] README atualizado
-- [ ] Comentários para lógica complexa
-- [ ] Props de componentes documentadas
-- [ ] CHANGELOG atualizado
-
----
-
-## Relatório
-
-```markdown
-## Relatório de Conformidade
-
-### Métricas
-- Conformidade com Prettier: [%]
-- Conformidade com ESLint: [%]
-- Conformidade com TypeScript: [%]
-- Conformidade com convenções: [%]
-- Cobertura de testes: [%]
-
-### Violações
-1. **[Tipo de violação]**
-   - Arquivo: [path]
-   - Descrição: [detalhes]
-   - Ação: [correção]
-
-### Recomendações
-- [Lista de ações para melhorar conformidade]
+```
+┌─────────────────────────┬─────────┬─────────┬────────┐
+│ Auditoria               │ Pontos  │ Máximo  │ Status │
+├─────────────────────────┼─────────┼─────────┼────────┤
+│ Arquitetura             │ XX/25   │ 25      │ ✅/⚠️/❌│
+│ Qualidade de Código     │ XX/25   │ 25      │ ✅/⚠️/❌│
+│ Testes                  │ XX/25   │ 25      │ ✅/⚠️/❌│
+│ Segurança               │ XX/25   │ 25      │ ✅/⚠️/❌│
+├─────────────────────────┼─────────┼─────────┼────────┤
+│ TOTAL GLOBAL            │ XX/100  │ 100     │ ✅/⚠️/❌│
+└─────────────────────────┴─────────┴─────────┴────────┘
 ```
 
+**Legenda:**
+- ✅ Excelente (≥ 80/100)
+- ⚠️ Atenção (60-79/100)
+- ❌ Crítico (< 60/100)
+
+### Etapa 3: Avaliação Global
+
+## 📊 RELATÓRIO GLOBAL DE CONFORMIDADE
+
+### 🎯 Pontuação Global: XX/100
+
+**Avaliação:**
+- 90-100: Projeto pronto para produção ✅
+- 80-89: Bom projeto, melhorias menores ⚠️
+- 70-79: Projeto aceitável, melhorias significativas necessárias ⚠️
+- 60-69: Projeto problemático, grandes melhorias exigidas ❌
+- < 60: Projeto crítico, refatoração necessária ❌
+
+### 📈 Pontuações Detalhadas
+
+#### 1. Arquitetura (XX/25)
+- Estrutura Feature-Based: XX/8
+- Organização de Pastas: XX/5
+- Navegação: XX/4
+- Arquitetura em Camadas: XX/4
+- Assets: XX/4
+
+**Status:** [✅/⚠️/❌]
+**Ações Prioritárias:** [Top 2-3]
+
+#### 2. Qualidade de Código (XX/25)
+- TypeScript: XX/7
+- ESLint: XX/6
+- Prettier: XX/3
+- SOLID: XX/4
+- KISS/DRY/YAGNI: XX/5
+
+**Status:** [✅/⚠️/❌]
+**Ações Prioritárias:** [Top 2-3]
+
+#### 3. Testes (XX/25)
+- Configuração do Jest: XX/5
+- Testes Unitários: XX/6
+- Testes de Componentes: XX/6
+- Testes de Integração: XX/4
+- Testes E2E: XX/4
+
+**Status:** [✅/⚠️/❌]
+**Ações Prioritárias:** [Top 2-3]
+
+#### 4. Segurança (XX/25)
+- Dados Sensíveis: XX/6
+- Segurança de API: XX/5
+- Segurança de Código: XX/5
+- Autenticação: XX/5
+- Segurança da Plataforma: XX/4
+
+**Status:** [✅/⚠️/❌]
+**Ações Prioritárias:** [Top 2-3]
+
+### 🚨 Problemas Críticos (Todas as Auditorias)
+
+Liste todos os problemas críticos identificados nas 4 auditorias:
+
+1. **[Problema Crítico #1]**
+   - **Auditoria:** Arquitetura/Qualidade de Código/Testes/Segurança
+   - **Impacto:** Crítico
+   - **Localização:** [Arquivos]
+   - **Ação:** [Ação imediata]
+
+2. **[Problema Crítico #2]**
+   - **Auditoria:** Arquitetura/Qualidade de Código/Testes/Segurança
+   - **Impacto:** Crítico
+   - **Localização:** [Arquivos]
+   - **Ação:** [Ação imediata]
+
+### ⚠️ Problemas de Alta Prioridade
+
+Liste todos os problemas de alta prioridade:
+
+1. **[Problema #1]**
+   - **Auditoria:** [Nome]
+   - **Impacto:** Alto
+   - **Ação:** [Ação necessária]
+
+2. **[Problema #2]**
+   - **Auditoria:** [Nome]
+   - **Impacto:** Alto
+   - **Ação:** [Ação necessária]
+
+### 🎯 PLANO DE AÇÃO GLOBAL
+
+#### Fase 1: Imediata (Semana 1)
+- [ ] [Ação Crítica #1]
+- [ ] [Ação Crítica #2]
+- [ ] [Ação Crítica #3]
+
+#### Fase 2: Curto Prazo (Semanas 2-4)
+- [ ] [Ação de Alta Prioridade #1]
+- [ ] [Ação de Alta Prioridade #2]
+- [ ] [Ação de Alta Prioridade #3]
+
+#### Fase 3: Médio Prazo (Mês 2)
+- [ ] [Ação de Média Prioridade #1]
+- [ ] [Ação de Média Prioridade #2]
+- [ ] [Ação de Média Prioridade #3]
+
+### 📊 Métricas-Chave
+
+```
+Painel de Saúde do Projeto
+════════════════════════════
+
+Qualidade de Código
+├─ Erros ESLint: XX
+├─ Erros TypeScript: XX
+├─ Duplicação de Código: XX%
+└─ Dívida Técnica: XX horas
+
+Testes
+├─ Cobertura Total: XX%
+├─ Testes Unitários: XX aprovados / XX total
+├─ Testes de Componentes: XX aprovados / XX total
+└─ Testes E2E: XX aprovados / XX total
+
+Segurança
+├─ Vulnerabilidades em Dependências: XX
+├─ Segredos Expostos: XX
+├─ Avisos de Segurança: XX
+└─ Problemas OWASP: XX
+
+Arquitetura
+├─ Features: XX
+├─ Componentes Compartilhados: XX
+├─ Hooks Customizados: XX
+└─ Profundidade de Pastas: XX níveis
+```
+
+### 🏆 Pontos Fortes
+
+Liste de 5 a 10 pontos fortes gerais do projeto:
+- [Ponto Forte 1]
+- [Ponto Forte 2]
+- [Ponto Forte 3]
+
+### 🎓 Recomendações de Aprendizado
+
+Com base nas lacunas identificadas, recomendar treinamentos/aprendizados para a equipe:
+- [Recomendação 1: ex. treinamento em TypeScript strict mode]
+- [Recomendação 2: ex. workshop de performance React Native]
+- [Recomendação 3: ex. curso de boas práticas de segurança]
+
+### 📚 Referências
+
+- `.claude/rules/` - Todas as regras do projeto
+- [React Native Documentation](https://reactnative.dev/)
+- [TypeScript Handbook](https://www.typescriptlang.org/docs/)
+- [OWASP Mobile Security](https://owasp.org/www-project-mobile-top-10/)
+
 ---
 
-## Ações
+## ✅ Checklist de Conformidade
 
-- [ ] Corrigir todas as violações críticas
-- [ ] Configurar pre-commit hooks (Husky)
-- [ ] Documentar padrões do projeto
-- [ ] Treinar equipe em convenções
+Use este checklist para futuras verificações de conformidade:
+
+### Antes do Deploy em Produção
+- [ ] Pontuação global ≥ 80/100
+- [ ] Sem problemas críticos
+- [ ] Cobertura de testes ≥ 70%
+- [ ] 0 vulnerabilidades de segurança (alta/crítica)
+- [ ] 0 erros ESLint
+- [ ] 0 erros TypeScript
+- [ ] Todos os testes aprovados
+- [ ] Documentação atualizada
 
 ---
 
-**Conformidade consistente resulta em código mais manutenível e colaboração mais eficiente.**
+**Pontuação Global: XX/100**
+**Recomendação: [Pronto para Produção / Precisa de Melhorias / Requer Refatoração]**

--- a/Dev/i18n/pt/ReactNative/commands/check-security.md
+++ b/Dev/i18n/pt/ReactNative/commands/check-security.md
@@ -1,194 +1,442 @@
 ---
-description: Comando: Verificar Segurança
+description: Verificar Segurança React Native
+argument-hint: [arguments]
 ---
 
-# Comando: Verificar Segurança
+# Verificar Segurança React Native
 
-Realize uma auditoria de segurança na aplicação React Native.
+## Argumentos
 
----
+$ARGUMENTS
 
-## Objetivo
+## Modo de Planejamento
 
-Este comando identifica vulnerabilidades de segurança, verifica conformidade com melhores práticas e recomenda melhorias.
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer uma investigação transversal.
 
----
+## MISSÃO
 
-## Modo Plano
+Você é um especialista em auditoria de segurança React Native. Sua missão é analisar as práticas de segurança de acordo com os padrões definidos em `.claude/rules/11-security.md`.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+### Etapa 1: Análise de dependências e configuração
 
-## Análise
+1. Verificar as dependências de segurança instaladas
+2. Analisar arquivos de configuração sensíveis
+3. Verificar a presença de segredos no código
+4. Analisar as permissões solicitadas
 
-### 1. Auditoria de Dependências
+### Etapa 2: Armazenamento Seguro (6 pontos)
 
-**Executar:**
+#### 🔐 Expo SecureStore / Keychain
+
+- [ ] **(2 pts)** Uso de `expo-secure-store` ou `react-native-keychain` para dados sensíveis
+- [ ] **(1 pt)** Sem armazenamento de token/segredo no AsyncStorage
+- [ ] **(1 pt)** Sem armazenamento de senha em texto simples
+- [ ] **(1 pt)** Sem dados sensíveis em estado Redux/Zustand não persistido
+- [ ] **(1 pt)** Configuração biométrica para acesso a dados sensíveis, quando aplicável
+
+**Arquivos a verificar:**
+```bash
+src/services/storage.ts
+src/utils/secureStorage.ts
+src/hooks/useAuth.ts
+```
+
+Buscar padrões perigosos:
+```bash
+# Buscar AsyncStorage para dados sensíveis
+grep -r "AsyncStorage.setItem.*token" src/
+grep -r "AsyncStorage.setItem.*password" src/
+grep -r "AsyncStorage.setItem.*secret" src/
+```
+
+### Etapa 3: Gerenciamento de segredos e chaves de API (5 pontos)
+
+#### 🔑 Sem segredos no código
+
+- [ ] **(2 pts)** Sem chave de API hardcoded no código-fonte
+- [ ] **(1 pt)** Uso de variáveis de ambiente (`.env`, `app.config.js`)
+- [ ] **(1 pt)** `.env` no `.gitignore`
+- [ ] **(1 pt)** Documentação das variáveis de ambiente necessárias (`.env.example`)
+
+**Arquivos a verificar:**
+```bash
+.env
+.env.example
+.gitignore
+app.config.js
+app.json
+```
+
+Buscar segredos hardcoded:
+```bash
+# Padrões suspeitos
+grep -rE "(api[_-]?key|secret|password|token|private[_-]?key).*=.*['\"][a-zA-Z0-9]{20,}" src/ --exclude-dir=node_modules
+grep -rE "https?://[^/]*:([^@]+)@" src/ --exclude-dir=node_modules
+```
+
+**Verificar especificamente:**
+- Sem chaves AWS, Google, Firebase hardcoded
+- Sem tokens OAuth hardcoded
+- Sem certificados ou chaves privadas no repositório
+
+### Etapa 4: Comunicação de rede segura (5 pontos)
+
+#### 🌐 HTTPS e Certificate Pinning
+
+- [ ] **(2 pts)** Todas as comunicações apenas em HTTPS
+- [ ] **(1 pt)** Certificate pinning implementado para APIs críticas
+- [ ] **(1 pt)** Validação de certificado SSL habilitada
+- [ ] **(1 pt)** Timeout e retry apropriados para requisições
+
+**Arquivos a verificar:**
+```bash
+src/services/api.ts
+src/config/network.ts
+app.json (iOS NSAppTransportSecurity)
+android/app/src/main/AndroidManifest.xml (android:usesCleartextTraffic)
+```
+
+Verificar:
+```typescript
+// Correto: apenas HTTPS
+const API_URL = 'https://api.example.com';
+
+// Incorreto: HTTP
+const API_URL = 'http://api.example.com';
+```
+
+Para iOS (app.json):
+```json
+{
+  "ios": {
+    "infoPlist": {
+      "NSAppTransportSecurity": {
+        "NSAllowsArbitraryLoads": false
+      }
+    }
+  }
+}
+```
+
+Para Android (AndroidManifest.xml):
+```xml
+<!-- Deve ser false ou ausente -->
+<application android:usesCleartextTraffic="false">
+```
+
+### Etapa 5: Autenticação e autorização (4 pontos)
+
+#### 🔒 Gerenciamento de tokens e sessões
+
+- [ ] **(1 pt)** JWT armazenado com segurança (SecureStore)
+- [ ] **(1 pt)** Refresh token implementado
+- [ ] **(1 pt)** Expiração de token tratada
+- [ ] **(1 pt)** Logout automático após inatividade (se aplicável)
+
+**Arquivos a verificar:**
+```bash
+src/services/auth.ts
+src/hooks/useAuth.ts
+src/contexts/AuthContext.tsx
+```
+
+**Verificar o fluxo:**
+```typescript
+// Padrão correto
+const token = await SecureStore.getItemAsync('access_token');
+const refreshToken = await SecureStore.getItemAsync('refresh_token');
+
+// Padrão incorreto
+const token = await AsyncStorage.getItem('access_token');
+```
+
+### Etapa 6: Permissões e dados do usuário (3 pontos)
+
+#### 📱 Permissões Android/iOS
+
+- [ ] **(1 pt)** Permissões solicitadas justificadas e mínimas
+- [ ] **(1 pt)** Solicitações de permissão em tempo de execução (não todas na inicialização)
+- [ ] **(1 pt)** Mensagens explicativas para permissões sensíveis
+
+**Arquivos a verificar:**
+```bash
+app.json (permissões iOS/Android)
+android/app/src/main/AndroidManifest.xml
+ios/[AppName]/Info.plist
+```
+
+**Permissões a auditar:**
+- Câmera (NSCameraUsageDescription / CAMERA)
+- Localização (NSLocationWhenInUseUsageDescription / ACCESS_FINE_LOCATION)
+- Contatos (NSContactsUsageDescription / READ_CONTACTS)
+- Armazenamento (READ_EXTERNAL_STORAGE, WRITE_EXTERNAL_STORAGE)
+
+### Etapa 7: Proteção de código (2 pontos)
+
+#### 🛡️ Ofuscação e proteção
+
+- [ ] **(1 pt)** Ofuscação habilitada para builds de produção (ProGuard/R8)
+- [ ] **(1 pt)** Logs sensíveis desabilitados em produção (sem console.log de tokens)
+
+**Arquivos a verificar:**
+```bash
+android/app/build.gradle (minifyEnabled, shrinkResources)
+src/**/*.ts (instruções console.log)
+```
+
+Para Android (build.gradle):
+```gradle
+buildTypes {
+    release {
+        minifyEnabled true
+        shrinkResources true
+        proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
+    }
+}
+```
+
+Buscar logs sensíveis:
+```bash
+grep -rE "console\.(log|debug|info).*token" src/
+grep -rE "console\.(log|debug|info).*password" src/
+grep -rE "console\.(log|debug|info).*secret" src/
+```
+
+### Etapa 8: Calcular pontuação
+
+```
+┌──────────────────────────────────┬─────────┬────────┐
+│ Critério                         │ Pontos  │ Status │
+├──────────────────────────────────┼─────────┼────────┤
+│ Armazenamento seguro             │ XX/6    │ ✅/⚠️/❌│
+│ Segredos e chaves de API         │ XX/5    │ ✅/⚠️/❌│
+│ Comunicação de rede              │ XX/5    │ ✅/⚠️/❌│
+│ Autenticação                     │ XX/4    │ ✅/⚠️/❌│
+│ Permissões                       │ XX/3    │ ✅/⚠️/❌│
+│ Proteção de código               │ XX/2    │ ✅/⚠️/❌│
+├──────────────────────────────────┼─────────┼────────┤
+│ TOTAL SEGURANÇA                  │ XX/25   │ ✅/⚠️/❌│
+└──────────────────────────────────┴─────────┴────────┘
+```
+
+**Legenda:**
+- ✅ Excelente (≥ 20/25)
+- ⚠️ Atenção (15-19/25)
+- ❌ Crítico (< 15/25)
+
+### Etapa 9: Varredura de vulnerabilidades
+
+Executar os seguintes comandos para detectar vulnerabilidades:
+
+#### 🔍 NPM Audit
 
 ```bash
-# NPM audit
+npm audit
+```
+
+Analisar os resultados:
+- **Vulnerabilidades críticas:** XX (alvo: 0)
+- **Vulnerabilidades altas:** XX (alvo: 0)
+- **Vulnerabilidades médias:** XX (alvo: < 5)
+- **Vulnerabilidades baixas:** XX
+
+#### 📦 Dependências desatualizadas
+
+```bash
+npm outdated
+```
+
+Listar dependências de segurança desatualizadas:
+- `expo-secure-store`
+- `react-native-keychain`
+- `react-native-ssl-pinning`
+- etc.
+
+### Etapa 10: Relatório detalhado
+
+## 📊 RESULTADOS DA AUDITORIA DE SEGURANÇA
+
+### ✅ Pontos Fortes
+
+Liste as boas práticas identificadas:
+- [Prática 1 com localização]
+- [Prática 2 com localização]
+
+### 🚨 Vulnerabilidades Críticas
+
+Liste os problemas de segurança críticos (pontuação ❌ imediata):
+
+1. **[CRÍTICO - Problema 1]**
+   - **Severidade:** CRÍTICA
+   - **Localização:** [Arquivos afetados]
+   - **Risco:** [Descrição do risco]
+   - **Exemplo:**
+   ```typescript
+   // Código vulnerável
+   const API_KEY = "sk_live_123456789abcdef"; // ❌ CRÍTICO
+   ```
+   - **Correção imediata:**
+   ```typescript
+   // Código seguro
+   const API_KEY = process.env.EXPO_PUBLIC_API_KEY; // ✅
+   ```
+
+### ⚠️ Pontos de Melhoria
+
+Liste os problemas por prioridade:
+
+1. **[Problema 1]**
+   - **Severidade:** Alta/Média
+   - **Localização:** [Arquivos afetados]
+   - **Risco:** [Descrição]
+   - **Recomendação:** [Ação]
+
+2. **[Problema 2]**
+   - **Severidade:** Alta/Média
+   - **Localização:** [Arquivos afetados]
+   - **Risco:** [Descrição]
+   - **Recomendação:** [Ação]
+
+### 📈 Métricas de Segurança
+
+#### Vulnerabilidades em dependências
+
+```
+┌─────────────────────┬──────────┐
+│ Severidade          │ Contagem │
+├─────────────────────┼──────────┤
+│ 🔴 Crítica          │ XX       │
+│ 🟠 Alta             │ XX       │
+│ 🟡 Média            │ XX       │
+│ 🟢 Baixa            │ XX       │
+└─────────────────────┴──────────┘
+```
+
+#### Segredos detectados
+
+- **Chaves de API hardcoded:** XX (alvo: 0)
+- **Tokens hardcoded:** XX (alvo: 0)
+- **Senhas hardcoded:** XX (alvo: 0)
+- **Chaves privadas no repositório:** XX (alvo: 0)
+
+#### Permissões
+
+- **Total de permissões solicitadas:** XX
+- **Permissões sensíveis:** XX
+- **Permissões não justificadas:** XX (alvo: 0)
+
+#### Armazenamento
+
+- **Uso de SecureStore/Keychain:** Sim/Não
+- **Dados sensíveis no AsyncStorage:** XX ocorrências (alvo: 0)
+- **Biometria configurada:** Sim/Não
+
+#### Comunicação
+
+- **Endpoints HTTP (inseguros):** XX (alvo: 0)
+- **Endpoints HTTPS:** XX
+- **Certificate pinning:** Sim/Não
+- **Tráfego em texto simples permitido:** Sim/Não (alvo: Não)
+
+### 🎯 TOP 3 AÇÕES PRIORITÁRIAS
+
+#### 1. [AÇÃO DE SEGURANÇA #1]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** CRÍTICO/Alto/Médio
+- **Risco se não corrigido:** [Descrição do risco]
+- **Descrição:** [Detalhe da vulnerabilidade]
+- **Solução:** [Ação concreta e código]
+- **Arquivos afetados:**
+  - `[arquivo1]` - [problema]
+  - `[arquivo2]` - [problema]
+- **Exemplo de correção:**
+```typescript
+// ANTES (vulnerável)
+[código vulnerável]
+
+// DEPOIS (seguro)
+[código seguro]
+```
+
+#### 2. [AÇÃO DE SEGURANÇA #2]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** CRÍTICO/Alto/Médio
+- **Risco se não corrigido:** [Descrição]
+- **Descrição:** [Detalhe]
+- **Solução:** [Ação]
+- **Arquivos afetados:** [Lista]
+
+#### 3. [AÇÃO DE SEGURANÇA #3]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** CRÍTICO/Alto/Médio
+- **Risco se não corrigido:** [Descrição]
+- **Descrição:** [Detalhe]
+- **Solução:** [Ação]
+- **Arquivos afetados:** [Lista]
+
+---
+
+## 🛡️ Checklist de Segurança Mobile OWASP
+
+Referência: [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
+
+- [ ] **M1: Uso Inadequado da Plataforma** - Uso correto das APIs da plataforma
+- [ ] **M2: Armazenamento de Dados Inseguro** - Armazenamento seguro (SecureStore/Keychain)
+- [ ] **M3: Comunicação Insegura** - HTTPS + Certificate Pinning
+- [ ] **M4: Autenticação Insegura** - Autenticação robusta com JWT
+- [ ] **M5: Criptografia Insuficiente** - Sem criptografia customizada, usar APIs da plataforma
+- [ ] **M6: Autorização Insegura** - Autorização validada no lado do servidor
+- [ ] **M7: Qualidade do Código do Cliente** - Código de qualidade, ofuscado em produção
+- [ ] **M8: Adulteração de Código** - Proteção contra modificação (detecção de jailbreak)
+- [ ] **M9: Engenharia Reversa** - Ofuscação e proteção do código
+- [ ] **M10: Funcionalidade Estranha** - Sem backdoors ou logs de debug em produção
+
+---
+
+## 🚀 Recomendações
+
+### Ações imediatas (hoje)
+1. Corrigir todas as vulnerabilidades CRÍTICAS
+2. Remover todos os segredos hardcoded
+3. Executar `npm audit fix` para vulnerabilidades corrigíveis automaticamente
+
+### Ações de curto prazo (esta semana)
+1. Implementar SecureStore para todos os tokens
+2. Habilitar apenas HTTPS (bloquear HTTP)
+3. Adicionar .env ao .gitignore se ausente
+4. Atualizar dependências vulneráveis
+
+### Ações de médio prazo (este mês)
+1. Implementar certificate pinning
+2. Habilitar ofuscação em produção
+3. Auditoria completa de permissões
+4. Treinamento da equipe em boas práticas
+
+### Ferramentas recomendadas
+
+```bash
+# Instalar ferramentas de segurança
+npm install --save-dev @react-native-community/cli-doctor
 npm audit
 
-# Com fix automático
-npm audit fix
+# Para iOS
+gem install fastlane
 
-# Verificar vulnerabilidades conhecidas
-npx snyk test
-
-# Better-npm-audit
-npx better-npm-audit audit
-```
-
-**Verificar:**
-
-- [ ] Sem vulnerabilidades críticas
-- [ ] Sem vulnerabilidades altas
-- [ ] Dependências atualizadas
-- [ ] Sem dependências obsoletas
-
-### 2. Armazenamento de Dados
-
-**Verificar:**
-
-```bash
-# Buscar por uso de AsyncStorage para dados sensíveis
-rg "AsyncStorage" src --type ts --type tsx
-```
-
-**Avaliar:**
-
-- [ ] Dados sensíveis no SecureStore (não AsyncStorage)
-- [ ] Tokens armazenados com segurança
-- [ ] Sem credenciais hardcoded
-- [ ] Sem chaves de API no código
-- [ ] Dados criptografados quando necessário
-
-### 3. Comunicação de Rede
-
-**Verificar:**
-
-```bash
-# Buscar por URLs HTTP (não HTTPS)
-rg "http://" src --type ts --type tsx
-
-# Buscar por API keys hardcoded
-rg "api[_-]?key|api[_-]?secret" src --type ts --type tsx -i
-```
-
-**Avaliar:**
-
-- [ ] Todas as comunicações sobre HTTPS
-- [ ] Certificate pinning para APIs críticas
-- [ ] Tokens em headers (não query params)
-- [ ] Rate limiting implementado
-
-### 4. Validação de Entrada
-
-**Verificar:**
-
-- [ ] Todos os inputs do usuário validados
-- [ ] Validação de tipo, formato, comprimento
-- [ ] Dados de API sanitizados
-- [ ] XSS prevenido (escaping de user input)
-- [ ] SQL injection prevenida (se aplicável)
-
-### 5. Permissões
-
-**Verificar:**
-
-```bash
-# iOS: app.json ou Info.plist
-cat ios/*/Info.plist | grep -A 1 "NSCameraUsageDescription"
-
-# Android: AndroidManifest.xml
-cat android/app/src/main/AndroidManifest.xml | grep "uses-permission"
-```
-
-**Avaliar:**
-
-- [ ] Apenas permissões necessárias solicitadas
-- [ ] Justificativas fornecidas (iOS)
-- [ ] Permissões solicitadas no momento de uso
-- [ ] Permissões negadas tratadas adequadamente
-
-### 6. Configuração
-
-**Verificar:**
-
-- [ ] .env não commitado
-- [ ] Secrets em variáveis de ambiente
-- [ ] Configurações diferentes por ambiente
-- [ ] Debug mode desabilitado em produção
-- [ ] Logging desabilitado em produção
-
-### 7. Código
-
-**Verificar:**
-
-```bash
-# Buscar por console.logs com dados potencialmente sensíveis
-rg "console\.log.*password|console\.log.*token|console\.log.*key" src
-
-# Buscar por TODOs de segurança
-rg "TODO.*security|FIXME.*security" src -i
-```
-
-**Avaliar:**
-
-- [ ] Sem console.logs com dados sensíveis
-- [ ] Sem debuggers em produção
-- [ ] Sem comentários com credenciais
-- [ ] Error messages não expõem informações sensíveis
-
----
-
-## Checklist OWASP Mobile Top 10
-
-- [ ] **M1: Improper Platform Usage** - Keychain/Keystore usado corretamente
-- [ ] **M2: Insecure Data Storage** - Dados sensíveis no SecureStore
-- [ ] **M3: Insecure Communication** - HTTPS para tudo
-- [ ] **M4: Insecure Authentication** - Autenticação robusta implementada
-- [ ] **M5: Insufficient Cryptography** - Algoritmos modernos, keys seguras
-- [ ] **M6: Insecure Authorization** - Controles de acesso no backend
-- [ ] **M7: Client Code Quality** - Code review, testes, análise estática
-- [ ] **M8: Code Tampering** - Detecção de jailbreak/root
-- [ ] **M9: Reverse Engineering** - Ofuscação de código
-- [ ] **M10: Extraneous Functionality** - Backdoors removidos, debug code removido
-
----
-
-## Relatório
-
-```markdown
-## Auditoria de Segurança
-
-### Vulnerabilidades Críticas
-1. [Descrição] - [Localização] - [Ação]
-
-### Vulnerabilidades Altas
-1. [Descrição] - [Localização] - [Ação]
-
-### Vulnerabilidades Médias
-1. [Descrição] - [Localização] - [Ação]
-
-### Recomendações
-1. [Ação prioritária]
-2. [Melhoria de segurança]
-
-### Score de Segurança: [X]/100
+# Para Android
+# Usar ProGuard/R8 (já incluído)
 ```
 
 ---
 
-## Ações Imediatas
+## 📚 Referências
 
-- [ ] Corrigir vulnerabilidades críticas
-- [ ] Atualizar dependências vulneráveis
-- [ ] Mover dados sensíveis para SecureStore
-- [ ] Remover credenciais hardcoded
-- [ ] Habilitar HTTPS estritamente
-- [ ] Implementar certificate pinning
-- [ ] Configurar monitoramento de segurança
+- `.claude/rules/11-security.md` - Padrões de segurança
+- [OWASP Mobile Top 10](https://owasp.org/www-project-mobile-top-10/)
+- [React Native Security](https://reactnative.dev/docs/security)
+- [Expo Security](https://docs.expo.dev/guides/security/)
 
 ---
 
-**Segurança não é opcional. É responsabilidade de todos os desenvolvedores.**
+**Pontuação final: XX/25**
+
+**⚠️ AVISO: Uma pontuação < 15/25 em segurança exige ação imediata antes de qualquer implantação em produção.**

--- a/Dev/i18n/pt/ReactNative/commands/check-testing.md
+++ b/Dev/i18n/pt/ReactNative/commands/check-testing.md
@@ -1,130 +1,320 @@
 ---
-description: Comando: Verificar Testes
+description: Verificar Testes React Native
+argument-hint: [arguments]
 ---
 
-# Comando: Verificar Testes
+# Verificar Testes React Native
 
-Avalie a cobertura e qualidade dos testes na aplicação React Native.
+## Argumentos
 
----
+$ARGUMENTS
 
-## Objetivo
+## Modo de Planejamento
 
-Este comando analisa a suite de testes, identifica gaps de cobertura e avalia a qualidade dos testes existentes.
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer uma investigação transversal.
 
----
+## MISSÃO
 
-## Modo Plano
+Você é um especialista em auditoria de testes React Native. Sua missão é analisar a estratégia de testes e a cobertura de acordo com os padrões definidos em `.claude/rules/07-testing.md` e `.claude/rules/08-quality-tools.md`.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+### Etapa 1: Análise da configuração de testes
 
-## Análise
+1. Verificar a presença e configuração do Jest
+2. Verificar a presença e configuração da React Native Testing Library (RNTL)
+3. Verificar a presença e configuração do Detox (testes E2E)
+4. Analisar os scripts de teste no package.json
 
-### 1. Executar Testes
+### Etapa 2: Configuração do Jest (5 pontos)
 
-**Comandos:**
+#### 🧪 Arquivos de configuração
+
+- [ ] **(1 pt)** `jest.config.js` ou configuração no package.json presente
+- [ ] **(1 pt)** Preset do React Native configurado (`@react-native/jest-preset` ou equivalente)
+- [ ] **(1 pt)** Arquivos de setup configurados (`setupFilesAfterEnv`)
+- [ ] **(1 pt)** Cobertura de código habilitada (coverage)
+- [ ] **(1 pt)** Transformações configuradas para TypeScript e React Native
+
+**Arquivos a verificar:**
+```bash
+jest.config.js
+jest.setup.js
+package.json
+```
+
+#### 📊 Configuração de cobertura
+
+Verificar em `jest.config.js`:
+```javascript
+coverageThreshold: {
+  global: {
+    branches: 80,
+    functions: 80,
+    lines: 80,
+    statements: 80
+  }
+}
+```
+
+- [ ] Limites de cobertura definidos (≥ 80% recomendado)
+- [ ] Coleta a partir das pastas corretas (src/, app/)
+- [ ] Exclusões apropriadas (node_modules, __tests__, etc.)
+
+### Etapa 3: Testes Unitários com RNTL (8 pontos)
+
+Referência: `.claude/rules/07-testing.md`
+
+#### 📁 Organização dos testes
+
+- [ ] **(1 pt)** Testes colocalizados com componentes ou em `__tests__/`
+- [ ] **(1 pt)** Convenção de nomenclatura: `*.test.tsx` ou `*.spec.tsx`
+- [ ] **(1 pt)** Estrutura AAA (Arrange, Act, Assert) respeitada
+
+**Arquivos a verificar:**
+```bash
+src/**/__tests__/
+src/**/*.test.tsx
+src/**/*.spec.tsx
+```
+
+#### 🧩 Qualidade dos testes unitários
+
+Analisar de 5 a 10 arquivos de teste:
+
+- [ ] **(1 pt)** Uso de `@testing-library/react-native` (render, fireEvent, waitFor)
+- [ ] **(1 pt)** Testes de componentes isolados com props mockados
+- [ ] **(1 pt)** Testes de hooks customizados com `@testing-library/react-hooks`
+- [ ] **(1 pt)** Mocks apropriados para módulos nativos (AsyncStorage, etc.)
+- [ ] **(1 pt)** Testes de casos extremos e de erro
+
+**Exemplo de bom teste:**
+```typescript
+describe('LoginButton', () => {
+  it('should call onPress when pressed', () => {
+    const onPress = jest.fn();
+    const { getByText } = render(<LoginButton onPress={onPress} />);
+
+    fireEvent.press(getByText('Login'));
+
+    expect(onPress).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+### Etapa 4: Testes de Integração (4 pontos)
+
+- [ ] **(1 pt)** Testes de fluxo completo do usuário
+- [ ] **(1 pt)** Testes de navegação entre telas
+- [ ] **(1 pt)** Testes de chamadas de API mockadas
+- [ ] **(1 pt)** Testes de gerenciamento de estado (Context, Redux, Zustand)
+
+**Arquivos a verificar:**
+```bash
+src/**/*.integration.test.tsx
+__tests__/integration/
+```
+
+### Etapa 5: Testes E2E com Detox (4 pontos)
+
+#### 🤖 Configuração do Detox
+
+- [ ] **(1 pt)** `.detoxrc.js` ou configuração do Detox presente
+- [ ] **(1 pt)** Configuração para iOS e Android
+- [ ] **(1 pt)** Scripts de testes E2E no package.json (`test:e2e`)
+
+**Arquivos a verificar:**
+```bash
+.detoxrc.js
+.detoxrc.json
+e2e/
+package.json
+```
+
+#### 🎬 Testes E2E
+
+- [ ] **(1 pt)** Pelo menos 3 cenários E2E críticos testados (login, navegação principal, ação-chave)
+
+**Arquivos a verificar:**
+```bash
+e2e/**/*.e2e.ts
+e2e/**/*.e2e.js
+```
+
+### Etapa 6: Cobertura de Testes (4 pontos)
+
+Executar o comando de cobertura:
 
 ```bash
-# Executar todos os testes
-npm test
-
-# Com cobertura
-npm test -- --coverage
-
-# Modo watch
-npm test -- --watch
+npm run test -- --coverage
+# ou
+yarn test --coverage
 ```
 
-### 2. Cobertura de Testes
+Analisar o relatório de cobertura:
 
-**Verificar:**
+- [ ] **(1 pt)** Cobertura global ≥ 80%
+- [ ] **(1 pt)** Cobertura de branches ≥ 75%
+- [ ] **(1 pt)** Componentes críticos cobertos a 100%
+- [ ] **(1 pt)** Relatório de cobertura gerado (coverage/lcov-report/)
 
+**Arquivos a verificar:**
 ```bash
-# Gerar relatório de cobertura
-npm test -- --coverage --coverageReporters=text --coverageReporters=html
-
-# Abrir relatório
-open coverage/index.html
+coverage/lcov-report/index.html
+coverage/coverage-summary.json
 ```
 
-**Avaliar:**
+### Etapa 7: Calcular pontuação
 
-- [ ] Cobertura de statements > 80%
-- [ ] Cobertura de branches > 80%
-- [ ] Cobertura de functions > 80%
-- [ ] Cobertura de lines > 80%
-- [ ] Componentes críticos 100% cobertos
-
-### 3. Qualidade dos Testes
-
-**Verificar:**
-
-- [ ] Testes são significativos (não apenas para cobertura)
-- [ ] Testes isolados (sem dependências entre testes)
-- [ ] Testes rápidos (< 1s por teste)
-- [ ] Asserções claras e específicas
-- [ ] Mocks apropriados
-- [ ] Setup e teardown adequados
-
-### 4. Tipos de Testes
-
-**Avaliar cobertura:**
-
-- [ ] **Testes Unitários**: Hooks, utils, serviços
-- [ ] **Testes de Componentes**: UI components
-- [ ] **Testes de Integração**: Fluxos de usuário
-- [ ] **Testes E2E**: Jornadas críticas (se aplicável)
-
-### 5. Gaps de Cobertura
-
-**Identificar:**
-
-```bash
-# Arquivos sem testes
-find src -name "*.tsx" -o -name "*.ts" | while read file; do
-  test_file="${file%.tsx}.test.tsx"
-  test_file="${test_file%.ts}.test.ts"
-  if [ ! -f "$test_file" ]; then
-    echo "Missing test: $file"
-  fi
-done
 ```
+┌──────────────────────────────────┬─────────┬────────┐
+│ Critério                         │ Pontos  │ Status │
+├──────────────────────────────────┼─────────┼────────┤
+│ Configuração do Jest             │ XX/5    │ ✅/⚠️/❌│
+│ Testes Unitários (RNTL)          │ XX/8    │ ✅/⚠️/❌│
+│ Testes de Integração             │ XX/4    │ ✅/⚠️/❌│
+│ Testes E2E (Detox)               │ XX/4    │ ✅/⚠️/❌│
+│ Cobertura de Código              │ XX/4    │ ✅/⚠️/❌│
+├──────────────────────────────────┼─────────┼────────┤
+│ TOTAL TESTES                     │ XX/25   │ ✅/⚠️/❌│
+└──────────────────────────────────┴─────────┴────────┘
+```
+
+**Legenda:**
+- ✅ Excelente (≥ 20/25)
+- ⚠️ Atenção (15-19/25)
+- ❌ Crítico (< 15/25)
+
+### Etapa 8: Relatório detalhado
+
+## 📊 RESULTADOS DA AUDITORIA DE TESTES
+
+### ✅ Pontos Fortes
+
+Liste as boas práticas identificadas:
+- [Prática 1 com exemplo de teste]
+- [Prática 2 com exemplo de teste]
+
+### ⚠️ Pontos de Melhoria
+
+Liste os problemas identificados por prioridade:
+
+1. **[Problema 1]**
+   - **Severidade:** Crítica/Alta/Média
+   - **Localização:** [Arquivos/componentes não testados]
+   - **Impacto:** [Risco de regressão]
+   - **Recomendação:** [Ações a tomar]
+
+2. **[Problema 2]**
+   - **Severidade:** Crítica/Alta/Média
+   - **Localização:** [Arquivos/componentes não testados]
+   - **Impacto:** [Risco de regressão]
+   - **Recomendação:** [Ações a tomar]
+
+### 📈 Métricas de Testes
+
+#### Cobertura de código
+
+```
+┌─────────────────┬──────────┬──────────┬──────────┬──────────┐
+│ Tipo            │ Linhas   │ Branches │ Funções  │ Statements│
+├─────────────────┼──────────┼──────────┼──────────┼──────────┤
+│ Global          │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+│ Componentes     │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+│ Hooks           │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+│ Utils           │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+│ Serviços        │ XX.XX%   │ XX.XX%   │ XX.XX%   │ XX.XX%   │
+└─────────────────┴──────────┴──────────┴──────────┴──────────┘
+```
+
+#### Estatísticas de testes
+
+- **Número total de testes:** XX
+  - Testes unitários: XX
+  - Testes de integração: XX
+  - Testes E2E: XX
+- **Testes aprovados:** XX
+- **Testes reprovados:** XX
+- **Tempo total de execução:** XX segundos
+- **Proporção testes/código:** XX testes para YY linhas de código
+
+#### Componentes sem testes
+
+Liste os componentes críticos não testados:
+1. `[Caminho/Componente]` - [Razão de criticidade]
+2. `[Caminho/Componente]` - [Razão de criticidade]
+3. `[Caminho/Componente]` - [Razão de criticidade]
+
+#### Funcionalidades críticas testadas
+
+- [ ] Autenticação (login, logout, refresh token)
+- [ ] Navegação principal
+- [ ] Formulários críticos
+- [ ] Principais chamadas de API
+- [ ] Tratamento de erros
+- [ ] Estados de carregamento
+- [ ] Gerenciamento offline
+
+### 🎯 TOP 3 AÇÕES PRIORITÁRIAS
+
+#### 1. [AÇÃO #1]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** Crítico/Alto/Médio
+- **Descrição:** [Componentes/funcionalidades a testar com prioridade]
+- **Cobertura atual:** XX%
+- **Cobertura alvo:** YY%
+- **Arquivos afetados:**
+  - `[arquivo1]` (cobertura: XX%)
+  - `[arquivo2]` (cobertura: XX%)
+- **Exemplos de testes a adicionar:**
+```typescript
+describe('[Componente]', () => {
+  it('should [comportamento]', () => {
+    // Teste a implementar
+  });
+});
+```
+
+#### 2. [AÇÃO #2]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** Crítico/Alto/Médio
+- **Descrição:** [Configuração ou melhoria de testes]
+- **Arquivos afetados:** [Lista]
+
+#### 3. [AÇÃO #3]
+- **Esforço:** Baixo/Médio/Alto
+- **Impacto:** Crítico/Alto/Médio
+- **Descrição:** [Testes E2E ou de integração a adicionar]
+- **Cenários a cobrir:**
+  - [Cenário 1]
+  - [Cenário 2]
 
 ---
 
-## Relatório
+## 🚀 Recomendações
 
-```markdown
-## Análise de Testes
+### Ganhos Rápidos (Baixo esforço, alto impacto)
+- [Melhoria rápida 1]
+- [Melhoria rápida 2]
 
-### Métricas de Cobertura
-- Statements: [X]%
-- Branches: [X]%
-- Functions: [X]%
-- Lines: [X]%
+### Investimentos (Esforço médio/alto, alto impacto)
+- [Melhoria estrutural 1]
+- [Melhoria estrutural 2]
 
-### Arquivos sem Testes
-- [lista de arquivos]
-
-### Testes Frágeis
-- [testes que falham intermitentemente]
-
-### Recomendações
-1. [Adicionar testes para componentes críticos]
-2. [Melhorar qualidade de testes existentes]
-3. [Implementar testes E2E para fluxos principais]
-```
+### Boas práticas a adotar
+- Escrever testes junto com o código (TDD)
+- Almejar cobertura mínima de 80%
+- Testar casos extremos e erros
+- Manter os testes atualizados com o código
+- Usar snapshots com parcimônia
 
 ---
 
-## Ações
+## 📚 Referências
 
-- [ ] Adicionar testes para arquivos sem cobertura
-- [ ] Melhorar testes frágeis
-- [ ] Atingir meta de cobertura de 80%
-- [ ] Implementar testes de integração
-- [ ] Configurar CI/CD para falhar se cobertura cair
+- `.claude/rules/07-testing.md` - Padrões de testes
+- `.claude/rules/08-quality-tools.md` - Ferramentas de qualidade
+- [React Native Testing Library](https://callstack.github.io/react-native-testing-library/)
+- [Detox Documentation](https://wix.github.io/Detox/)
 
 ---
 
-**Testes não são custo, são investimento em confiança e velocidade de desenvolvimento.**
+**Pontuação final: XX/25**

--- a/Dev/i18n/pt/ReactNative/commands/generate-screen.md
+++ b/Dev/i18n/pt/ReactNative/commands/generate-screen.md
@@ -1,420 +1,587 @@
 ---
-description: Comando: Gerar Screen
+description: Geração de Tela React Native
+argument-hint: [arguments]
 ---
 
-# Comando: Gerar Screen
+# Geração de Tela React Native
 
-Gere uma nova screen React Native com Expo Router seguindo as melhores práticas e padrões do projeto.
+Você é um desenvolvedor React Native sênior. Você deve gerar uma tela completa com navegação, gerenciamento de estado, testes e acessibilidade.
 
----
+## Argumentos
+$ARGUMENTS
 
-## Uso
+Argumentos:
+- Nome da tela (ex.: `Profile`, `Settings`, `ProductDetail`)
+- (Opcional) Tipo: list, detail, form, dashboard
 
-```bash
-npx generate-screen <nome-da-screen> [opções]
+Exemplo: `/reactnative:generate-screen ProductDetail detail`
+
+## Modo de Planejamento
+
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+
+## MISSÃO
+
+### Etapa 1: Estrutura da Tela
+
+```
+src/
+└── screens/
+    └── {ScreenName}/
+        ├── index.ts
+        ├── {ScreenName}Screen.tsx
+        ├── {ScreenName}Screen.types.ts
+        ├── {ScreenName}Screen.styles.ts
+        ├── {ScreenName}Screen.test.tsx
+        ├── hooks/
+        │   └── use{ScreenName}.ts
+        └── components/
+            └── {ScreenName}Header.tsx
 ```
 
-**Opções:**
-- `--type`: tipo de screen (stack, tab, modal)
-- `--feature`: feature a qual pertence
-- `--with-test`: gerar arquivo de teste
-- `--with-form`: incluir componentes de formulário
-
-**Exemplos:**
-
-```bash
-# Screen simples
-npx generate-screen UserProfile
-
-# Screen em feature específica
-npx generate-screen CreatePost --feature=posts
-
-# Screen com teste
-npx generate-screen Settings --with-test
-
-# Modal screen
-npx generate-screen ShareModal --type=modal
-```
-
----
-
-## Modo Plano
-
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
-
-## Templates Gerados
-
-### 1. Screen Básica
-
-**app/user-profile.tsx:**
+### Etapa 2: Tipos
 
 ```typescript
-import { View, Text, StyleSheet } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
+// src/screens/{ScreenName}/{ScreenName}Screen.types.ts
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+import type { RootStackParamList } from '@/navigation/types';
 
-export default function UserProfileScreen() {
-  return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.content}>
-        <Text style={styles.title}>User Profile</Text>
-      </View>
-    </SafeAreaView>
-  );
+export type {ScreenName}ScreenProps = NativeStackScreenProps<
+  RootStackParamList,
+  '{ScreenName}'
+>;
+
+export interface {ScreenName}ScreenParams {
+  id: string;
+  title?: string;
 }
 
-const styles = StyleSheet.create({
+export interface {ScreenName}Data {
+  id: string;
+  title: string;
+  description: string;
+  imageUrl?: string;
+  createdAt: string;
+  // ...outros campos
+}
+
+export interface {ScreenName}ScreenState {
+  data: {ScreenName}Data | null;
+  isLoading: boolean;
+  error: string | null;
+}
+```
+
+### Etapa 3: Hook Personalizado
+
+```typescript
+// src/screens/{ScreenName}/hooks/use{ScreenName}.ts
+import { useState, useEffect, useCallback } from 'react';
+import { useRoute } from '@react-navigation/native';
+
+import { {screenName}Service } from '@/services/{screenName}Service';
+import type { {ScreenName}Data, {ScreenName}ScreenParams } from '../{ScreenName}Screen.types';
+
+interface Use{ScreenName}Return {
+  data: {ScreenName}Data | null;
+  isLoading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+}
+
+export function use{ScreenName}(): Use{ScreenName}Return {
+  const route = useRoute<{ params: {ScreenName}ScreenParams }>();
+  const { id } = route.params;
+
+  const [data, setData] = useState<{ScreenName}Data | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+      const result = await {screenName}Service.getById(id);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Ocorreu um erro');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [id]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const refresh = useCallback(async () => {
+    await fetchData();
+  }, [fetchData]);
+
+  return { data, isLoading, error, refresh };
+}
+```
+
+### Etapa 4: Estilos
+
+```typescript
+// src/screens/{ScreenName}/{ScreenName}Screen.styles.ts
+import { StyleSheet } from 'react-native';
+import { theme } from '@/theme';
+
+export const styles = StyleSheet.create({
   container: {
     flex: 1,
-    backgroundColor: '#fff',
+    backgroundColor: theme.colors.background,
   },
   content: {
     flex: 1,
-    padding: 16,
+    padding: theme.spacing.md,
   },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 16,
-  },
-});
-```
-
-### 2. Screen com Data Fetching
-
-**app/article/[id].tsx:**
-
-```typescript
-import { View, Text, StyleSheet, ActivityIndicator } from 'react-native';
-import { useLocalSearchParams } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useArticle } from '@/features/articles/hooks/useArticle';
-
-export default function ArticleScreen() {
-  const { id } = useLocalSearchParams<{ id: string }>();
-  const { data: article, isLoading, error } = useArticle(id);
-
-  if (isLoading) {
-    return (
-      <View style={styles.centerContainer}>
-        <ActivityIndicator size="large" />
-      </View>
-    );
-  }
-
-  if (error || !article) {
-    return (
-      <View style={styles.centerContainer}>
-        <Text style={styles.errorText}>Erro ao carregar artigo</Text>
-      </View>
-    );
-  }
-
-  return (
-    <SafeAreaView style={styles.container}>
-      <View style={styles.content}>
-        <Text style={styles.title}>{article.title}</Text>
-        <Text style={styles.body}>{article.content}</Text>
-      </View>
-    </SafeAreaView>
-  );
-}
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-  },
-  centerContainer: {
+  loadingContainer: {
     flex: 1,
     justifyContent: 'center',
     alignItems: 'center',
   },
-  content: {
+  errorContainer: {
     flex: 1,
-    padding: 16,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 16,
-  },
-  body: {
-    fontSize: 16,
-    lineHeight: 24,
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: theme.spacing.lg,
   },
   errorText: {
-    fontSize: 16,
-    color: '#f00',
+    fontSize: theme.typography.body.fontSize,
+    color: theme.colors.error,
+    textAlign: 'center',
+    marginBottom: theme.spacing.md,
+  },
+  retryButton: {
+    paddingHorizontal: theme.spacing.lg,
+    paddingVertical: theme.spacing.sm,
+    backgroundColor: theme.colors.primary,
+    borderRadius: theme.borderRadius.md,
+  },
+  retryButtonText: {
+    color: theme.colors.white,
+    fontWeight: '600',
+  },
+  headerImage: {
+    width: '100%',
+    height: 200,
+    resizeMode: 'cover',
+  },
+  title: {
+    fontSize: theme.typography.h1.fontSize,
+    fontWeight: theme.typography.h1.fontWeight,
+    color: theme.colors.text,
+    marginBottom: theme.spacing.sm,
+  },
+  description: {
+    fontSize: theme.typography.body.fontSize,
+    color: theme.colors.textSecondary,
+    lineHeight: 24,
+  },
+  metadata: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginTop: theme.spacing.md,
+  },
+  metadataText: {
+    fontSize: theme.typography.caption.fontSize,
+    color: theme.colors.textMuted,
   },
 });
 ```
 
-### 3. Screen com Formulário
+### Etapa 5: Componente da Tela
 
-**app/create-post.tsx:**
-
-```typescript
-import { View, Text, StyleSheet, ScrollView } from 'react-native';
+```tsx
+// src/screens/{ScreenName}/{ScreenName}Screen.tsx
+import React, { useCallback } from 'react';
+import {
+  View,
+  Text,
+  ScrollView,
+  Image,
+  RefreshControl,
+  TouchableOpacity,
+  ActivityIndicator,
+} from 'react-native';
 import { SafeAreaView } from 'react-native-safe-area-context';
-import { router } from 'expo-router';
-import { useCreatePost } from '@/features/posts/hooks/useCreatePost';
-import { PostForm } from '@/features/posts/components/PostForm';
-import type { CreatePostDTO } from '@/features/posts/types/Post.types';
 
-export default function CreatePostScreen() {
-  const { mutate: createPost, isPending } = useCreatePost();
+import { use{ScreenName} } from './hooks/use{ScreenName}';
+import { styles } from './{ScreenName}Screen.styles';
+import type { {ScreenName}ScreenProps } from './{ScreenName}Screen.types';
 
-  const handleSubmit = (data: CreatePostDTO) => {
-    createPost(data, {
-      onSuccess: (post) => {
-        router.push(`/post/${post.id}`);
-      },
-      onError: (error) => {
-        Alert.alert('Erro', 'Não foi possível criar o post');
-      },
-    });
-  };
+export function {ScreenName}Screen({ navigation }: {ScreenName}ScreenProps) {
+  const { data, isLoading, error, refresh } = use{ScreenName}();
+  const [isRefreshing, setIsRefreshing] = React.useState(false);
 
+  const handleRefresh = useCallback(async () => {
+    setIsRefreshing(true);
+    await refresh();
+    setIsRefreshing(false);
+  }, [refresh]);
+
+  // Estado de carregamento inicial
+  if (isLoading && !data) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View
+          style={styles.loadingContainer}
+          accessibilityLabel="Carregamento em andamento"
+          accessibilityRole="progressbar"
+        >
+          <ActivityIndicator size="large" />
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // Estado de erro
+  if (error && !data) {
+    return (
+      <SafeAreaView style={styles.container}>
+        <View style={styles.errorContainer}>
+          <Text
+            style={styles.errorText}
+            accessibilityRole="alert"
+          >
+            {error}
+          </Text>
+          <TouchableOpacity
+            style={styles.retryButton}
+            onPress={refresh}
+            accessibilityLabel="Tentar novamente o carregamento"
+            accessibilityRole="button"
+          >
+            <Text style={styles.retryButtonText}>Tentar novamente</Text>
+          </TouchableOpacity>
+        </View>
+      </SafeAreaView>
+    );
+  }
+
+  // Estado normal com dados
   return (
-    <SafeAreaView style={styles.container}>
-      <ScrollView style={styles.scrollView}>
-        <View style={styles.content}>
-          <Text style={styles.title}>Criar Novo Post</Text>
-          <PostForm
-            onSubmit={handleSubmit}
-            isSubmitting={isPending}
+    <SafeAreaView style={styles.container} edges={['bottom']}>
+      <ScrollView
+        style={styles.content}
+        refreshControl={
+          <RefreshControl
+            refreshing={isRefreshing}
+            onRefresh={handleRefresh}
+            accessibilityLabel="Atualizar página"
           />
+        }
+        contentContainerStyle={{ paddingBottom: 20 }}
+      >
+        {data?.imageUrl && (
+          <Image
+            source={{ uri: data.imageUrl }}
+            style={styles.headerImage}
+            accessibilityLabel={`Imagem de ${data.title}`}
+          />
+        )}
+
+        <View style={{ padding: 16 }}>
+          <Text
+            style={styles.title}
+            accessibilityRole="header"
+          >
+            {data?.title}
+          </Text>
+
+          <Text style={styles.description}>
+            {data?.description}
+          </Text>
+
+          <View style={styles.metadata}>
+            <Text style={styles.metadataText}>
+              Criado em {new Date(data?.createdAt || '').toLocaleDateString()}
+            </Text>
+          </View>
         </View>
       </ScrollView>
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-  },
-  scrollView: {
-    flex: 1,
-  },
-  content: {
-    padding: 16,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 24,
-  },
-});
 ```
 
-### 4. Modal Screen
-
-**app/modal.tsx:**
+### Etapa 6: Exportação
 
 ```typescript
-import { View, Text, StyleSheet, Pressable } from 'react-native';
-import { router } from 'expo-router';
-import { StatusBar } from 'expo-status-bar';
+// src/screens/{ScreenName}/index.ts
+export { {ScreenName}Screen } from './{ScreenName}Screen';
+export type { {ScreenName}ScreenProps, {ScreenName}ScreenParams } from './{ScreenName}Screen.types';
+```
 
-export default function ModalScreen() {
-  return (
-    <View style={styles.container}>
-      <StatusBar style="light" />
+### Etapa 7: Navegação
 
-      <View style={styles.content}>
-        <Text style={styles.title}>Modal</Text>
+```typescript
+// src/navigation/types.ts
+export type RootStackParamList = {
+  Home: undefined;
+  {ScreenName}: { id: string; title?: string };
+  // ...outras telas
+};
 
-        <Pressable
-          style={styles.closeButton}
-          onPress={() => router.back()}
-        >
-          <Text style={styles.closeButtonText}>Fechar</Text>
-        </Pressable>
-      </View>
-    </View>
+// src/navigation/RootNavigator.tsx
+import { {ScreenName}Screen } from '@/screens/{ScreenName}';
+
+<Stack.Screen
+  name="{ScreenName}"
+  component={{ScreenName}Screen}
+  options={({ route }) => ({
+    title: route.params?.title || '{ScreenName}',
+    headerBackTitleVisible: false,
+  })}
+/>
+```
+
+### Etapa 8: Testes
+
+```tsx
+// src/screens/{ScreenName}/{ScreenName}Screen.test.tsx
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react-native';
+import { NavigationContainer } from '@react-navigation/native';
+import { createNativeStackNavigator } from '@react-navigation/native-stack';
+
+import { {ScreenName}Screen } from './{ScreenName}Screen';
+import { {screenName}Service } from '@/services/{screenName}Service';
+
+// Mock do serviço
+jest.mock('@/services/{screenName}Service');
+const mockService = {screenName}Service as jest.Mocked<typeof {screenName}Service>;
+
+const Stack = createNativeStackNavigator();
+
+function renderWithNavigation(params = { id: '123' }) {
+  return render(
+    <NavigationContainer>
+      <Stack.Navigator>
+        <Stack.Screen
+          name="{ScreenName}"
+          component={{ScreenName}Screen}
+          initialParams={params}
+        />
+      </Stack.Navigator>
+    </NavigationContainer>
   );
 }
 
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: 'rgba(0, 0, 0, 0.5)',
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  content: {
-    backgroundColor: '#fff',
-    borderRadius: 16,
-    padding: 24,
-    width: '80%',
-    maxWidth: 400,
-  },
-  title: {
-    fontSize: 24,
-    fontWeight: 'bold',
-    marginBottom: 24,
-    textAlign: 'center',
-  },
-  closeButton: {
-    backgroundColor: '#007AFF',
-    padding: 12,
-    borderRadius: 8,
-    alignItems: 'center',
-  },
-  closeButtonText: {
-    color: '#fff',
-    fontSize: 16,
-    fontWeight: '600',
-  },
+describe('{ScreenName}Screen', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('Estado de carregamento', () => {
+    it('exibe indicador de carregamento inicialmente', () => {
+      mockService.getById.mockImplementation(() => new Promise(() => {}));
+
+      renderWithNavigation();
+
+      expect(screen.getByLabelText('Carregamento em andamento')).toBeTruthy();
+    });
+  });
+
+  describe('Estado de sucesso', () => {
+    const mockData = {
+      id: '123',
+      title: 'Título de Teste',
+      description: 'Descrição de Teste',
+      createdAt: '2024-01-15T10:00:00Z',
+    };
+
+    beforeEach(() => {
+      mockService.getById.mockResolvedValue(mockData);
+    });
+
+    it('exibe os dados corretamente', async () => {
+      renderWithNavigation();
+
+      await waitFor(() => {
+        expect(screen.getByText('Título de Teste')).toBeTruthy();
+      });
+
+      expect(screen.getByText('Descrição de Teste')).toBeTruthy();
+    });
+
+    it('suporta pull to refresh', async () => {
+      renderWithNavigation();
+
+      await waitFor(() => {
+        expect(screen.getByText('Título de Teste')).toBeTruthy();
+      });
+
+      const scrollView = screen.getByLabelText('Atualizar página');
+      fireEvent(scrollView, 'refresh');
+
+      await waitFor(() => {
+        expect(mockService.getById).toHaveBeenCalledTimes(2);
+      });
+    });
+  });
+
+  describe('Estado de erro', () => {
+    beforeEach(() => {
+      mockService.getById.mockRejectedValue(new Error('Erro de rede'));
+    });
+
+    it('exibe mensagem de erro', async () => {
+      renderWithNavigation();
+
+      await waitFor(() => {
+        expect(screen.getByText('Erro de rede')).toBeTruthy();
+      });
+    });
+
+    it('permite tentar novamente em caso de erro', async () => {
+      renderWithNavigation();
+
+      await waitFor(() => {
+        expect(screen.getByText('Erro de rede')).toBeTruthy();
+      });
+
+      // Agora a nova tentativa será bem-sucedida
+      mockService.getById.mockResolvedValueOnce({
+        id: '123',
+        title: 'Sucesso',
+        description: 'Agora funciona',
+        createdAt: '2024-01-15',
+      });
+
+      fireEvent.press(screen.getByText('Tentar novamente'));
+
+      await waitFor(() => {
+        expect(screen.getByText('Sucesso')).toBeTruthy();
+      });
+    });
+  });
+
+  describe('Acessibilidade', () => {
+    it('possui roles de acessibilidade corretas', async () => {
+      mockService.getById.mockResolvedValue({
+        id: '123',
+        title: 'Teste',
+        description: 'Desc',
+        createdAt: '2024-01-15',
+      });
+
+      renderWithNavigation();
+
+      await waitFor(() => {
+        expect(screen.getByRole('header', { name: 'Teste' })).toBeTruthy();
+      });
+    });
+  });
 });
 ```
 
-### 5. List Screen
+### Etapa 9: Variantes de Tela
 
-**app/users.tsx:**
+#### Tela de Lista
 
-```typescript
-import { View, Text, StyleSheet, FlatList, ActivityIndicator } from 'react-native';
-import { SafeAreaView } from 'react-native-safe-area-context';
-import { useUsers } from '@/features/users/hooks/useUsers';
-import { UserCard } from '@/features/users/components/UserCard';
-import type { User } from '@/features/users/types/User.types';
+```tsx
+// Para uma tela do tipo lista
+import { FlatList } from 'react-native';
 
-export default function UsersScreen() {
-  const { data: users, isLoading, error, refetch } = useUsers();
-
-  if (isLoading) {
-    return (
-      <View style={styles.centerContainer}>
-        <ActivityIndicator size="large" />
-      </View>
-    );
-  }
-
-  if (error) {
-    return (
-      <View style={styles.centerContainer}>
-        <Text style={styles.errorText}>Erro ao carregar usuários</Text>
-      </View>
-    );
-  }
+export function {ScreenName}ListScreen() {
+  const { data, isLoading, refresh, loadMore, hasMore } = use{ScreenName}List();
 
   return (
     <SafeAreaView style={styles.container}>
       <FlatList
-        data={users}
-        keyExtractor={(item: User) => item.id}
-        renderItem={({ item }) => <UserCard user={item} />}
-        contentContainerStyle={styles.listContent}
-        onRefresh={refetch}
-        refreshing={isLoading}
-        ListEmptyComponent={
-          <View style={styles.emptyContainer}>
-            <Text style={styles.emptyText}>Nenhum usuário encontrado</Text>
-          </View>
+        data={data}
+        keyExtractor={(item) => item.id}
+        renderItem={({ item }) => (
+          <{ScreenName}ListItem item={item} onPress={() => navigate(item.id)} />
+        )}
+        refreshControl={
+          <RefreshControl refreshing={isLoading} onRefresh={refresh} />
         }
+        onEndReached={hasMore ? loadMore : undefined}
+        onEndReachedThreshold={0.5}
+        ListEmptyComponent={<EmptyState message="Nenhum item" />}
+        ListFooterComponent={hasMore ? <ActivityIndicator /> : null}
       />
     </SafeAreaView>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: '#fff',
-  },
-  centerContainer: {
-    flex: 1,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  listContent: {
-    padding: 16,
-  },
-  emptyContainer: {
-    padding: 32,
-    alignItems: 'center',
-  },
-  emptyText: {
-    fontSize: 16,
-    color: '#999',
-  },
-  errorText: {
-    fontSize: 16,
-    color: '#f00',
-  },
-});
 ```
 
----
+#### Tela de Formulário
 
-## Arquivo de Teste
+```tsx
+// Para uma tela do tipo formulário
+import { useForm, Controller } from 'react-hook-form';
+import { zodResolver } from '@hookform/resolvers/zod';
 
-**app/user-profile.test.tsx:**
-
-```typescript
-import { render, screen } from '@testing-library/react-native';
-import UserProfileScreen from './user-profile';
-
-describe('UserProfileScreen', () => {
-  it('should render correctly', () => {
-    render(<UserProfileScreen />);
-    expect(screen.getByText('User Profile')).toBeTruthy();
+export function {ScreenName}FormScreen() {
+  const { control, handleSubmit, formState } = useForm({
+    resolver: zodResolver(schema),
+    defaultValues: { name: '', email: '' },
   });
 
-  it('should match snapshot', () => {
-    const tree = render(<UserProfileScreen />).toJSON();
-    expect(tree).toMatchSnapshot();
-  });
-});
+  const onSubmit = async (data) => {
+    // ...
+  };
+
+  return (
+    <KeyboardAvoidingView behavior="padding" style={styles.container}>
+      <ScrollView>
+        <Controller
+          control={control}
+          name="name"
+          render={({ field, fieldState }) => (
+            <TextInput
+              {...field}
+              onChangeText={field.onChange}
+              placeholder="Nome"
+              error={fieldState.error?.message}
+            />
+          )}
+        />
+        {/* outros campos */}
+        <Button
+          title="Salvar"
+          onPress={handleSubmit(onSubmit)}
+          loading={formState.isSubmitting}
+        />
+      </ScrollView>
+    </KeyboardAvoidingView>
+  );
+}
 ```
 
----
+### Resumo
 
-## Melhores Práticas
+```
+══════════════════════════════════════════════════════════════
+✅ TELA GERADA - {ScreenName}
+══════════════════════════════════════════════════════════════
 
-### 1. Naming
-- Arquivos: kebab-case (user-profile.tsx)
-- Componentes: PascalCase (UserProfileScreen)
-- Rotas dinâmicas: [param].tsx
+📁 Arquivos criados:
+- src/screens/{ScreenName}/index.ts
+- src/screens/{ScreenName}/{ScreenName}Screen.tsx
+- src/screens/{ScreenName}/{ScreenName}Screen.types.ts
+- src/screens/{ScreenName}/{ScreenName}Screen.styles.ts
+- src/screens/{ScreenName}/{ScreenName}Screen.test.tsx
+- src/screens/{ScreenName}/hooks/use{ScreenName}.ts
 
-### 2. Estrutura
-- SafeAreaView para gerenciar safe areas
-- ScrollView para conteúdo que pode rolar
-- FlatList para listas longas
-- StatusBar configurada apropriadamente
+📝 Funcionalidades:
+- TypeScript strict
+- Navegação tipada
+- Hook personalizado para lógica
+- Pull-to-refresh
+- Tratamento de estados: carregamento/erro/sucesso
+- Acessibilidade (roles, labels)
+- Testes completos
 
-### 3. Estados
-- Loading state
-- Error state
-- Empty state
-- Success state
-
-### 4. Navegação
-- useLocalSearchParams para parâmetros de rota
-- router.push para navegação
-- router.back para voltar
-
-### 5. Tipagem
-- Todas as props tipadas
-- Parâmetros de rota tipados
-- Data fetching tipado
-
----
-
-## Checklist
-
-- [ ] Screen criada na estrutura de app/
-- [ ] SafeAreaView implementada
-- [ ] Estados de loading/error tratados
-- [ ] Tipagem TypeScript completa
-- [ ] Estilos com StyleSheet.create
-- [ ] Navegação implementada
-- [ ] Teste criado
-- [ ] Documentação adicionada
-
----
-
-**Screens bem estruturadas são a base de uma boa UX. Siga os padrões consistentemente.**
+🔧 Próximos passos:
+1. Adicionar a tela à navegação
+2. Criar serviço de API
+3. Personalizar estilos
+4. Executar testes: npm test {ScreenName}
+```

--- a/Dev/i18n/pt/ReactNative/commands/native-module.md
+++ b/Dev/i18n/pt/ReactNative/commands/native-module.md
@@ -1,143 +1,600 @@
 ---
-description: Comando: Criar Módulo Nativo
+description: Guia de Criação de Módulo Nativo React Native
+argument-hint: [arguments]
 ---
 
-# Comando: Criar Módulo Nativo
+# Guia de Criação de Módulo Nativo React Native
 
-Guia para criar um módulo nativo (bridge) React Native para iOS e Android.
+Você é um desenvolvedor React Native sênior. Você deve orientar a criação de um módulo nativo (bridge) para iOS e Android.
 
----
+## Argumentos
+$ARGUMENTS
 
-## Objetivo
+Argumentos:
+- Nome do módulo (ex.: `DeviceInfo`, `Biometrics`, `FileManager`)
+- (Opcional) Funcionalidades: sync, async, events
 
-Este comando orienta a criação de um módulo nativo para acessar funcionalidades específicas da plataforma não disponíveis via JavaScript.
+Exemplo: `/reactnative:native-module Biometrics async,events`
 
----
+## Modo de Planejamento
 
-## Modo Plano
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+## MISSÃO
 
-## Estrutura do Módulo
+### Etapa 1: Estrutura do Módulo
 
 ```
-src/native/{ModuleName}/
-├── index.ts          # API JavaScript
-├── types.ts          # Tipos TypeScript
-└── NativeModule.ts   # Bridge
+src/
+└── native/
+    └── {ModuleName}/
+        ├── index.ts          # API JavaScript
+        ├── types.ts          # Tipos TypeScript
+        └── NativeModule.ts   # Bridge com TurboModule
 
-android/app/src/main/java/com/{package}/{modulename}/
-├── {ModuleName}Module.kt      # Módulo principal Android
-└── {ModuleName}Package.kt     # Registro do pacote
+android/
+└── app/src/main/java/com/{package}/
+    └── {modulename}/
+        ├── {ModuleName}Module.kt      # Módulo principal
+        └── {ModuleName}Package.kt     # Registro do pacote
 
-ios/{AppName}/
-├── {ModuleName}.swift         # Módulo Swift
-└── {ModuleName}-Bridging-Header.h  # Header Objective-C
+ios/
+└── {AppName}/
+    ├── {ModuleName}.swift             # Módulo Swift
+    └── {ModuleName}-Bridging-Header.h # Header para bridge Obj-C
 ```
 
----
-
-## Implementação TypeScript
+### Etapa 2: API JavaScript/TypeScript
 
 ```typescript
-// types.ts
-export interface ModuleResult {
+// src/native/{ModuleName}/types.ts
+export interface {ModuleName}Result {
   success: boolean;
   data?: unknown;
   error?: string;
 }
 
-// NativeModule.ts
-import { NativeModules } from 'react-native';
+export interface {ModuleName}Options {
+  timeout?: number;
+  // ...outras opções
+}
 
-const { ModuleName } = NativeModules;
+export type {ModuleName}EventType = 'onProgress' | 'onComplete' | 'onError';
 
-export const callNativeMethod = async (): Promise<ModuleResult> => {
-  return await ModuleName.methodName();
-};
+export interface {ModuleName}Event {
+  type: {ModuleName}EventType;
+  payload: unknown;
+}
 ```
 
----
+```typescript
+// src/native/{ModuleName}/NativeModule.ts
+import { NativeModules, NativeEventEmitter, Platform } from 'react-native';
 
-## Implementação Android (Kotlin)
+const LINKING_ERROR =
+  `O pacote '{ModuleName}' não parece estar vinculado. Certifique-se de: \n\n` +
+  Platform.select({ ios: "- Você executou 'pod install'\n", default: '' }) +
+  '- Você reconstruiu o app após instalar o pacote\n' +
+  '- Você não está usando Expo Go\n';
+
+// Tipo do módulo nativo
+interface {ModuleName}NativeModule {
+  // Métodos síncronos
+  getConstant(): string;
+
+  // Métodos assíncronos
+  authenticate(options: {ModuleName}Options): Promise<{ModuleName}Result>;
+  isSupported(): Promise<boolean>;
+
+  // Para eventos
+  addListener(eventType: string): void;
+  removeListeners(count: number): void;
+}
+
+const Native{ModuleName} = NativeModules.{ModuleName}
+  ? (NativeModules.{ModuleName} as {ModuleName}NativeModule)
+  : new Proxy(
+      {} as {ModuleName}NativeModule,
+      {
+        get() {
+          throw new Error(LINKING_ERROR);
+        },
+      }
+    );
+
+export { Native{ModuleName} };
+export const {ModuleName}EventEmitter = new NativeEventEmitter(
+  NativeModules.{ModuleName}
+);
+```
+
+```typescript
+// src/native/{ModuleName}/index.ts
+import { useEffect, useCallback } from 'react';
+import { Native{ModuleName}, {ModuleName}EventEmitter } from './NativeModule';
+import type {
+  {ModuleName}Result,
+  {ModuleName}Options,
+  {ModuleName}Event,
+} from './types';
+
+/**
+ * Verifica se o recurso é suportado no dispositivo.
+ */
+export async function isSupported(): Promise<boolean> {
+  try {
+    return await Native{ModuleName}.isSupported();
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Inicia a autenticação biométrica.
+ */
+export async function authenticate(
+  options: {ModuleName}Options = {}
+): Promise<{ModuleName}Result> {
+  return Native{ModuleName}.authenticate(options);
+}
+
+/**
+ * Hook para escutar eventos do módulo.
+ */
+export function use{ModuleName}Events(
+  onEvent: (event: {ModuleName}Event) => void
+) {
+  useEffect(() => {
+    const subscription = {ModuleName}EventEmitter.addListener(
+      '{moduleName}Event',
+      onEvent
+    );
+
+    return () => {
+      subscription.remove();
+    };
+  }, [onEvent]);
+}
+
+/**
+ * Hook completo para usar o módulo.
+ */
+export function use{ModuleName}() {
+  const [isAvailable, setIsAvailable] = useState<boolean | null>(null);
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    isSupported().then(setIsAvailable);
+  }, []);
+
+  const authenticate = useCallback(async (options?: {ModuleName}Options) => {
+    if (!isAvailable) {
+      setError('{ModuleName} não disponível');
+      return { success: false, error: '{ModuleName} não disponível' };
+    }
+
+    setIsAuthenticating(true);
+    setError(null);
+
+    try {
+      const result = await Native{ModuleName}.authenticate(options || {});
+      return result;
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : 'Erro desconhecido';
+      setError(errorMessage);
+      return { success: false, error: errorMessage };
+    } finally {
+      setIsAuthenticating(false);
+    }
+  }, [isAvailable]);
+
+  return {
+    isAvailable,
+    isAuthenticating,
+    error,
+    authenticate,
+  };
+}
+
+// Exportar tudo
+export * from './types';
+```
+
+### Etapa 3: Módulo Android (Kotlin)
 
 ```kotlin
-package com.yourapp.modulename
+// android/app/src/main/java/com/{package}/{modulename}/{ModuleName}Module.kt
+package com.{package}.{modulename}
 
 import com.facebook.react.bridge.*
+import com.facebook.react.modules.core.DeviceEventManagerModule
+import kotlinx.coroutines.*
 
-class ModuleNameModule(reactContext: ReactApplicationContext) :
-    ReactContextBaseJavaModule(reactContext) {
+class {ModuleName}Module(reactContext: ReactApplicationContext) :
+    ReactContextBaseJavaModule(reactContext),
+    CoroutineScope by MainScope() {
 
-    override fun getName() = "ModuleName"
+    companion object {
+        const val NAME = "{ModuleName}"
+        private const val EVENT_NAME = "{moduleName}Event"
+    }
+
+    override fun getName(): String = NAME
+
+    // Constantes expostas ao JS
+    override fun getConstants(): MutableMap<String, Any> {
+        return hashMapOf(
+            "SUPPORTED" to isBiometricSupported()
+        )
+    }
+
+    // Método síncrono
+    @ReactMethod(isBlockingSynchronousMethod = true)
+    fun getConstant(): String {
+        return "some_value"
+    }
+
+    // Método assíncrono com Promise
+    @ReactMethod
+    fun isSupported(promise: Promise) {
+        launch {
+            try {
+                val supported = isBiometricSupported()
+                promise.resolve(supported)
+            } catch (e: Exception) {
+                promise.reject("ERROR", e.message, e)
+            }
+        }
+    }
 
     @ReactMethod
-    fun methodName(promise: Promise) {
-        try {
-            // Implementação nativa
-            val result = Arguments.createMap()
-            result.putBoolean("success", true)
-            promise.resolve(result)
-        } catch (e: Exception) {
-            promise.reject("ERROR_CODE", e.message, e)
+    fun authenticate(options: ReadableMap, promise: Promise) {
+        val timeout = if (options.hasKey("timeout")) options.getInt("timeout") else 30000
+
+        launch {
+            try {
+                // Implementar lógica nativa aqui
+                val result = performAuthentication(timeout)
+
+                val response = Arguments.createMap().apply {
+                    putBoolean("success", result.success)
+                    result.data?.let { putString("data", it) }
+                    result.error?.let { putString("error", it) }
+                }
+                promise.resolve(response)
+            } catch (e: Exception) {
+                promise.reject("AUTH_ERROR", e.message, e)
+            }
         }
+    }
+
+    // Enviar eventos ao JS
+    private fun sendEvent(eventName: String, params: WritableMap?) {
+        reactApplicationContext
+            .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+            .emit(eventName, params)
+    }
+
+    private fun emitProgress(progress: Int) {
+        val params = Arguments.createMap().apply {
+            putString("type", "onProgress")
+            putInt("progress", progress)
+        }
+        sendEvent(EVENT_NAME, params)
+    }
+
+    // Necessário para eventos
+    @ReactMethod
+    fun addListener(eventName: String) {
+        // Necessário para NativeEventEmitter
+    }
+
+    @ReactMethod
+    fun removeListeners(count: Int) {
+        // Necessário para NativeEventEmitter
+    }
+
+    // Lógica de negócio nativa
+    private suspend fun performAuthentication(timeout: Int): AuthResult {
+        return withContext(Dispatchers.IO) {
+            // Implementar aqui
+            AuthResult(success = true, data = "authenticated")
+        }
+    }
+
+    private fun isBiometricSupported(): Boolean {
+        // Implementar verificação
+        return true
+    }
+
+    override fun onCatalystInstanceDestroy() {
+        super.onCatalystInstanceDestroy()
+        cancel() // Cancelar coroutines
+    }
+}
+
+data class AuthResult(
+    val success: Boolean,
+    val data: String? = null,
+    val error: String? = null
+)
+```
+
+```kotlin
+// android/app/src/main/java/com/{package}/{modulename}/{ModuleName}Package.kt
+package com.{package}.{modulename}
+
+import com.facebook.react.ReactPackage
+import com.facebook.react.bridge.NativeModule
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.uimanager.ViewManager
+
+class {ModuleName}Package : ReactPackage {
+    override fun createNativeModules(
+        reactContext: ReactApplicationContext
+    ): List<NativeModule> {
+        return listOf({ModuleName}Module(reactContext))
+    }
+
+    override fun createViewManagers(
+        reactContext: ReactApplicationContext
+    ): List<ViewManager<*, *>> {
+        return emptyList()
     }
 }
 ```
 
----
+```kotlin
+// Adicionar ao MainApplication.kt
+override fun getPackages(): List<ReactPackage> =
+    PackageList(this).packages.apply {
+        add({ModuleName}Package())
+    }
+```
 
-## Implementação iOS (Swift)
+### Etapa 4: Módulo iOS (Swift)
 
 ```swift
-@objc(ModuleName)
-class ModuleName: NSObject {
+// ios/{AppName}/{ModuleName}.swift
+import Foundation
+import React
+import LocalAuthentication // ou outro framework necessário
+
+@objc({ModuleName})
+class {ModuleName}: RCTEventEmitter {
+
+    private let eventName = "{moduleName}Event"
+
+    // MARK: - Configuração do Módulo
+
+    @objc override static func moduleName() -> String! {
+        return "{ModuleName}"
+    }
+
+    @objc override static func requiresMainQueueSetup() -> Bool {
+        return false
+    }
+
+    // Eventos suportados
+    override func supportedEvents() -> [String]! {
+        return [eventName]
+    }
+
+    // Constantes expostas ao JS
+    @objc override func constantsToExport() -> [AnyHashable : Any]! {
+        return [
+            "SUPPORTED": isBiometricSupported()
+        ]
+    }
+
+    // MARK: - Métodos
 
     @objc
-    func methodName(
-        _ resolve: @escaping RCTPromiseResolveBlock,
+    func getConstant() -> String {
+        return "some_value"
+    }
+
+    @objc(isSupported:rejecter:)
+    func isSupported(
+        resolver resolve: @escaping RCTPromiseResolveBlock,
         rejecter reject: @escaping RCTPromiseRejectBlock
     ) {
-        do {
-            // Implementação nativa
-            let result: [String: Any] = ["success": true]
-            resolve(result)
-        } catch {
-            reject("ERROR_CODE", error.localizedDescription, error)
+        resolve(isBiometricSupported())
+    }
+
+    @objc(authenticate:resolver:rejecter:)
+    func authenticate(
+        options: NSDictionary,
+        resolver resolve: @escaping RCTPromiseResolveBlock,
+        rejecter reject: @escaping RCTPromiseRejectBlock
+    ) {
+        let timeout = options["timeout"] as? Int ?? 30000
+
+        DispatchQueue.global(qos: .userInitiated).async { [weak self] in
+            self?.performAuthentication(timeout: timeout) { result in
+                switch result {
+                case .success(let data):
+                    resolve([
+                        "success": true,
+                        "data": data
+                    ])
+                case .failure(let error):
+                    resolve([
+                        "success": false,
+                        "error": error.localizedDescription
+                    ])
+                }
+            }
         }
     }
 
-    @objc
-    static func requiresMainQueueSetup() -> Bool {
-        return false
+    // MARK: - Métodos Privados
+
+    private func isBiometricSupported() -> Bool {
+        let context = LAContext()
+        var error: NSError?
+        return context.canEvaluatePolicy(
+            .deviceOwnerAuthenticationWithBiometrics,
+            error: &error
+        )
+    }
+
+    private func performAuthentication(
+        timeout: Int,
+        completion: @escaping (Result<String, Error>) -> Void
+    ) {
+        let context = LAContext()
+        context.localizedFallbackTitle = "Usar senha"
+
+        context.evaluatePolicy(
+            .deviceOwnerAuthenticationWithBiometrics,
+            localizedReason: "Autenticação necessária"
+        ) { success, error in
+            if success {
+                completion(.success("authenticated"))
+            } else if let error = error {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    // Emitir evento ao JS
+    private func emitProgress(_ progress: Int) {
+        sendEvent(withName: eventName, body: [
+            "type": "onProgress",
+            "progress": progress
+        ])
     }
 }
 ```
 
----
+```objc
+// ios/{AppName}/{ModuleName}-Bridging-Header.h
+#import <React/RCTBridgeModule.h>
+#import <React/RCTEventEmitter.h>
 
-## Casos de Uso Comuns
+// Expor métodos ao Objective-C
+@interface RCT_EXTERN_MODULE({ModuleName}, RCTEventEmitter)
 
-- Biometria (Face ID, Touch ID, Fingerprint)
-- Gerenciamento de arquivos nativos
-- Acesso a hardware específico
-- Funcionalidades de segurança avançadas
-- Integração com SDKs nativos
-- Otimizações de performance críticas
+RCT_EXTERN_METHOD(isSupported:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
----
+RCT_EXTERN_METHOD(authenticate:(NSDictionary *)options
+                  resolver:(RCTPromiseResolveBlock)resolve
+                  rejecter:(RCTPromiseRejectBlock)reject)
 
-## Checklist
+RCT_EXTERN__BLOCKING_SYNCHRONOUS_METHOD(getConstant)
 
-- [ ] Estrutura de módulo criada
-- [ ] Implementação Android completa
-- [ ] Implementação iOS completa
-- [ ] Tipagem TypeScript definida
-- [ ] Testes unitários criados
-- [ ] Documentação escrita
-- [ ] Tratamento de erros implementado
-- [ ] Testado em ambas plataformas
+@end
+```
 
----
+### Etapa 5: Testes do Módulo
 
-**Módulos nativos são poderosos mas aumentam complexidade. Use apenas quando necessário.**
+```typescript
+// src/native/{ModuleName}/__tests__/{ModuleName}.test.ts
+import { NativeModules } from 'react-native';
+import { authenticate, isSupported } from '../index';
+
+// Mock do módulo nativo
+jest.mock('react-native', () => ({
+  NativeModules: {
+    {ModuleName}: {
+      isSupported: jest.fn(),
+      authenticate: jest.fn(),
+    },
+  },
+  NativeEventEmitter: jest.fn(() => ({
+    addListener: jest.fn(() => ({ remove: jest.fn() })),
+  })),
+  Platform: {
+    OS: 'ios',
+    select: jest.fn((obj) => obj.ios),
+  },
+}));
+
+describe('{ModuleName}', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('isSupported', () => {
+    it('retorna true quando suportado', async () => {
+      (NativeModules.{ModuleName}.isSupported as jest.Mock).mockResolvedValue(true);
+
+      const result = await isSupported();
+
+      expect(result).toBe(true);
+    });
+
+    it('retorna false em caso de erro', async () => {
+      (NativeModules.{ModuleName}.isSupported as jest.Mock).mockRejectedValue(
+        new Error('Não disponível')
+      );
+
+      const result = await isSupported();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('authenticate', () => {
+    it('retorna resultado de sucesso', async () => {
+      const mockResult = { success: true, data: 'authenticated' };
+      (NativeModules.{ModuleName}.authenticate as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await authenticate({ timeout: 5000 });
+
+      expect(result).toEqual(mockResult);
+      expect(NativeModules.{ModuleName}.authenticate).toHaveBeenCalledWith({
+        timeout: 5000,
+      });
+    });
+
+    it('trata falha de autenticação', async () => {
+      const mockResult = { success: false, error: 'Usuário cancelou' };
+      (NativeModules.{ModuleName}.authenticate as jest.Mock).mockResolvedValue(mockResult);
+
+      const result = await authenticate();
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Usuário cancelou');
+    });
+  });
+});
+```
+
+### Resumo
+
+```
+══════════════════════════════════════════════════════════════
+✅ MÓDULO NATIVO - {ModuleName}
+══════════════════════════════════════════════════════════════
+
+📁 Arquivos criados:
+
+JavaScript/TypeScript:
+- src/native/{ModuleName}/index.ts
+- src/native/{ModuleName}/types.ts
+- src/native/{ModuleName}/NativeModule.ts
+
+Android (Kotlin):
+- android/.../{ ModuleName}Module.kt
+- android/.../{ ModuleName}Package.kt
+
+iOS (Swift):
+- ios/{AppName}/{ModuleName}.swift
+- ios/{AppName}/{ModuleName}-Bridging-Header.h
+
+📝 API exposta:
+- isSupported(): Promise<boolean>
+- authenticate(options): Promise<Result>
+- use{ModuleName}(): Hook completo
+- use{ModuleName}Events(): Listener de eventos
+
+🔧 Próximos passos:
+1. Android: Adicionar {ModuleName}Package ao MainApplication.kt
+2. iOS: pod install
+3. Reconstruir ambos os apps
+4. Testar em dispositivo físico
+```

--- a/Dev/i18n/pt/ReactNative/commands/store-prepare.md
+++ b/Dev/i18n/pt/ReactNative/commands/store-prepare.md
@@ -1,243 +1,487 @@
 ---
-description: Comando: Preparar para Publicação
+description: Lista de Verificação para Publicação React Native nas Lojas
+argument-hint: [arguments]
 ---
 
-# Comando: Preparar para Publicação
+# Lista de Verificação para Publicação React Native nas Lojas
 
-Prepare sua aplicação React Native para submissão à App Store (iOS) e Google Play Store (Android).
+Você é um especialista em publicação mobile. Você deve preparar a aplicação para submissão à App Store (iOS) e ao Google Play Store (Android).
 
----
+## Argumentos
+$ARGUMENTS
 
-## Objetivo
+Argumentos:
+- (Opcional) Loja: ios, android, both
+- (Opcional) Tipo: new, update
 
-Este comando guia através do processo completo de preparação para publicação nas lojas de aplicativos.
+Exemplo: `/reactnative:store-prepare both new`
 
----
+## Modo de Planejamento
 
-## Modo Plano
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+## MISSÃO
 
-## Checklist Pré-Submissão
+### Etapa 1: Lista de Verificação Pré-Submissão
 
-### Configuração Técnica
+```
+══════════════════════════════════════════════════════════════
+📱 LISTA DE VERIFICAÇÃO PARA PUBLICAÇÃO NAS LOJAS
+══════════════════════════════════════════════════════════════
 
-- [ ] Versão incrementada (semver)
-- [ ] Build number incrementado
-- [ ] Changelog preparado
-- [ ] Release mode configurado
-- [ ] Hermes habilitado
-- [ ] ProGuard/R8 habilitado (Android)
-- [ ] Secrets em variáveis de ambiente
+──────────────────────────────────────────────────────────────
+🔧 CONFIGURAÇÃO TÉCNICA
+──────────────────────────────────────────────────────────────
 
-### iOS
+### Versão e Build
 
-- [ ] CFBundleShortVersionString atualizado
-- [ ] CFBundleVersion incrementado
-- [ ] Provisioning profile válido
-- [ ] Certificados de distribuição configurados
-- [ ] Info.plist atualizado com descrições de permissões
-- [ ] App icons configurados (todos os tamanhos)
-- [ ] Launch screen configurada
+[ ] Versão incrementada (semver)
+    - iOS: CFBundleShortVersionString
+    - Android: versionName
 
-### Android
+[ ] Número de build incrementado
+    - iOS: CFBundleVersion (inteiro)
+    - Android: versionCode (inteiro)
 
-- [ ] versionName atualizado
-- [ ] versionCode incrementado
-- [ ] Keystore configurado
-- [ ] Assinatura de release configurada
-- [ ] ProGuard rules configuradas
-- [ ] Permissões no AndroidManifest.xml justificadas
-- [ ] App icons configurados (todos os tamanhos)
-- [ ] Splash screen configurada
+[ ] Changelog preparado para esta versão
 
----
+### Build de Release
 
-## Assets Necessários
+[ ] Modo release configurado (sem modo dev)
+[ ] Bundle JS otimizado
+[ ] ProGuard/R8 habilitado (Android)
+[ ] Bitcode desabilitado se necessário (iOS)
+[ ] Hermes habilitado (recomendado)
 
-### Ícones do App
+### Segurança
 
-**iOS:**
-- 1024x1024 (App Store)
-- 180x180 (iPhone @3x)
-- 120x120 (iPhone @2x)
-- 167x167 (iPad Pro @2x)
+[ ] Chaves de API em variáveis de ambiente
+[ ] Nenhum segredo no código
+[ ] Certificate pinning se necessário
+[ ] Keystore assinada corretamente (Android)
+[ ] Perfil de provisioning válido (iOS)
+```
 
-**Android:**
-- 512x512 (Google Play)
-- xxxhdpi: 192x192
-- xxhdpi: 144x144
-- xhdpi: 96x96
-- hdpi: 72x72
-- mdpi: 48x48
+### Etapa 2: Configuração iOS
 
-### Screenshots
+```xml
+<!-- ios/{App}/Info.plist -->
 
-**iOS (por dispositivo):**
-- 6.7": 1290x2796
-- 6.5": 1242x2688
-- 5.5": 1242x2208
+<!-- Versão -->
+<key>CFBundleShortVersionString</key>
+<string>1.2.0</string>
+<key>CFBundleVersion</key>
+<string>45</string>
 
-**Android:**
-- Telefone: 1080x1920
-- Tablet 7": 1920x1200
-- Tablet 10": 2560x1600
+<!-- Permissões (com descrições para o usuário) -->
+<key>NSCameraUsageDescription</key>
+<string>Este app usa a câmera para escanear QR codes.</string>
 
----
+<key>NSPhotoLibraryUsageDescription</key>
+<string>Este app acessa suas fotos para permitir que você envie imagens.</string>
 
-## Build de Release
+<key>NSLocationWhenInUseUsageDescription</key>
+<string>Este app usa sua localização para exibir lojas próximas.</string>
 
-### iOS
+<key>NSFaceIDUsageDescription</key>
+<string>Este app usa o Face ID para proteger o acesso à sua conta.</string>
+
+<key>NSMicrophoneUsageDescription</key>
+<string>Este app usa o microfone para mensagens de voz.</string>
+
+<!-- App Transport Security -->
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSAllowsArbitraryLoads</key>
+    <false/>
+    <!-- Exceções se necessário -->
+</dict>
+
+<!-- Capacidades exigidas -->
+<key>UIRequiredDeviceCapabilities</key>
+<array>
+    <string>armv7</string>
+</array>
+
+<!-- Orientações suportadas -->
+<key>UISupportedInterfaceOrientations</key>
+<array>
+    <string>UIInterfaceOrientationPortrait</string>
+</array>
+<key>UISupportedInterfaceOrientations~ipad</key>
+<array>
+    <string>UIInterfaceOrientationPortrait</string>
+    <string>UIInterfaceOrientationLandscapeLeft</string>
+    <string>UIInterfaceOrientationLandscapeRight</string>
+</array>
+```
+
+```ruby
+# ios/Podfile - Configuração de release
+post_install do |installer|
+  installer.pods_project.targets.each do |target|
+    target.build_configurations.each do |config|
+      # iOS mínimo
+      config.build_settings['IPHONEOS_DEPLOYMENT_TARGET'] = '13.0'
+
+      # Bitcode
+      config.build_settings['ENABLE_BITCODE'] = 'NO'
+
+      # Arquitetura
+      config.build_settings['EXCLUDED_ARCHS[sdk=iphonesimulator*]'] = 'arm64'
+    end
+  end
+end
+```
+
+### Etapa 3: Configuração Android
+
+```groovy
+// android/app/build.gradle
+
+android {
+    compileSdkVersion 34
+    buildToolsVersion "34.0.0"
+
+    defaultConfig {
+        applicationId "com.example.myapp"
+        minSdkVersion 24
+        targetSdkVersion 34
+        versionCode 45
+        versionName "1.2.0"
+    }
+
+    signingConfigs {
+        release {
+            storeFile file(MYAPP_UPLOAD_STORE_FILE)
+            storePassword MYAPP_UPLOAD_STORE_PASSWORD
+            keyAlias MYAPP_UPLOAD_KEY_ALIAS
+            keyPassword MYAPP_UPLOAD_KEY_PASSWORD
+        }
+    }
+
+    buildTypes {
+        release {
+            minifyEnabled true
+            shrinkResources true
+            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.release
+        }
+    }
+
+    // App Bundle (recomendado)
+    bundle {
+        language {
+            enableSplit = false // Manter todos os idiomas
+        }
+        density {
+            enableSplit = true
+        }
+        abi {
+            enableSplit = true
+        }
+    }
+}
+```
+
+```properties
+# android/gradle.properties
+MYAPP_UPLOAD_STORE_FILE=my-upload-key.keystore
+MYAPP_UPLOAD_KEY_ALIAS=my-key-alias
+MYAPP_UPLOAD_STORE_PASSWORD=***
+MYAPP_UPLOAD_KEY_PASSWORD=***
+
+# Otimização de build
+org.gradle.jvmargs=-Xmx4g
+org.gradle.daemon=true
+org.gradle.parallel=true
+```
+
+### Etapa 4: Recursos de Marketing
+
+```
+══════════════════════════════════════════════════════════════
+🎨 RECURSOS NECESSÁRIOS
+══════════════════════════════════════════════════════════════
+
+──────────────────────────────────────────────────────────────
+🍎 APP STORE (iOS)
+──────────────────────────────────────────────────────────────
+
+### Ícone do App
+- 1024x1024 px (PNG, sem transparência, sem cantos arredondados)
+
+### Screenshots do iPhone
+Tamanhos obrigatórios (pelo menos um):
+- iPhone 6.7" (1290 × 2796 px) - iPhone 15 Pro Max
+- iPhone 6.5" (1242 × 2688 px) - iPhone 11 Pro Max
+- iPhone 5.5" (1242 × 2208 px) - iPhone 8 Plus
+
+### Screenshots do iPad
+Tamanhos obrigatórios (se iPad suportado):
+- iPad Pro 12.9" (2048 × 2732 px)
+- iPad Pro 11" (1668 × 2388 px)
+
+### Prévia do App (vídeo opcional)
+- 15-30 segundos
+- Formato .mov ou .mp4
+- Mesmas resoluções que os screenshots
+
+### Textos
+- Nome do app (máximo 30 caracteres)
+- Subtítulo (máximo 30 caracteres)
+- Descrição (máximo 4000 caracteres)
+- Palavras-chave (máximo 100 caracteres, separadas por vírgula)
+- URL de suporte
+- URL de política de privacidade
+- Notas de versão (máximo 4000 caracteres)
+
+──────────────────────────────────────────────────────────────
+🤖 GOOGLE PLAY (Android)
+──────────────────────────────────────────────────────────────
+
+### Ícone do App
+- 512x512 px (PNG 32-bit com alpha)
+
+### Imagem de Destaque (Feature Graphic)
+- 1024x500 px (PNG ou JPG)
+
+### Screenshots do Celular
+- Mínimo 2, máximo 8
+- 16:9 ou 9:16
+- Mínimo 320px, máximo 3840px
+- PNG ou JPG
+
+### Screenshots de Tablet 7"
+- Opcional, mas recomendado
+- Mesmas especificações que celular
+
+### Screenshots de Tablet 10"
+- Opcional, mas recomendado
+
+### Vídeo promocional (opcional)
+- URL do YouTube
+- Não listado ou público
+
+### Textos
+- Título (máximo 50 caracteres)
+- Descrição curta (máximo 80 caracteres)
+- Descrição completa (máximo 4000 caracteres)
+- Notas de versão (máximo 500 caracteres)
+- URL de política de privacidade
+- E-mail do desenvolvedor
+```
+
+### Etapa 5: Build e Assinatura
 
 ```bash
-# Limpar build anterior
-cd ios && rm -rf build && cd ..
+#!/bin/bash
+# scripts/build-release.sh
 
-# Instalar pods
-cd ios && pod install && cd ..
+set -e
 
-# Build do arquivo
+echo "📱 Construindo Release..."
+
+# Variáveis
+VERSION=$(node -p "require('./package.json').version")
+BUILD_NUMBER=$(date +%Y%m%d%H%M)
+
+echo "Versão: $VERSION"
+echo "Build: $BUILD_NUMBER"
+
+# iOS
+echo "🍎 Construindo iOS..."
 cd ios
-xcodebuild -workspace YourApp.xcworkspace \
-  -scheme YourApp \
+
+# Atualizar número de build
+/usr/libexec/PlistBuddy -c "Set :CFBundleVersion $BUILD_NUMBER" {App}/Info.plist
+
+# Arquivar
+xcodebuild -workspace {App}.xcworkspace \
+  -scheme {App} \
   -configuration Release \
-  -archivePath build/YourApp.xcarchive \
+  -archivePath build/{App}.xcarchive \
   archive
 
 # Exportar IPA
 xcodebuild -exportArchive \
-  -archivePath build/YourApp.xcarchive \
-  -exportPath build/Release \
+  -archivePath build/{App}.xcarchive \
+  -exportPath build \
   -exportOptionsPlist ExportOptions.plist
+
+cd ..
+
+# Android
+echo "🤖 Construindo Android..."
+cd android
+
+# Atualizar versionCode no build.gradle ou via variável
+./gradlew bundleRelease
+
+# Opcional: também gerar APK
+./gradlew assembleRelease
+
+cd ..
+
+echo "✅ Build concluído!"
+echo "iOS: ios/build/{App}.ipa"
+echo "Android: android/app/build/outputs/bundle/release/app-release.aab"
 ```
 
-### Android
+```plist
+<!-- ios/ExportOptions.plist -->
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>method</key>
+    <string>app-store</string>
+    <key>teamID</key>
+    <string>XXXXXXXXXX</string>
+    <key>uploadBitcode</key>
+    <false/>
+    <key>uploadSymbols</key>
+    <true/>
+</dict>
+</plist>
+```
+
+### Etapa 6: Submissão
+
+#### iOS - App Store Connect
 
 ```bash
-# Limpar build anterior
-cd android && ./gradlew clean && cd ..
+# Via Xcode
+# Xcode > Product > Archive > Distribute App
 
-# Build AAB (recomendado para Google Play)
-cd android && ./gradlew bundleRelease
+# Via linha de comando (Transporter)
+xcrun altool --upload-app \
+  -f build/{App}.ipa \
+  -t ios \
+  -u "apple-id@example.com" \
+  -p "@keychain:AC_PASSWORD"
 
-# ou Build APK
-cd android && ./gradlew assembleRelease
-
-# Arquivo gerado em:
-# AAB: android/app/build/outputs/bundle/release/app-release.aab
-# APK: android/app/build/outputs/apk/release/app-release.apk
+# Ou via Fastlane
+fastlane ios release
 ```
 
----
+#### Android - Google Play Console
 
-## Metadados da Loja
+```bash
+# Via Play Console web
+# https://play.google.com/console
 
-### Informações Básicas
+# Ou via Fastlane
+fastlane android release
 
-- [ ] Nome do app (curto)
-- [ ] Título (longo, com keywords)
-- [ ] Descrição curta (80-100 caracteres)
-- [ ] Descrição completa
-- [ ] Keywords / Tags
-- [ ] Categoria principal
-- [ ] Classificação etária
-- [ ] Política de privacidade URL
-- [ ] Termos de serviço URL
-- [ ] Website URL
-- [ ] Email de suporte
+# Ou via bundletool
+bundletool build-apks --bundle=app-release.aab --output=app.apks
 
-### Localização
+# Via Google Play Developer API
+# (requer conta de serviço)
+```
 
-- [ ] Traduções para idiomas suportados
-- [ ] Screenshots localizados
-- [ ] Descrições localizadas
+### Etapa 7: Lista de Verificação Final
 
----
+```
+══════════════════════════════════════════════════════════════
+✅ LISTA DE VERIFICAÇÃO FINAL PRÉ-SUBMISSÃO
+══════════════════════════════════════════════════════════════
 
-## Testes Finais
+──────────────────────────────────────────────────────────────
+📱 TESTES
+──────────────────────────────────────────────────────────────
 
-### Funcionalidade
+[ ] App testado em dispositivo físico iOS
+[ ] App testado em dispositivo físico Android
+[ ] Testes em versões mais antigas do SO (iOS 13, Android 7)
+[ ] Testes em diferentes tamanhos de tela
+[ ] Testes no modo escuro
+[ ] Testes offline
+[ ] Testes com dados reais
+[ ] Testes de performance
+[ ] Testes de Crash/ANR
+[ ] Testes de acessibilidade (VoiceOver, TalkBack)
 
-- [ ] Fluxos principais testados
-- [ ] Pagamentos testados (se aplicável)
-- [ ] Notificações push testadas
-- [ ] Deep links testados
-- [ ] Compartilhamento testado
-- [ ] Permissões testadas
+──────────────────────────────────────────────────────────────
+🔒 CONFORMIDADE
+──────────────────────────────────────────────────────────────
 
-### Performance
+[ ] Política de privacidade acessível
+[ ] Termos de serviço
+[ ] Conformidade com LGPD/GDPR (se aplicável)
+    - Consentimento de cookies
+    - Direito à exclusão
+    - Exportação de dados
+[ ] Conformidade com COPPA (se destinado a crianças)
+[ ] Declarações de permissões
+[ ] Nenhum conteúdo proibido
 
-- [ ] Tempo de inicialização < 3s
-- [ ] Sem crashes
-- [ ] Sem memory leaks
-- [ ] Performance em dispositivos antigos
-- [ ] Bateria não drena excessivamente
+──────────────────────────────────────────────────────────────
+🍎 ESPECÍFICO iOS
+──────────────────────────────────────────────────────────────
 
-### Compliance
+[ ] Diretrizes de revisão do App cumpridas
+[ ] Sem links para lojas externas
+[ ] In-App Purchase se conteúdo digital
+[ ] Sign in with Apple se outras autenticações sociais
+[ ] App Tracking Transparency se rastreamento
+[ ] Perfil de provisioning válido
+[ ] Notificações push configuradas (se aplicável)
+[ ] Testado no TestFlight
 
-- [ ] GDPR compliant (se aplicável)
-- [ ] COPPA compliant (se app para crianças)
-- [ ] Acessibilidade implementada
-- [ ] Guidelines da loja seguidas
+──────────────────────────────────────────────────────────────
+🤖 ESPECÍFICO ANDROID
+──────────────────────────────────────────────────────────────
 
----
+[ ] Nível de API alvo recente (34+)
+[ ] Políticas do Play Store cumpridas
+[ ] Formulário de segurança de dados preenchido
+[ ] Questionário de classificação de conteúdo
+[ ] Assinatura do app pelo Google Play
+[ ] Testes interno/fechado realizados
+[ ] Lançamento gradual planejado
 
-## Submissão
+──────────────────────────────────────────────────────────────
+📄 DOCUMENTOS PRONTOS
+──────────────────────────────────────────────────────────────
 
-### iOS (App Store Connect)
+[ ] Screenshots em todos os idiomas suportados
+[ ] Imagem de destaque (Android)
+[ ] Ícone do app em alta resolução
+[ ] Descrições em todos os idiomas
+[ ] Notas de versão
+[ ] Vídeo promocional (opcional)
 
-1. Criar app no App Store Connect
-2. Preencher metadados
-3. Upload de screenshots
-4. Upload do build (via Xcode ou Transporter)
-5. Selecionar build para revisão
-6. Responder questões de compliance
-7. Submeter para revisão
+──────────────────────────────────────────────────────────────
+🚀 SUBMISSÃO
+──────────────────────────────────────────────────────────────
 
-### Android (Google Play Console)
+[ ] Build enviado ao App Store Connect
+[ ] Build enviado ao Play Console
+[ ] Metadados completos
+[ ] Preço e disponibilidade configurados
+[ ] Data de lançamento escolhida (imediata ou agendada)
+[ ] Perguntas de revisão preparadas
+```
 
-1. Criar app no Google Play Console
-2. Preencher metadados
-3. Upload de screenshots
-4. Upload do AAB/APK
-5. Configurar países e preço
-6. Responder questões de compliance
-7. Submeter para revisão
+### Etapa 8: Pós-Publicação
 
----
+```
+══════════════════════════════════════════════════════════════
+📊 APÓS A PUBLICAÇÃO
+══════════════════════════════════════════════════════════════
 
-## Pós-Submissão
-
-- [ ] Monitorar status da revisão
-- [ ] Responder a solicitações do review team
-- [ ] Preparar release notes
-- [ ] Configurar staged rollout (Google Play)
-- [ ] Monitorar crashes pós-lançamento
-- [ ] Monitorar reviews e feedback
-- [ ] Preparar hotfix se necessário
-
----
-
-## Ferramentas Úteis
-
-- **Fastlane**: Automação de build e deploy
-- **EAS Build**: Build na nuvem (Expo)
-- **TestFlight**: Beta testing (iOS)
-- **Google Play Beta**: Beta testing (Android)
-
----
-
-## Checklist Final
-
-- [ ] Todos os builds testados
-- [ ] Metadados completos
-- [ ] Screenshots prontos
-- [ ] Políticas de privacidade e termos prontos
-- [ ] Compliance verificado
-- [ ] Equipe de suporte preparada
-- [ ] Monitoramento configurado
-- [ ] Plano de marketing pronto
-
----
-
-**Primeira impressão importa. Invista tempo em metadados e screenshots de qualidade.**
+[ ] Monitoramento de crashes (Sentry, Crashlytics)
+[ ] Analytics configurado
+[ ] Alertas para avaliações negativas
+[ ] Plano de resposta a avaliações
+[ ] Acompanhar KPIs:
+    - Downloads
+    - Retenção D1, D7, D30
+    - Taxa livre de crashes (> 99%)
+    - Taxa de ANR (< 0,47%)
+    - Avaliação média
+[ ] Preparação de hotfix se necessário
+[ ] Comunicação com usuários (in-app, e-mail)
+```

--- a/Dev/i18n/pt/ReactNative/rules/02-architecture.md
+++ b/Dev/i18n/pt/ReactNative/rules/02-architecture.md
@@ -2,7 +2,7 @@
 
 ## Introdução
 
-Este documento define a arquitetura recomendada para aplicações React Native com TypeScript e Expo, baseada nas melhores práticas da indústria.
+Este documento define a arquitetura recomendada para aplicações React Native com TypeScript e Expo, baseada nas melhores práticas do setor.
 
 ---
 
@@ -10,7 +10,7 @@ Este documento define a arquitetura recomendada para aplicações React Native c
 
 ### 1. Clean Architecture
 
-A aplicação é organizada em **camadas** com responsabilidades claras:
+A aplicação é organizada em **camadas** com responsabilidades bem definidas:
 
 ```
 ┌─────────────────────────────────────┐
@@ -20,21 +20,21 @@ A aplicação é organizada em **camadas** com responsabilidades claras:
 ├─────────────────────────────────────┤
 │      CAMADA DE DOMÍNIO              │  <- Lógica de Negócio, Tipos
 ├─────────────────────────────────────┤
-│      CAMADA DE DADOS                │  <- API, Storage, Serviços
+│      CAMADA DE DADOS                │  <- API, Armazenamento, Serviços
 └─────────────────────────────────────┘
 ```
 
 **Regras de dependência**:
 - Camadas superiores podem depender de camadas inferiores
 - Camadas inferiores NÃO DEVEM depender de camadas superiores
-- Cada camada tem uma responsabilidade única e bem definida
+- Cada camada tem uma única responsabilidade bem definida
 
-### 2. Organização Baseada em Features
+### 2. Organização Baseada em Funcionalidades
 
-Organização por **feature de negócio** ao invés de tipo técnico:
+Organização por **funcionalidade de negócio** em vez de tipo técnico:
 
 ```typescript
-// ✅ BOM: Baseado em features
+// ✅ BOM: Baseado em funcionalidade
 features/
 ├── auth/
 │   ├── screens/
@@ -56,7 +56,7 @@ types/
 
 ### 3. Separação de Responsabilidades
 
-Cada arquivo, função, componente tem **UMA responsabilidade**:
+Cada arquivo, função e componente tem **UMA responsabilidade**:
 
 ```typescript
 // ✅ BOM: Separação clara
@@ -77,7 +77,7 @@ export const LoginButton = () => {
   const handleLogin = async () => {
     setLoading(true);
     const response = await fetch('/api/login');
-    // Lógica + UI misturados
+    // Lógica + UI misturadas
   };
   return <Pressable onPress={handleLogin}>Login</Pressable>;
 };
@@ -87,21 +87,21 @@ export const LoginButton = () => {
 
 ## Estrutura de Pastas
 
-### Visão Completa
+### Visão Geral Completa
 
 ```
 my-app/
 ├── src/
 │   ├── app/                         # Expo Router (App Router)
-│   │   ├── (auth)/                  # Grupo Auth (layout compartilhado)
+│   │   ├── (auth)/                  # Grupo auth (layout compartilhado)
 │   │   │   ├── login.tsx
 │   │   │   ├── register.tsx
 │   │   │   └── _layout.tsx
-│   │   ├── (tabs)/                  # Grupo Tabs (navegação em tabs)
-│   │   │   ├── index.tsx            # Tab Home
-│   │   │   ├── profile.tsx          # Tab Profile
-│   │   │   ├── settings.tsx         # Tab Settings
-│   │   │   └── _layout.tsx          # Layout de Tabs
+│   │   ├── (tabs)/                  # Grupo tabs (abas de navegação)
+│   │   │   ├── index.tsx            # Aba inicial
+│   │   │   ├── profile.tsx          # Aba de perfil
+│   │   │   ├── settings.tsx         # Aba de configurações
+│   │   │   └── _layout.tsx          # Layout das abas
 │   │   ├── article/
 │   │   │   └── [id].tsx             # Rota dinâmica
 │   │   ├── modal.tsx                # Tela modal
@@ -110,35 +110,145 @@ my-app/
 │   │
 │   ├── components/                  # Componentes reutilizáveis
 │   │   ├── ui/                      # Componentes UI base
+│   │   │   ├── Button/
+│   │   │   │   ├── Button.tsx
+│   │   │   │   ├── Button.styles.ts
+│   │   │   │   ├── Button.test.tsx
+│   │   │   │   └── index.ts
+│   │   │   ├── Input/
+│   │   │   ├── Card/
+│   │   │   └── index.ts
 │   │   ├── forms/                   # Componentes de formulário
+│   │   │   ├── LoginForm/
+│   │   │   ├── ProfileForm/
+│   │   │   └── index.ts
 │   │   ├── layout/                  # Componentes de layout
+│   │   │   ├── Container/
+│   │   │   ├── SafeArea/
+│   │   │   └── index.ts
 │   │   └── shared/                  # Componentes compartilhados
+│   │       ├── Header/
+│   │       ├── Footer/
+│   │       └── index.ts
 │   │
-│   ├── features/                    # Features por domínio de negócio
+│   ├── features/                    # Funcionalidades por domínio de negócio
 │   │   ├── auth/
 │   │   │   ├── components/          # Componentes específicos de auth
+│   │   │   │   ├── SocialLoginButtons/
+│   │   │   │   └── PasswordStrength/
 │   │   │   ├── hooks/               # Hooks de auth
+│   │   │   │   ├── useAuth.ts
+│   │   │   │   ├── useLogin.ts
+│   │   │   │   └── useRegister.ts
 │   │   │   ├── services/            # Serviços de auth
-│   │   │   ├── stores/              # Gerenciamento de estado auth
-│   │   │   ├── types/               # Tipos auth
-│   │   │   └── utils/               # Utils auth
+│   │   │   │   ├── auth.service.ts
+│   │   │   │   └── token.service.ts
+│   │   │   ├── stores/              # Gerenciamento de estado de auth
+│   │   │   │   └── auth.store.ts
+│   │   │   ├── types/               # Tipos de auth
+│   │   │   │   └── Auth.types.ts
+│   │   │   └── utils/               # Utilitários de auth
+│   │   │       └── validation.ts
 │   │   ├── profile/
+│   │   │   ├── components/
+│   │   │   ├── hooks/
+│   │   │   ├── services/
+│   │   │   └── types/
 │   │   └── articles/
+│   │       ├── components/
+│   │       ├── hooks/
+│   │       ├── services/
+│   │       └── types/
 │   │
 │   ├── hooks/                       # Hooks globais/compartilhados
+│   │   ├── useAppState.ts           # Estado do app (foreground/background)
+│   │   ├── useKeyboard.ts           # Estado do teclado
+│   │   ├── useOrientation.ts        # Orientação do dispositivo
+│   │   ├── useNetworkStatus.ts      # Conectividade de rede
+│   │   └── index.ts
+│   │
 │   ├── services/                    # Serviços globais
+│   │   ├── api/                     # Serviços de API
+│   │   │   ├── client.ts            # Cliente da API (Axios)
+│   │   │   ├── interceptors.ts      # Interceptadores de requisição/resposta
+│   │   │   ├── endpoints.ts         # Constantes de endpoints da API
+│   │   │   └── index.ts
+│   │   ├── storage/                 # Serviços de armazenamento
+│   │   │   ├── mmkv.storage.ts      # Armazenamento MMKV
+│   │   │   ├── secure.storage.ts    # Armazenamento seguro
+│   │   │   └── index.ts
+│   │   ├── analytics/               # Serviço de analytics
+│   │   │   ├── analytics.service.ts
+│   │   │   └── events.ts
+│   │   ├── notifications/           # Serviço de notificações
+│   │   │   └── push.service.ts
+│   │   └── location/                # Serviço de localização
+│   │       └── location.service.ts
+│   │
 │   ├── stores/                      # Gerenciamento de estado global
+│   │   ├── app.store.ts             # Estado global do app
+│   │   ├── theme.store.ts           # Estado do tema
+│   │   └── index.ts
+│   │
+│   ├── navigation/                  # Configuração de navegação
+│   │   ├── types.ts                 # Tipos de navegação
+│   │   ├── linking.ts               # Configuração de deep linking
+│   │   └── index.ts
+│   │
 │   ├── utils/                       # Utilitários
+│   │   ├── date.utils.ts
+│   │   ├── string.utils.ts
+│   │   ├── number.utils.ts
+│   │   ├── validation.utils.ts
+│   │   └── index.ts
+│   │
 │   ├── constants/                   # Constantes
+│   │   ├── app.constants.ts
+│   │   ├── api.constants.ts
+│   │   ├── storage.constants.ts
+│   │   └── index.ts
+│   │
 │   ├── types/                       # Tipos globais
+│   │   ├── global.types.ts
+│   │   ├── api.types.ts
+│   │   ├── navigation.types.ts
+│   │   └── index.ts
+│   │
 │   ├── config/                      # Configuração
+│   │   ├── env.ts                   # Variáveis de ambiente
+│   │   ├── app.config.ts            # Configuração do app
+│   │   └── index.ts
+│   │
 │   ├── theme/                       # Tema
+│   │   ├── colors.ts
+│   │   ├── spacing.ts
+│   │   ├── typography.ts
+│   │   ├── shadows.ts
+│   │   └── index.ts
+│   │
 │   └── assets/                      # Assets
+│       ├── images/
+│       ├── fonts/
+│       ├── icons/
+│       └── animations/
 │
 ├── __tests__/                       # Testes
 │   ├── unit/
 │   ├── integration/
 │   └── e2e/
+│
+├── .expo/                           # Gerado pelo Expo
+├── .husky/                          # Git hooks
+├── node_modules/
+├── app.json                         # Configuração do app Expo
+├── babel.config.js
+├── tsconfig.json
+├── package.json
+├── .eslintrc.js
+├── .prettierrc.js
+├── .env.development
+├── .env.production
+└── README.md
 ```
 
 ---
@@ -149,7 +259,7 @@ my-app/
 
 #### A. App Router (Expo Router)
 
-**Nova arquitetura de roteamento baseada em arquivos**:
+**Nova arquitetura de roteamento baseado em arquivos**:
 
 ```typescript
 // src/app/_layout.tsx - Layout raiz
@@ -167,34 +277,977 @@ export default function RootLayout() {
     </QueryClientProvider>
   );
 }
+
+// src/app/(tabs)/_layout.tsx - Layout das abas
+import { Tabs } from 'expo-router';
+
+export default function TabsLayout() {
+  return (
+    <Tabs>
+      <Tabs.Screen
+        name="index"
+        options={{
+          title: 'Home',
+          tabBarIcon: ({ color }) => <HomeIcon color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="profile"
+        options={{
+          title: 'Profile',
+          tabBarIcon: ({ color }) => <ProfileIcon color={color} />,
+        }}
+      />
+    </Tabs>
+  );
+}
+
+// src/app/(tabs)/index.tsx - Tela inicial
+export default function HomeScreen() {
+  return <HomeView />;
+}
+
+// src/app/article/[id].tsx - Rota dinâmica
+import { useLocalSearchParams } from 'expo-router';
+
+export default function ArticleScreen() {
+  const { id } = useLocalSearchParams();
+  return <ArticleDetail id={id} />;
+}
 ```
 
 **Vantagens do Expo Router**:
 - Roteamento baseado em arquivos (como Next.js)
-- Navegação type-safe
+- Navegação com tipagem segura
 - Deep linking automático
-- SEO-friendly (Expo Web)
+- Amigável para SEO (Expo Web)
 - Layouts compartilhados
 - Navegação aninhada simplificada
+
+#### B. Componentes
+
+**Organização hierárquica**:
+
+```typescript
+// components/ui/Button/Button.tsx
+import { Pressable, Text } from 'react-native';
+import { styles } from './Button.styles';
+import type { ButtonProps } from './Button.types';
+
+export const Button = ({
+  children,
+  variant = 'primary',
+  onPress,
+  disabled,
+}: ButtonProps) => {
+  return (
+    <Pressable
+      style={[styles.button, styles[variant], disabled && styles.disabled]}
+      onPress={onPress}
+      disabled={disabled}
+    >
+      <Text style={styles.text}>{children}</Text>
+    </Pressable>
+  );
+};
+
+// components/ui/Button/Button.styles.ts
+import { StyleSheet } from 'react-native';
+import { theme } from '@/theme';
+
+export const styles = StyleSheet.create({
+  button: {
+    paddingHorizontal: theme.spacing.md,
+    paddingVertical: theme.spacing.sm,
+    borderRadius: theme.borderRadius.md,
+    alignItems: 'center',
+  },
+  primary: {
+    backgroundColor: theme.colors.primary,
+  },
+  secondary: {
+    backgroundColor: theme.colors.secondary,
+  },
+  disabled: {
+    opacity: 0.5,
+  },
+  text: {
+    color: theme.colors.white,
+    fontSize: theme.typography.fontSize.md,
+    fontWeight: '600',
+  },
+});
+
+// components/ui/Button/Button.types.ts
+import type { PressableProps } from 'react-native';
+
+export interface ButtonProps extends Omit<PressableProps, 'style'> {
+  children: React.ReactNode;
+  variant?: 'primary' | 'secondary' | 'outline';
+  disabled?: boolean;
+}
+
+// components/ui/Button/index.ts
+export { Button } from './Button';
+export type { ButtonProps } from './Button.types';
+```
+
+**Tipos de componentes**:
+
+1. **Componentes UI** (burros/apresentacionais):
+   - Sem lógica de negócio
+   - Orientados por props
+   - Altamente reutilizáveis
+   - Facilmente testáveis
+
+```typescript
+// components/ui/Card/Card.tsx
+interface CardProps {
+  children: React.ReactNode;
+  onPress?: () => void;
+}
+
+export const Card = ({ children, onPress }: CardProps) => (
+  <Pressable onPress={onPress} style={styles.card}>
+    {children}
+  </Pressable>
+);
+```
+
+2. **Componentes Inteligentes** (containers):
+   - Conectados ao estado
+   - Lidam com lógica de negócio
+   - Utilizam hooks
+
+```typescript
+// features/articles/components/ArticleList/ArticleList.tsx
+export const ArticleList = () => {
+  const { data: articles, isLoading } = useArticles();
+
+  if (isLoading) return <LoadingSpinner />;
+
+  return (
+    <FlatList
+      data={articles}
+      renderItem={({ item }) => <ArticleCard article={item} />}
+      keyExtractor={(item) => item.id}
+    />
+  );
+};
+```
+
+3. **Componentes Compostos**:
+   - Componentes composicionais
+   - API intuitiva
+
+```typescript
+// components/ui/Form/Form.tsx
+export const Form = ({ children, onSubmit }: FormProps) => (
+  <View style={styles.form}>{children}</View>
+);
+
+Form.Field = ({ label, children }: FieldProps) => (
+  <View style={styles.field}>
+    <Text style={styles.label}>{label}</Text>
+    {children}
+  </View>
+);
+
+Form.Submit = ({ children, ...props }: SubmitProps) => (
+  <Button {...props}>{children}</Button>
+);
+
+// Uso:
+<Form onSubmit={handleSubmit}>
+  <Form.Field label="Email">
+    <Input name="email" />
+  </Form.Field>
+  <Form.Submit>Enviar</Form.Submit>
+</Form>
+```
+
+---
+
+### 2. Camada de Aplicação (Lógica)
+
+#### A. Custom Hooks
+
+**Encapsulam lógica reutilizável**:
+
+```typescript
+// hooks/useAuth.ts
+import { useAuthStore } from '@/features/auth/stores/auth.store';
+import { authService } from '@/features/auth/services/auth.service';
+
+export const useAuth = () => {
+  const { user, setUser, clearUser } = useAuthStore();
+
+  const login = async (credentials: Credentials) => {
+    const response = await authService.login(credentials);
+    setUser(response.user);
+    return response;
+  };
+
+  const logout = async () => {
+    await authService.logout();
+    clearUser();
+  };
+
+  const isAuthenticated = !!user;
+
+  return {
+    user,
+    login,
+    logout,
+    isAuthenticated,
+  };
+};
+
+// Uso no componente:
+const LoginScreen = () => {
+  const { login, isAuthenticated } = useAuth();
+  const { mutate, isLoading } = useMutation({
+    mutationFn: login,
+  });
+
+  if (isAuthenticated) {
+    return <Redirect href="/(tabs)" />;
+  }
+
+  return <LoginForm onSubmit={mutate} isLoading={isLoading} />;
+};
+```
+
+**Padrões comuns de hooks**:
+
+```typescript
+// 1. Hook de busca de dados
+export const useArticles = (filters?: ArticleFilters) => {
+  return useQuery({
+    queryKey: ['articles', filters],
+    queryFn: () => articlesService.getAll(filters),
+  });
+};
+
+// 2. Hook de mutação
+export const useCreateArticle = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: articlesService.create,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['articles'] });
+    },
+  });
+};
+
+// 3. Hook específico de plataforma
+export const usePlatform = () => {
+  const isIOS = Platform.OS === 'ios';
+  const isAndroid = Platform.OS === 'android';
+  const isWeb = Platform.OS === 'web';
+
+  return { isIOS, isAndroid, isWeb };
+};
+
+// 4. Hook de informações do dispositivo
+export const useDeviceInfo = () => {
+  const { width, height } = useWindowDimensions();
+  const isTablet = width > 768;
+  const isLandscape = width > height;
+
+  return { width, height, isTablet, isLandscape };
+};
+
+// 5. Hook de teclado
+export const useKeyboard = () => {
+  const [isVisible, setIsVisible] = useState(false);
+  const [keyboardHeight, setKeyboardHeight] = useState(0);
+
+  useEffect(() => {
+    const showListener = Keyboard.addListener('keyboardDidShow', (e) => {
+      setIsVisible(true);
+      setKeyboardHeight(e.endCoordinates.height);
+    });
+
+    const hideListener = Keyboard.addListener('keyboardDidHide', () => {
+      setIsVisible(false);
+      setKeyboardHeight(0);
+    });
+
+    return () => {
+      showListener.remove();
+      hideListener.remove();
+    };
+  }, []);
+
+  return { isVisible, keyboardHeight };
+};
+```
+
+#### B. Gerenciamento de Estado
+
+**Arquitetura em múltiplos níveis**:
+
+```typescript
+// 1. Estado Local (useState, useReducer)
+// Para estado isolado em um componente
+const [count, setCount] = useState(0);
+
+// 2. Estado de URL (Expo Router)
+// Para estado sincronizado com a URL
+const { id, filter } = useLocalSearchParams<{ id: string; filter: string }>();
+
+// 3. Estado do Servidor (React Query)
+// Para dados do servidor com cache
+const { data } = useQuery({
+  queryKey: ['user', userId],
+  queryFn: () => fetchUser(userId),
+});
+
+// 4. Estado Global (Zustand)
+// Para estado global do lado do cliente
+// stores/theme.store.ts
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+import { createMMKVStorage } from '@/services/storage/mmkv.storage';
+
+interface ThemeState {
+  isDark: boolean;
+  toggleTheme: () => void;
+}
+
+export const useThemeStore = create<ThemeState>()(
+  persist(
+    (set) => ({
+      isDark: false,
+      toggleTheme: () => set((state) => ({ isDark: !state.isDark })),
+    }),
+    {
+      name: 'theme',
+      storage: createMMKVStorage(),
+    }
+  )
+);
+
+// 5. Estado Persistido (MMKV)
+// Para armazenamento de alto desempenho
+// services/storage/mmkv.storage.ts
+import { MMKV } from 'react-native-mmkv';
+
+const storage = new MMKV();
+
+export const mmkvStorage = {
+  setItem: (key: string, value: string) => {
+    storage.set(key, value);
+  },
+  getItem: (key: string) => {
+    return storage.getString(key) ?? null;
+  },
+  removeItem: (key: string) => {
+    storage.delete(key);
+  },
+};
+
+export const createMMKVStorage = () => ({
+  getItem: (name: string) => {
+    const value = storage.getString(name);
+    return value ?? null;
+  },
+  setItem: (name: string, value: string) => {
+    storage.set(name, value);
+  },
+  removeItem: (name: string) => {
+    storage.delete(name);
+  },
+});
+```
+
+---
+
+### 3. Camada de Domínio (Lógica de Negócio)
+
+#### Tipos e Interfaces
+
+**Organização de tipos**:
+
+```typescript
+// types/User.types.ts
+export interface User {
+  id: string;
+  email: string;
+  firstName: string;
+  lastName: string;
+  avatar?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateUserDTO {
+  email: string;
+  password: string;
+  firstName: string;
+  lastName: string;
+}
+
+export interface UpdateUserDTO extends Partial<CreateUserDTO> {
+  avatar?: string;
+}
+
+// types/Article.types.ts
+export interface Article {
+  id: string;
+  title: string;
+  content: string;
+  author: User;
+  tags: string[];
+  publishedAt: Date;
+  updatedAt: Date;
+}
+
+export interface ArticleFilters {
+  tag?: string;
+  authorId?: string;
+  search?: string;
+  page?: number;
+  limit?: number;
+}
+
+// types/api.types.ts
+export interface ApiResponse<T> {
+  data: T;
+  message?: string;
+  status: number;
+}
+
+export interface PaginatedResponse<T> {
+  data: T[];
+  total: number;
+  page: number;
+  limit: number;
+  hasMore: boolean;
+}
+
+export interface ApiError {
+  message: string;
+  code: string;
+  status: number;
+  errors?: Record<string, string[]>;
+}
+```
+
+---
+
+### 4. Camada de Dados
+
+#### A. Serviços de API
+
+**Organização do serviço de API**:
+
+```typescript
+// services/api/client.ts
+import axios from 'axios';
+import { setupInterceptors } from './interceptors';
+import { ENV } from '@/config/env';
+
+export const apiClient = axios.create({
+  baseURL: ENV.API_URL,
+  timeout: 10000,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+setupInterceptors(apiClient);
+
+export default apiClient;
+
+// services/api/interceptors.ts
+import type { AxiosInstance } from 'axios';
+import { router } from 'expo-router';
+import { tokenService } from '@/features/auth/services/token.service';
+
+export const setupInterceptors = (instance: AxiosInstance) => {
+  // Interceptador de requisição
+  instance.interceptors.request.use(
+    async (config) => {
+      const token = await tokenService.getAccessToken();
+      if (token) {
+        config.headers.Authorization = `Bearer ${token}`;
+      }
+      return config;
+    },
+    (error) => Promise.reject(error)
+  );
+
+  // Interceptador de resposta
+  instance.interceptors.response.use(
+    (response) => response,
+    async (error) => {
+      const originalRequest = error.config;
+
+      // Lógica de renovação de token
+      if (error.response?.status === 401 && !originalRequest._retry) {
+        originalRequest._retry = true;
+
+        try {
+          const newToken = await tokenService.refreshToken();
+          originalRequest.headers.Authorization = `Bearer ${newToken}`;
+          return instance(originalRequest);
+        } catch (refreshError) {
+          // Redirecionar para login
+          router.replace('/(auth)/login');
+          return Promise.reject(refreshError);
+        }
+      }
+
+      return Promise.reject(error);
+    }
+  );
+};
+
+// features/articles/services/articles.service.ts
+import { apiClient } from '@/services/api/client';
+import type { Article, ArticleFilters, CreateArticleDTO } from '../types/Article.types';
+import type { PaginatedResponse } from '@/types/api.types';
+
+class ArticlesService {
+  private readonly endpoint = '/articles';
+
+  async getAll(filters?: ArticleFilters): Promise<PaginatedResponse<Article>> {
+    const { data } = await apiClient.get(this.endpoint, { params: filters });
+    return data;
+  }
+
+  async getById(id: string): Promise<Article> {
+    const { data } = await apiClient.get(`${this.endpoint}/${id}`);
+    return data;
+  }
+
+  async create(dto: CreateArticleDTO): Promise<Article> {
+    const { data } = await apiClient.post(this.endpoint, dto);
+    return data;
+  }
+
+  async update(id: string, dto: Partial<CreateArticleDTO>): Promise<Article> {
+    const { data } = await apiClient.patch(`${this.endpoint}/${id}`, dto);
+    return data;
+  }
+
+  async delete(id: string): Promise<void> {
+    await apiClient.delete(`${this.endpoint}/${id}`);
+  }
+}
+
+export const articlesService = new ArticlesService();
+```
+
+#### B. Serviços de Armazenamento
+
+```typescript
+// services/storage/secure.storage.ts
+import * as SecureStore from 'expo-secure-store';
+import { Platform } from 'react-native';
+
+class SecureStorage {
+  async setItem(key: string, value: string): Promise<void> {
+    if (Platform.OS === 'web') {
+      // Fallback para web
+      localStorage.setItem(key, value);
+      return;
+    }
+    await SecureStore.setItemAsync(key, value);
+  }
+
+  async getItem(key: string): Promise<string | null> {
+    if (Platform.OS === 'web') {
+      return localStorage.getItem(key);
+    }
+    return await SecureStore.getItemAsync(key);
+  }
+
+  async removeItem(key: string): Promise<void> {
+    if (Platform.OS === 'web') {
+      localStorage.removeItem(key);
+      return;
+    }
+    await SecureStore.deleteItemAsync(key);
+  }
+}
+
+export const secureStorage = new SecureStorage();
+```
+
+---
+
+## Arquitetura de Navegação
+
+### Padrões do Expo Router
+
+```typescript
+// 1. Rotas de Grupo (Layouts Compartilhados)
+app/
+├── (auth)/
+│   ├── _layout.tsx          # Layout de auth
+│   ├── login.tsx
+│   └── register.tsx
+└── (tabs)/
+    ├── _layout.tsx          # Layout de abas
+    ├── index.tsx
+    └── profile.tsx
+
+// 2. Rotas Dinâmicas
+app/
+└── article/
+    └── [id].tsx             # /article/123
+
+// 3. Rotas Catch-all
+app/
+└── blog/
+    └── [...slug].tsx        # /blog/2024/01/article
+
+// 4. Rotas de Modal
+app/
+├── _layout.tsx
+└── modal.tsx                # Apresentado como modal
+
+// Tipos de navegação
+import type { NativeStackScreenProps } from '@react-navigation/native-stack';
+
+type RootStackParamList = {
+  '(tabs)': undefined;
+  '(auth)': undefined;
+  'article/[id]': { id: string };
+  modal: { title: string };
+};
+
+type ArticleScreenProps = NativeStackScreenProps<RootStackParamList, 'article/[id]'>;
+
+// Navegação com tipagem segura
+import { router } from 'expo-router';
+
+router.push({ pathname: '/article/[id]', params: { id: '123' } });
+router.back();
+router.replace('/login');
+```
+
+---
+
+## Código Específico por Plataforma
+
+### Organização de Código Específico por Plataforma
+
+```typescript
+// Método 1: Platform.select
+import { Platform, StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  container: {
+    ...Platform.select({
+      ios: {
+        paddingTop: 20,
+      },
+      android: {
+        paddingTop: 0,
+      },
+      default: {
+        paddingTop: 10,
+      },
+    }),
+  },
+});
+
+// Método 2: Extensões de arquivo
+// Button.ios.tsx
+export const Button = () => <IOSButton />;
+
+// Button.android.tsx
+export const Button = () => <AndroidButton />;
+
+// Button.tsx (fallback)
+export const Button = () => <DefaultButton />;
+
+// Método 3: Verificação de plataforma
+if (Platform.OS === 'ios') {
+  // Específico para iOS
+} else if (Platform.OS === 'android') {
+  // Específico para Android
+}
+
+// Método 4: Versão da plataforma
+if (Platform.Version >= 23) {
+  // Android API 23+
+}
+```
+
+---
+
+## Organização de Módulos Nativos
+
+```typescript
+// src/modules/
+├── camera/
+│   ├── CameraModule.ts          # Wrapper TypeScript
+│   ├── CameraModule.ios.ts      # Implementação iOS
+│   └── CameraModule.android.ts  # Implementação Android
+└── biometrics/
+    ├── BiometricsModule.ts
+    ├── BiometricsModule.ios.ts
+    └── BiometricsModule.android.ts
+
+// Exemplo de wrapper
+// modules/camera/CameraModule.ts
+import { NativeModules } from 'react-native';
+
+interface CameraInterface {
+  takePicture(): Promise<string>;
+  hasPermission(): Promise<boolean>;
+  requestPermission(): Promise<boolean>;
+}
+
+const { CameraModule } = NativeModules;
+
+export default CameraModule as CameraInterface;
+
+// Uso
+import CameraModule from '@/modules/camera/CameraModule';
+
+const takePicture = async () => {
+  const hasPermission = await CameraModule.hasPermission();
+  if (!hasPermission) {
+    const granted = await CameraModule.requestPermission();
+    if (!granted) return;
+  }
+  const photoUri = await CameraModule.takePicture();
+  return photoUri;
+};
+```
+
+---
+
+## Boas Práticas de Arquitetura
+
+### 1. Injeção de Dependência
+
+```typescript
+// ✅ BOM: Injeção de dependência
+interface StorageService {
+  get(key: string): Promise<string | null>;
+  set(key: string, value: string): Promise<void>;
+}
+
+class UserRepository {
+  constructor(private storage: StorageService) {}
+
+  async getUser(): Promise<User | null> {
+    const data = await this.storage.get('user');
+    return data ? JSON.parse(data) : null;
+  }
+}
+
+// Uso
+const repository = new UserRepository(mmkvStorage);
+
+// ❌ RUIM: Dependência hard-coded
+class UserRepository {
+  async getUser() {
+    const data = await mmkvStorage.get('user'); // Acoplamento forte
+    return data ? JSON.parse(data) : null;
+  }
+}
+```
+
+### 2. Padrão Repository
+
+```typescript
+// features/articles/repositories/articles.repository.ts
+import { articlesService } from '../services/articles.service';
+import { articlesStorage } from '../services/articles.storage';
+
+class ArticlesRepository {
+  async getArticles(filters?: ArticleFilters): Promise<Article[]> {
+    try {
+      // Tenta a API primeiro
+      const articles = await articlesService.getAll(filters);
+      // Salva em cache local
+      await articlesStorage.saveArticles(articles.data);
+      return articles.data;
+    } catch (error) {
+      // Fallback para armazenamento local
+      return await articlesStorage.getArticles();
+    }
+  }
+
+  async getArticleById(id: string): Promise<Article | null> {
+    // Tenta o cache primeiro
+    const cached = await articlesStorage.getArticleById(id);
+    if (cached) return cached;
+
+    // Busca da API
+    const article = await articlesService.getById(id);
+    await articlesStorage.saveArticle(article);
+    return article;
+  }
+}
+
+export const articlesRepository = new ArticlesRepository();
+```
+
+### 3. Padrão Adapter
+
+```typescript
+// Para adaptar APIs externas
+interface ArticleDTO {
+  id: number;
+  post_title: string;
+  post_content: string;
+  author_name: string;
+}
+
+interface Article {
+  id: string;
+  title: string;
+  content: string;
+  author: string;
+}
+
+class ArticleAdapter {
+  static toArticle(dto: ArticleDTO): Article {
+    return {
+      id: String(dto.id),
+      title: dto.post_title,
+      content: dto.post_content,
+      author: dto.author_name,
+    };
+  }
+
+  static toDTO(article: Article): ArticleDTO {
+    return {
+      id: Number(article.id),
+      post_title: article.title,
+      post_content: article.content,
+      author_name: article.author,
+    };
+  }
+}
+```
+
+---
+
+## Exemplos Completos
+
+### Exemplo Completo de Funcionalidade: Artigos
+
+```typescript
+// 1. Tipos
+// features/articles/types/Article.types.ts
+export interface Article {
+  id: string;
+  title: string;
+  content: string;
+  authorId: string;
+  tags: string[];
+  publishedAt: Date;
+}
+
+// 2. Serviço de API
+// features/articles/services/articles.service.ts
+class ArticlesService {
+  async getAll(): Promise<Article[]> {
+    const { data } = await apiClient.get('/articles');
+    return data;
+  }
+}
+export const articlesService = new ArticlesService();
+
+// 3. Serviço de Armazenamento
+// features/articles/services/articles.storage.ts
+class ArticlesStorage {
+  async saveArticles(articles: Article[]): Promise<void> {
+    await mmkvStorage.setItem('articles', JSON.stringify(articles));
+  }
+
+  async getArticles(): Promise<Article[]> {
+    const data = await mmkvStorage.getItem('articles');
+    return data ? JSON.parse(data) : [];
+  }
+}
+export const articlesStorage = new ArticlesStorage();
+
+// 4. Repository
+// features/articles/repositories/articles.repository.ts
+class ArticlesRepository {
+  async getArticles(): Promise<Article[]> {
+    try {
+      const articles = await articlesService.getAll();
+      await articlesStorage.saveArticles(articles);
+      return articles;
+    } catch {
+      return await articlesStorage.getArticles();
+    }
+  }
+}
+export const articlesRepository = new ArticlesRepository();
+
+// 5. Hook
+// features/articles/hooks/useArticles.ts
+export const useArticles = () => {
+  return useQuery({
+    queryKey: ['articles'],
+    queryFn: () => articlesRepository.getArticles(),
+  });
+};
+
+// 6. Componente
+// features/articles/components/ArticleCard/ArticleCard.tsx
+interface ArticleCardProps {
+  article: Article;
+}
+
+export const ArticleCard = ({ article }: ArticleCardProps) => {
+  return (
+    <Card onPress={() => router.push(`/article/${article.id}`)}>
+      <Text style={styles.title}>{article.title}</Text>
+      <Text style={styles.content}>{article.content}</Text>
+    </Card>
+  );
+};
+
+// 7. Tela
+// app/(tabs)/articles.tsx
+export default function ArticlesScreen() {
+  const { data: articles, isLoading } = useArticles();
+
+  if (isLoading) return <LoadingSpinner />;
+
+  return (
+    <FlatList
+      data={articles}
+      renderItem={({ item }) => <ArticleCard article={item} />}
+      keyExtractor={(item) => item.id}
+    />
+  );
+}
+```
 
 ---
 
 ## Checklist de Arquitetura
 
-**Antes de implementar uma feature**:
+**Antes de implementar uma funcionalidade**:
 
-- [ ] Pasta de feature criada em features/
+- [ ] Pasta da funcionalidade criada em features/
 - [ ] Tipos definidos em types/
-- [ ] Serviço API criado em services/
-- [ ] Serviço de storage se necessário
-- [ ] Repository se lógica complexa
-- [ ] Hook customizado criado em hooks/
+- [ ] Serviço de API criado em services/
+- [ ] Serviço de armazenamento se necessário
+- [ ] Repository se houver lógica complexa
+- [ ] Custom hook criado em hooks/
 - [ ] Componentes UI em components/
-- [ ] Screen em app/
+- [ ] Tela em app/
 - [ ] Navegação configurada
 - [ ] Testes unitários
 - [ ] Documentação
 
 ---
 
-**Arquitetura é a fundação da manutenibilidade. Invista tempo desde o início.**
+**A arquitetura é a base da manutenibilidade. Invista tempo desde o início.**

--- a/Dev/i18n/pt/Symfony/commands/check-compliance.md
+++ b/Dev/i18n/pt/Symfony/commands/check-compliance.md
@@ -1,181 +1,253 @@
 ---
-description: Audit Complet de Conformité Symfony
+description: Verificar Conformidade Completa do Symfony
 argument-hint: [arguments]
 ---
 
-# Audit Complet de Conformité Symfony
+# Verificar Conformidade Completa do Symfony
 
-## Arguments
+## Argumentos
 
-$ARGUMENTS : Chemin du projet Symfony à auditer (optionnel, par défaut : répertoire courant)
+$ARGUMENTS (opcional: caminho para o projeto a analisar)
 
-## Modo Plano
+## Modo de Planejamento
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
-## MISSION
+## MISSÃO
 
-Tu es un auditeur expert Symfony chargé de réaliser un audit complet de conformité d'un projet Symfony.
+Realizar uma auditoria de conformidade completa do projeto Symfony orquestrando as 4 verificações principais: Arquitetura, Qualidade de Código, Testes e Segurança. Produzir um relatório consolidado com uma pontuação geral de 100 pontos.
 
-### Step 1 : Verification du projet
+### Etapa 1: Preparação da Auditoria
 
-1. Identifie le répertoire du projet à auditer
-2. Vérifie qu'il s'agit bien d'un projet Symfony (présence de composer.json avec symfony/*)
-3. Vérifie la version de Symfony utilisée
+Preparar o ambiente de auditoria:
+- [ ] Identificar o caminho do projeto a auditar
+- [ ] Verificar a presença de arquivos de configuração (composer.json com symfony/*, .env)
+- [ ] Listar os diretórios principais (src/, tests/, config/, etc.)
+- [ ] Identificar a estrutura do projeto e a versão do Symfony
 
-### Step 2 : Audit Architecture (25 points)
+**Nota**: Se $ARGUMENTS for fornecido, utilizá-lo como caminho do projeto; caso contrário, usar o diretório atual.
 
-Exécute l'audit d'architecture en vérifiant :
+### Etapa 2: Auditoria de Arquitetura (25 pontos)
 
-**Référence aux règles** : `.claude/rules/symfony-architecture.md`
+Executar a verificação completa de arquitetura:
 
-- [ ] Structure des dossiers respecte Clean Architecture
-- [ ] Séparation Domain / Application / Infrastructure
-- [ ] Respect des principes DDD (Entities, Value Objects, Aggregates)
-- [ ] Architecture Hexagonale (Ports & Adapters)
-- [ ] Utilisation de Deptrac pour vérifier les dépendances
-- [ ] Absence de couplage entre les couches
-- [ ] Interfaces correctement définies pour les ports
-- [ ] Use Cases / Application Services bien définis
-- [ ] Repositories avec interfaces dans le domain
-- [ ] DTOs pour les transferts de données
+**Comando**: Usar o slash command `/symfony:check-architecture` ou seguir manualmente os passos em `check-architecture.md`
 
-**Score Architecture** : ___/25 points
+**Critérios Avaliados**:
+- Estrutura de Clean Architecture (6 pts)
+- Separação Domain/Application/Infrastructure (6 pts)
+- Arquitetura Hexagonal / Ports & Adapters (4 pts)
+- Modelagem DDD (Entidades, Value Objects, Agregados) (4 pts)
+- Use Cases e Application Services (3 pts)
+- Regras de dependência e Deptrac (2 pts)
 
-### Step 3 : Audit Qualité du Code (25 points)
+**Referência**: `check-architecture.md`
 
-Exécute l'audit de qualité du code en vérifiant :
+### Etapa 3: Auditoria de Qualidade de Código (25 pontos)
 
-**Référence aux règles** : `.claude/rules/symfony-code-quality.md`
+Executar a verificação de qualidade de código:
 
-- [ ] Respect de PSR-12
-- [ ] PHPStan niveau 9 sans erreur
-- [ ] Type hints strict sur tous les paramètres et retours
-- [ ] Déclaration `declare(strict_types=1)` dans tous les fichiers
-- [ ] Pas de code mort (détecté par PHPStan)
-- [ ] Pas de dépendances inutilisées
-- [ ] Complexité cyclomatique < 10 par méthode
-- [ ] Longueur des méthodes < 20 lignes
-- [ ] Classes single responsibility
-- [ ] Documentation PHPDoc complète et à jour
+**Comando**: Usar o slash command `/symfony:check-code-quality` ou seguir manualmente os passos em `check-code-quality.md`
 
-**Score Qualité du Code** : ___/25 points
+**Critérios Avaliados**:
+- Conformidade com PSR-12 (5 pts)
+- PHPStan nível 9 (5 pts)
+- Type hints estritos e declare(strict_types=1) (4 pts)
+- Princípios KISS/DRY/YAGNI (4 pts)
+- Documentação e PHPDoc (4 pts)
+- Tratamento de erros (3 pts)
 
-### Step 4 : Audit Testing (25 points)
+**Referência**: `check-code-quality.md`
 
-Exécute l'audit des tests en vérifiant :
+### Etapa 4: Auditoria de Testes (25 pontos)
 
-**Référence aux règles** : `.claude/rules/symfony-testing.md`
+Executar a verificação de testes:
 
-- [ ] Couverture de code ≥ 80%
-- [ ] Tests unitaires pour le Domain
-- [ ] Tests d'intégration pour l'Infrastructure
-- [ ] Tests fonctionnels avec Behat ou Symfony WebTestCase
-- [ ] Tests de mutation avec Infection (MSI ≥ 70%)
-- [ ] Fixtures pour les tests
-- [ ] Tests isolés (pas de dépendances entre tests)
-- [ ] Base de données de test séparée
-- [ ] Mocks et Stubs appropriés
-- [ ] CI/CD avec exécution automatique des tests
+**Comando**: Usar o slash command `/symfony:check-testing` ou seguir manualmente os passos em `check-testing.md`
 
-**Score Testing** : ___/25 points
+**Critérios Avaliados**:
+- Cobertura de código (7 pts)
+- Testes unitários para o Domínio (6 pts)
+- Testes de integração para a Infraestrutura (4 pts)
+- Testes funcionais (WebTestCase/Behat) (3 pts)
+- Mutation testing com Infection (3 pts)
+- Isolamento de testes e fixtures (2 pts)
 
-### Step 5 : Audit Sécurité (25 points)
+**Referência**: `check-testing.md`
 
-Exécute l'audit de sécurité en vérifiant :
+### Etapa 5: Auditoria de Segurança (25 pontos)
 
-**Référence aux règles** : `.claude/rules/symfony-security.md`
+Executar a verificação de segurança:
 
-- [ ] Symfony Security Bundle correctement configuré
-- [ ] OWASP Top 10 : Protection contre injection SQL
-- [ ] OWASP Top 10 : Protection XSS
-- [ ] OWASP Top 10 : Protection CSRF
-- [ ] OWASP Top 10 : Authentification sécurisée
-- [ ] OWASP Top 10 : Contrôle d'accès (Voters, ACL)
-- [ ] RGPD : Consentement utilisateur
-- [ ] RGPD : Droit à l'oubli implémenté
-- [ ] RGPD : Export des données personnelles
-- [ ] Secrets externalisés (pas dans le code)
+**Comando**: Usar o slash command `/symfony:check-security` ou seguir manualmente os passos em `check-security.md`
 
-**Score Sécurité** : ___/25 points
+**Critérios Avaliados**:
+- Configuração do Symfony Security Bundle (6 pts)
+- Proteções OWASP Top 10 (5 pts)
+- Gestão de segredos e credenciais (4 pts)
+- Validação de entradas e CSRF (4 pts)
+- Autenticação e Autorização (Voters) (3 pts)
+- Vulnerabilidades de dependências (2 pts)
+- Conformidade com o RGPD (1 pt)
 
-### Step 6 : Calcul du Score Global
+**Referência**: `check-security.md`
 
-**SCORE GLOBAL** : ___/100 points
+### Etapa 6: Consolidação e Pontuação Global
 
-Interprétation :
-- ✅ 90-100 : Excellent - Conformité exemplaire
-- ✅ 75-89 : Bon - Quelques améliorations mineures
-- ⚠️ 60-74 : Moyen - Améliorations nécessaires
-- ⚠️ 40-59 : Insuffisant - Refactoring important requis
-- ❌ 0-39 : Critique - Refonte complète nécessaire
+Calcular a pontuação geral e produzir o relatório consolidado:
+- [ ] Somar as 4 pontuações (máximo de 100 pontos)
+- [ ] Identificar categorias críticas (<50%)
+- [ ] Listar todos os problemas transversais críticos
+- [ ] Priorizar ações por impacto/esforço
+- [ ] Produzir o relatório consolidado final
 
-### Step 7 : Rapport Détaillé
+**Escala de Avaliação**:
+- 90-100: Excelente — Projeto de referência
+- 75-89: Muito Bom — Algumas melhorias menores
+- 60-74: Aceitável — Requer melhorias
+- 40-59: Insuficiente — Refatoração significativa necessária
+- 0-39: Crítico — Revisão completa necessária
 
-Génère un rapport structuré avec :
+### Etapa 7: Recomendações e Plano de Ação
+
+Produzir as recomendações finais:
+- [ ] Identificar as 3 ações prioritárias em todas as categorias
+- [ ] Estimar o esforço (Baixo/Médio/Alto) para cada ação
+- [ ] Estimar o impacto (Baixo/Médio/Alto) para cada ação
+- [ ] Propor a ordem de implementação
+- [ ] Sugerir ganhos rápidos (alta relação impacto/esforço)
+
+## FORMATO DE SAÍDA
 
 ```
-=================================================
-   AUDIT DE CONFORMITÉ SYMFONY
-=================================================
+AUDITORIA DE CONFORMIDADE SYMFONY - RELATÓRIO COMPLETO
+=======================================================
 
-📊 SCORE GLOBAL : ___/100
+PONTUAÇÃO GERAL: XX/100
 
-📐 Architecture        : ___/25 [✅|⚠️|❌]
-🎯 Qualité du Code    : ___/25 [✅|⚠️|❌]
-🧪 Testing            : ___/25 [✅|⚠️|❌]
-🔒 Sécurité           : ___/25 [✅|⚠️|❌]
+NÍVEL DE CONFORMIDADE: [Excelente/Muito Bom/Aceitável/Insuficiente/Crítico]
 
-=================================================
-   DÉTAILS PAR CATÉGORIE
-=================================================
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-[Insérer les détails de chaque audit]
+PONTUAÇÕES POR CATEGORIA:
 
-=================================================
-   TOP 3 ACTIONS PRIORITAIRES
-=================================================
+ARQUITETURA        : XX/25  [██████████░░░░░░░░░░] XX%
+QUALIDADE DE CÓDIGO: XX/25  [██████████░░░░░░░░░░] XX%
+TESTES             : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURANÇA          : XX/25  [██████████░░░░░░░░░░] XX%
 
-1. [Action prioritaire #1 avec impact estimé]
-2. [Action prioritaire #2 avec impact estimé]
-3. [Action prioritaire #3 avec impact estimé]
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 
-=================================================
-   RECOMMANDATIONS TECHNIQUES
-=================================================
+PONTOS FORTES GERAIS:
+1. [Ponto forte identificado em múltiplas categorias]
+2. [Outro ponto forte principal]
+3. [Terceiro ponto forte]
 
-- [Recommandation technique spécifique]
-- [Recommandation technique spécifique]
-- [Recommandation technique spécifique]
+MELHORIAS GERAIS:
+1. [Melhoria transversal menor]
+2. [Outra melhoria recomendada]
+3. [Terceira melhoria]
 
-=================================================
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico nº 1 - categoria afetada]
+2. [Problema crítico nº 2 - categoria afetada]
+3. [Problema crítico nº 3 - categoria afetada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALHES POR CATEGORIA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITETURA (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Sub-pontuações:
+  • Estrutura de Clean Architecture : XX/6
+  • Separação de camadas            : XX/6
+  • Hexagonal / Ports & Adapters    : XX/4
+  • Modelagem DDD                   : XX/4
+  • Use Cases                       : XX/3
+  • Regras de dependência           : XX/2
+
+Pontos Fortes:
+- [Pontos fortes de arquitetura]
+
+Problemas:
+- [Problemas de arquitetura]
+
+[Seções semelhantes para Qualidade de Código, Testes e Segurança...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 AÇÕES PRIORITÁRIAS (TODAS AS CATEGORIAS):
+
+1. CRÍTICO - [Ação nº 1]
+   Categoria : [Arquitetura/Qualidade/Testes/Segurança]
+   Impacto   : [Alto/Médio/Baixo]
+   Esforço   : [Alto/Médio/Baixo]
+   Prioridade: IMEDIATA
+
+   Descrição detalhada:
+   [Explicação do problema e solução proposta]
+
+   Arquivos afetados:
+   - [arquivo:linha]
+
+   Exemplo de correção:
+   [Código ou comando de correção]
+
+2. IMPORTANTE - [Ação nº 2]
+   [Mesmo formato...]
+
+3. RECOMENDADO - [Ação nº 3]
+   [Mesmo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GANHOS RÁPIDOS (Alto Impacto / Baixo Esforço):
+
+- [Ganho rápido nº 1] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Ganho rápido nº 2] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Ganho rápido nº 3] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLANO DE AÇÃO RECOMENDADO:
+
+SEMANA 1 (Imediato):
+- [ ] [Ação crítica nº 1]
+- [ ] [Ganho rápido prioritário]
+
+SEMANAS 2-4 (Curto prazo):
+- [ ] [Ação importante nº 2]
+- [ ] [Outros ganhos rápidos]
+
+MESES 2-3 (Médio prazo):
+- [ ] [Ação recomendada nº 3]
+- [ ] [Melhorias progressivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMO EXECUTIVO:
+
+[Parágrafo de síntese sobre o estado geral do projeto, principais pontos
+fortes, principais pontos fracos e a trajetória recomendada para melhorar
+a conformidade. Indicar se o projeto está pronto para produção,
+requer correções ou necessita de refatoração.]
+
+Recomendação Geral: [Pronto para produção / Correções menores /
+Refatoração significativa / Revisão completa necessária]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### Step 8 : Commandes Docker pour Verifications
+## NOTAS IMPORTANTES
 
-Pour chaque vérification, utilise Docker pour s'abstraire de l'environnement local :
-
-```bash
-# PHPStan
-docker run --rm -v $(pwd):/app phpstan/phpstan analyse src --level=9
-
-# PHP_CodeSniffer (PSR-12)
-docker run --rm -v $(pwd):/project php:8.2-cli vendor/bin/phpcs --standard=PSR12 src/
-
-# PHPUnit avec couverture
-docker run --rm -v $(pwd):/app php:8.2-cli vendor/bin/phpunit --coverage-text --coverage-html=coverage
-
-# Infection (mutation testing)
-docker run --rm -v $(pwd):/app infection/infection --min-msi=70
-
-# Deptrac
-docker run --rm -v $(pwd):/app qossmic/deptrac analyse
-```
-
-## IMPORTANT
-
-- Utilise TOUJOURS Docker pour les commandes afin de s'abstraire de l'environnement local
-- Ne stocke JAMAIS de fichiers dans /tmp
-- Fournis des exemples concrets de problèmes détectés
-- Priorise les actions selon l'impact et l'effort
-- Sois factuel et objectif dans l'évaluation
+- Este comando orquestra as 4 auditorias especializadas
+- Usar Docker para todas as ferramentas de análise
+- Fornecer exemplos concretos com arquivo:linha para cada problema
+- Priorizar ações com base na matriz Impacto/Esforço
+- Problemas de segurança são SEMPRE a prioridade máxima
+- Propor correções automatizáveis (scripts, hooks de pré-commit)
+- O relatório deve ser acionável, não apenas descritivo
+- Adaptar as recomendações ao contexto de negócio do projeto

--- a/Dev/i18n/pt/UIUX/commands/a11y-audit.md
+++ b/Dev/i18n/pt/UIUX/commands/a11y-audit.md
@@ -1,25 +1,25 @@
 ---
 description: Auditoria de Acessibilidade WCAG 2.2 AAA
-argument-hint: [arguments]
+argument-hint: [argumentos]
 ---
 
 # Auditoria de Acessibilidade WCAG 2.2 AAA
 
-Você é um Especialista em Acessibilidade certificado. Você deve realizar uma auditoria completa de acessibilidade segundo os critérios WCAG 2.2 nível AAA.
+Você é um Especialista em Acessibilidade certificado. Você deve realizar uma auditoria completa de acessibilidade de acordo com os critérios WCAG 2.2 nível AAA.
 
 ## Argumentos
 $ARGUMENTS
 
 Argumentos:
-- Caminho para a página/componente a auditar
+- Caminho para a página/componente a ser auditado
 - (Opcional) Nível: AA ou AAA (padrão: AAA)
 - (Opcional) Foco: all, keyboard, contrast, aria
 
 Exemplo: `/uiux:a11y-audit src/pages/Home.tsx AAA` ou `/uiux:a11y-audit src/components/Modal.tsx AA keyboard`
 
-## Modo Plano
+## Modo de Planejamento
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
 ## MISSÃO
 
@@ -31,15 +31,15 @@ npx axe-cli {URL}
 npx pa11y {URL} --standard WCAG2AAA
 npx lighthouse {URL} --only-categories=accessibility
 
-# Verificar pontuação Lighthouse
-# Objetivo: 100/100 nas 4 categorias
+# Verificar pontuação do Lighthouse
+# Objetivo: 100/100 em todas as 4 categorias
 ```
 
 ### Etapa 2: Auditoria manual WCAG 2.2
 
 ```
 ══════════════════════════════════════════════════════════════
-♿ AUDITORIA ACESSIBILIDADE WCAG 2.2 AAA
+♿ AUDITORIA DE ACESSIBILIDADE WCAG 2.2 AAA
 ══════════════════════════════════════════════════════════════
 
 Página/Componente: {nome}
@@ -54,8 +54,10 @@ Nível alvo: AAA + Lighthouse 100/100
 ### Lighthouse
 | Categoria | Pontuação | Objetivo | Status |
 |-----------|-----------|----------|--------|
-| Performance | /100 | 100 | ✅/❌ |
-| Accessibility | /100 | 100 | ✅/❌ |
+| Desempenho | /100 | 100 | ✅/❌ |
+| Acessibilidade | /100 | 100 | ✅/❌ |
+| Boas Práticas | /100 | 100 | ✅/❌ |
+| SEO | /100 | 100 | ✅/❌ |
 
 ### WCAG 2.2
 | Nível | Critérios | Conformes | Não conformes |
@@ -65,38 +67,220 @@ Nível alvo: AAA + Lighthouse 100/100
 | AAA | 28 | {X} | {Y} |
 
 ──────────────────────────────────────────────────────────────
-1️⃣ PERCEPTÍVEL / 2️⃣ OPERÁVEL / 3️⃣ COMPREENSÍVEL / 4️⃣ ROBUSTO
+1️⃣ PERCEPTÍVEL
 ──────────────────────────────────────────────────────────────
 
-{Tabelas detalhadas de verificação por princípio}
+### 1.1 Alternativas em Texto
+
+#### 1.1.1 Conteúdo não textual (A)
+| Elemento | Texto alternativo | Status | Ação |
+|----------|-------------------|--------|------|
+| img.logo | "Logo {nome}" | ✅ | - |
+| img.hero | "" (ausente) | ❌ | Adicionar alt descritivo |
+| img.icon | aria-hidden="true" | ✅ | - |
+
+### 1.3 Adaptável
+
+#### 1.3.1 Informações e Relações (A)
+| Verificação | Status | Detalhe |
+|-------------|--------|---------|
+| Estrutura de títulos | ✅/❌ | h1 → h2 → h3 sequencial |
+| Marcos ARIA | ✅/❌ | header, nav, main, footer |
+| Listas semânticas | ✅/❌ | ul/ol/dl apropriados |
+| Tabelas | ✅/❌ | th, scope, caption |
+| Formulários | ✅/❌ | label + fieldset/legend |
+
+### 1.4 Distinguível
+
+#### 1.4.3 Contraste Mínimo (AA) / 1.4.6 Contraste Aprimorado (AAA)
+| Elemento | Cores | Proporção | Requerido | Status |
+|----------|-------|-----------|-----------|--------|
+| Texto do corpo | #333 / #fff | 12,6:1 | 7:1 | ✅ |
+| Texto atenuado | #666 / #fff | 5,7:1 | 7:1 | ❌ |
+| Botão primário | #fff / #3B82F6 | 4,5:1 | 4,5:1 | ✅ |
+| Placeholder | #9CA3AF / #fff | 2,9:1 | 4,5:1 | ❌ |
+
+#### 1.4.10 Redistribuição (AA)
+| Teste | Status | Problema |
+|-------|--------|----------|
+| Largura 320px | ✅/❌ | {rolagem horizontal?} |
+| Zoom 400% | ✅/❌ | {conteúdo cortado?} |
+
+#### 1.4.11 Contraste de Componentes Não Textuais (AA)
+| Elemento de IU | Proporção | Status |
+|----------------|-----------|--------|
+| Borda do campo | 3:1 | ✅/❌ |
+| Borda do botão | 3:1 | ✅/❌ |
+| Ícone de ação | 3:1 | ✅/❌ |
+| Anel de foco | 3:1 | ✅/❌ |
+
+──────────────────────────────────────────────────────────────
+2️⃣ OPERÁVEL
+──────────────────────────────────────────────────────────────
+
+### 2.1 Acessível por Teclado
+
+#### 2.1.1 Teclado (A) / 2.1.3 Teclado Sem Exceção (AAA)
+| Elemento | Tab | Enter | Escape | Setas | Status |
+|----------|-----|-------|--------|-------|--------|
+| Links | ✅ | ✅ | - | - | ✅ |
+| Botões | ✅ | ✅ | - | - | ✅ |
+| Campos | ✅ | ✅ | - | - | ✅ |
+| Dropdown | ✅ | ✅ | ✅ | ✅ | ❌ |
+| Modal | ✅ | ✅ | ✅ | - | ✅ |
+| div customizada | ❌ | ❌ | - | - | ❌ |
+
+#### 2.1.2 Sem Armadilha de Teclado (A)
+| Zona | Entrada | Saída | Status |
+|------|---------|-------|--------|
+| Modal | Armadilha de foco OK | Escape OK | ✅ |
+| Dropdown | Tab OK | Tab/Escape OK | ✅ |
+| Barra lateral | Tab OK | Tab OK | ✅ |
+
+### 2.4 Navegável
+
+#### 2.4.1 Ignorar Blocos (A)
+| Link de salto | Destino | Status |
+|---------------|---------|--------|
+| "Ir para o conteúdo" | #main-content | ✅/❌ |
+| "Ir para a navegação" | #nav | ✅/❌ |
+
+#### 2.4.3 Ordem do Foco (A)
+| Sequência | Esperado | Atual | Status |
+|-----------|----------|-------|--------|
+| 1 | Link de salto | Link de salto | ✅ |
+| 2 | Logo | Logo | ✅ |
+| 3 | Item de nav 1 | Item de nav 1 | ✅ |
+| ... | ... | ... | ... |
+
+#### 2.4.7 Foco Visível (AA) / 2.4.11 Foco Aprimorado (AA)
+| Elemento | Contorno | Deslocamento | Proporção | Status |
+|----------|----------|--------------|-----------|--------|
+| Links | 2px solid | 2px | 3:1 | ✅ |
+| Botões | 2px solid | 2px | 3:1 | ✅ |
+| Campos | 2px solid | 0 | 3:1 | ✅ |
+| Cards | ❌ | - | - | ❌ |
+
+#### 2.5.5 Tamanho do Alvo (AAA)
+| Elemento | Tamanho | Mínimo requerido | Status |
+|----------|---------|------------------|--------|
+| Botões | 44×40px | 44×44px | ❌ |
+| Links do menu | 120×48px | 44×44px | ✅ |
+| Botões com ícone | 32×32px | 44×44px | ❌ |
+| Caixas de seleção | 24×24px | 44×44px | ❌ |
+
+──────────────────────────────────────────────────────────────
+3️⃣ COMPREENSÍVEL
+──────────────────────────────────────────────────────────────
+
+### 3.1 Legível
+
+#### 3.1.1 Idioma da Página (A)
+```html
+<html lang="pt-BR"> <!-- ✅ Presente -->
+```
+
+#### 3.1.2 Idioma das Partes (AA)
+| Elemento | Idioma | atributo lang | Status |
+|----------|--------|---------------|--------|
+| Citação estrangeira | Francês | ❌ | ❌ |
+| Termo técnico | Francês | ❌ | ⚠️ |
+
+### 3.3 Assistência de Entrada
+
+#### 3.3.1 Identificação de Erros (A)
+| Campo | Mensagem de erro | Em texto | Status |
+|-------|-----------------|----------|--------|
+| E-mail | "E-mail inválido" | ✅ | ✅ |
+| Senha | Somente borda vermelha | ❌ | ❌ |
+
+#### 3.3.2 Rótulos ou Instruções (A)
+| Campo | Rótulo | Associação | Status |
+|-------|--------|------------|--------|
+| E-mail | "E-mail" | htmlFor OK | ✅ |
+| Busca | ❌ | Sem rótulo | ❌ |
+| Telefone | Somente placeholder | Sem rótulo | ❌ |
+
+──────────────────────────────────────────────────────────────
+4️⃣ ROBUSTO
+──────────────────────────────────────────────────────────────
+
+### 4.1.2 Nome, Função, Valor (A)
+| Componente | role | aria-* | Status |
+|------------|------|--------|--------|
+| Modal | dialog | aria-modal, aria-labelledby | ✅ |
+| Dropdown | listbox | aria-expanded, aria-activedescendant | ✅ |
+| Abas | tablist/tab | aria-selected, aria-controls | ❌ |
+| Acordeão | - | aria-expanded | ❌ |
+
+### 4.1.3 Mensagens de Status (AA)
+| Mensagem | aria-live | aria-atomic | Status |
+|----------|-----------|-------------|--------|
+| Toast sucesso | polite | true | ✅ |
+| Toast erro | assertive | true | ✅ |
+| Carregando | polite | false | ❌ |
+| Erros de formulário | assertive | - | ❌ |
 
 ──────────────────────────────────────────────────────────────
 ❌ VIOLAÇÕES CRÍTICAS (Bloqueantes)
 ──────────────────────────────────────────────────────────────
 
-| # | Critério | Elemento | Descrição | Remediação |
-|---|----------|----------|-----------|------------|
+| # | Critério | Elemento | Descrição | Correção |
+|---|----------|----------|-----------|----------|
+| 1 | 1.4.6 | .text-muted | Contraste 5,7:1 < 7:1 | color: #595959 |
+| 2 | 2.5.5 | .btn-icon | Tamanho 32px < 44px | min-width: 44px |
+| 3 | 3.3.2 | input[type="search"] | Sem rótulo | Adicionar rótulo |
 
 ──────────────────────────────────────────────────────────────
-🎯 PLANO DE REMEDIAÇÃO
+⚠️ VIOLAÇÕES MAIORES
 ──────────────────────────────────────────────────────────────
 
-### Prioridade 1 - Críticos (esta semana)
-1. [ ] {ação}
+| # | Critério | Elemento | Descrição | Correção |
+|---|----------|----------|-----------|----------|
+| 4 | 2.1.1 | .card-clickable | div não focalizável | Usar button |
+| 5 | 4.1.2 | .tabs | ARIA incorreto | Adicionar role="tablist" |
 
-### Prioridade 2 - Maiores (este sprint)
-1. [ ] {ação}
+──────────────────────────────────────────────────────────────
+ℹ️ VIOLAÇÕES MENORES
+──────────────────────────────────────────────────────────────
 
-### Prioridade 3 - Menores (backlog)
-1. [ ] {ação}
+| # | Critério | Elemento | Descrição | Correção |
+|---|----------|----------|-----------|----------|
+| 6 | 3.1.2 | blockquote | Texto em inglês sem lang | lang="en" |
+
+──────────────────────────────────────────────────────────────
+✅ PONTOS DE CONFORMIDADE NOTÁVEIS
+──────────────────────────────────────────────────────────────
+
+- Estrutura semântica correta (títulos, marcos)
+- Link de salto presente e funcional
+- Armadilha de foco correta nos modais
+- Mensagens de erro em texto claras
+
+──────────────────────────────────────────────────────────────
+🎯 PLANO DE CORREÇÃO
+──────────────────────────────────────────────────────────────
+
+### Prioridade 1 — Crítico (esta semana)
+1. [ ] Corrigir contraste de .text-muted → #595959
+2. [ ] Ampliar alvos de toque para mínimo de 44px
+3. [ ] Adicionar rótulos aos campos sem rótulo
+
+### Prioridade 2 — Maior (esta sprint)
+4. [ ] Substituir divs clicáveis por button
+5. [ ] Corrigir ARIA no componente de Abas
+6. [ ] Adicionar aria-live nos estados de carregamento
+
+### Prioridade 3 — Menor (backlog)
+7. [ ] Adicionar lang="en" nos textos em inglês
 ```
 
 ### Etapa 3: Teste com leitor de tela
 
 - VoiceOver (macOS): navegação completa
 - NVDA (Windows): verificação de anúncios
-- TalkBack (Android): se app mobile
+- TalkBack (Android): se aplicativo móvel
 
-### Etapa 4: Teste apenas teclado
+### Etapa 4: Teste somente com teclado
 
-Navegar toda a interface usando apenas o teclado.
+Navegue pela interface completa usando somente o teclado.

--- a/Dev/i18n/pt/UIUX/commands/a11y-component.md
+++ b/Dev/i18n/pt/UIUX/commands/a11y-component.md
@@ -1,11 +1,11 @@
 ---
 description: Especificação de Acessibilidade de Componente
-argument-hint: [arguments]
+argument-hint: [argumentos]
 ---
 
 # Especificação de Acessibilidade de Componente
 
-Você é um Especialista em Acessibilidade certificado. Você deve produzir as especificações de acessibilidade completas para um componente UI.
+Você é um Especialista em Acessibilidade certificado. Você deve produzir especificações completas de acessibilidade para um componente de IU.
 
 ## Argumentos
 $ARGUMENTS
@@ -14,23 +14,23 @@ Argumentos:
 - Nome do componente
 - (Opcional) Tipo: button, input, modal, dropdown, tabs, accordion, tooltip, etc.
 
-Exemplo: `/uiux:a11y-component Modal` ou `/uiux:a11y-component "Seletor de Data" tipo:input`
+Exemplo: `/uiux:a11y-component Modal` ou `/uiux:a11y-component "Date Picker" type:input`
 
-## Modo Plano
+## Modo de Planejamento
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+> **O modo de planejamento é obrigatório.** Antes de executar, Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar a sua validação antes de fazer qualquer alteração.
 
 ## MISSÃO
 
 ### Etapa 1: Identificar o padrão ARIA
 
-Consultar o ARIA Authoring Practices Guide (APG) para o padrão correspondente.
+Consultar o Guia de Práticas de Autoria ARIA (APG) para o padrão correspondente.
 
 ### Etapa 2: Produzir a especificação
 
 ```
 ══════════════════════════════════════════════════════════════
-♿ ESPECIFICAÇÃO ACESSIBILIDADE: {NOME_COMPONENTE}
+♿ ESPECIFICAÇÃO DE ACESSIBILIDADE: {NOME_DO_COMPONENTE}
 ══════════════════════════════════════════════════════════════
 
 Tipo: {Button | Input | Dialog | Listbox | Tabs | ...}
@@ -42,14 +42,24 @@ Data: {data}
 ──────────────────────────────────────────────────────────────
 
 ### Elemento nativo recomendado
+
 ```html
-<!-- Sempre preferir elemento nativo -->
+<!-- Sempre prefira o elemento nativo -->
 <{elemento} ...>
   {conteúdo}
 </{elemento}>
 ```
 
+### Se componente customizado for necessário
+
+```html
+<div role="{role}" ...>
+  {conteúdo}
+</div>
+```
+
 ### Estrutura completa
+
 ```html
 <!-- Exemplo completo com ARIA -->
 <div
@@ -57,7 +67,8 @@ Data: {data}
   aria-{atributo}="{valor}"
   tabindex="0"
 >
-  <span id="{id}-label">{Label}</span>
+  <span id="{id}-label">{Rótulo}</span>
+  <div id="{id}-description">{Descrição}</div>
   {conteúdo}
 </div>
 ```
@@ -66,77 +77,324 @@ Data: {data}
 🏷️ ATRIBUTOS ARIA
 ──────────────────────────────────────────────────────────────
 
-### Atributos requeridos
+### Atributos obrigatórios
+
 | Atributo | Valor | Quando | Descrição |
 |----------|-------|--------|-----------|
-| role | {role} | Sempre (se custom) | Define o tipo |
-| aria-label | "{texto}" | Se não há label visível | Label acessível |
+| role | {role} | Sempre (se customizado) | Define o tipo |
+| aria-label | "{texto}" | Se sem rótulo visível | Rótulo acessível |
+| aria-labelledby | "{id}" | Se rótulo visível | Referência ao rótulo |
 
 ### Atributos condicionais
+
 | Atributo | Valor | Quando | Descrição |
 |----------|-------|--------|-----------|
+| aria-describedby | "{id}" | Se há descrição | Referência à descrição |
 | aria-expanded | "true"/"false" | Se expansível | Estado aberto/fechado |
+| aria-controls | "{id}" | Se controla outro | ID do elemento controlado |
+| aria-owns | "{id}" | Se DOM separado | Relação pai |
+| aria-haspopup | "dialog"/"menu"/"listbox" | Se popup | Tipo de popup |
+| aria-pressed | "true"/"false" | Se toggle | Estado pressionado |
+| aria-selected | "true"/"false" | Se seleção | Estado selecionado |
+| aria-checked | "true"/"false"/"mixed" | Se caixa de seleção | Estado marcado |
 | aria-disabled | "true" | Se desabilitado | Estado desabilitado |
+| aria-invalid | "true" | Se erro | Estado inválido |
+| aria-required | "true" | Se obrigatório | Campo obrigatório |
+| aria-busy | "true" | Se carregando | Em progresso |
+| aria-live | "polite"/"assertive" | Se dinâmico | Anunciar alteração |
+| aria-atomic | "true" | Com aria-live | Anunciar tudo |
+
+### Estados por interação
+
+| Estado | Atributos ARIA |
+|--------|----------------|
+| Padrão | {atributos base} |
+| Hover | Sem alteração ARIA |
+| Foco | Sem alteração ARIA |
+| Expandido | aria-expanded="true" |
+| Recolhido | aria-expanded="false" |
+| Selecionado | aria-selected="true" |
+| Desabilitado | aria-disabled="true" |
+| Carregando | aria-busy="true" |
+| Erro | aria-invalid="true", aria-errormessage="{id}" |
 
 ──────────────────────────────────────────────────────────────
 ⌨️ NAVEGAÇÃO POR TECLADO
 ──────────────────────────────────────────────────────────────
 
+### Teclas principais
+
 | Tecla | Ação | Detalhe |
 |-------|------|---------|
 | Tab | Foco no componente | Entra no componente |
-| Enter | Ativar | Ação principal |
-| Space | Ativar (toggle) | Para botões toggle |
+| Shift+Tab | Foco anterior | Sai do componente |
+| Enter | Ativar | Ação primária |
+| Space | Ativar (toggle) | Para botões de alternância |
 | Escape | Fechar/Cancelar | Se popup/modal |
-| Setas | Navegação interna | Em listas |
+| ↑ Seta para cima | Item anterior | Navegação em lista |
+| ↓ Seta para baixo | Próximo item | Navegação em lista |
+| ← Seta para esquerda | Item anterior (horizontal) | Abas, slider |
+| → Seta para direita | Próximo item (horizontal) | Abas, slider |
+| Home | Primeiro item | Navegação rápida |
+| End | Último item | Navegação rápida |
+
+### Gestão do foco
+
+| Situação | Comportamento |
+|----------|---------------|
+| Abertura | Foco no {primeiro elemento focalizável} |
+| Fechamento | Foco retorna ao {elemento acionador} |
+| Navegação interna | Roving tabindex OU aria-activedescendant |
+| Armadilha de foco | {Sim para modal / Não para dropdown} |
+
+### Roving tabindex (se aplicável)
+
+```html
+<!-- Apenas um elemento focalizável por vez -->
+<div role="tablist">
+  <button role="tab" tabindex="0" aria-selected="true">Aba 1</button>
+  <button role="tab" tabindex="-1" aria-selected="false">Aba 2</button>
+  <button role="tab" tabindex="-1" aria-selected="false">Aba 3</button>
+</div>
+```
+
+──────────────────────────────────────────────────────────────
+🎯 FOCO VISÍVEL
+──────────────────────────────────────────────────────────────
+
+### Estilo obrigatório (WCAG 2.4.11 AAA)
+
+```css
+.{componente}:focus-visible {
+  /* Contorno visível */
+  outline: 2px solid var(--color-focus);
+  outline-offset: 2px;
+
+  /* Proporção de contraste ≥ 3:1 */
+  /* Área de foco ≥ perímetro visível */
+}
+
+/* Redefinir para mouse */
+.{componente}:focus:not(:focus-visible) {
+  outline: none;
+}
+```
+
+### Verificações
+
+| Critério | Valor | Status |
+|----------|-------|--------|
+| Espessura do contorno | ≥ 2px | ✅ |
+| Contraste do contorno | ≥ 3:1 | ✅ |
+| Área visível | ≥ perímetro | ✅ |
+| Visível em todos os fundos | Sim | ✅ |
 
 ──────────────────────────────────────────────────────────────
 🔊 ANÚNCIOS DO LEITOR DE TELA
 ──────────────────────────────────────────────────────────────
 
 ### Ao entrar (foco)
+
 ```
-"{Label}, {papel}, {estado}"
+"{Rótulo}, {role}, {estado}"
+
 Exemplos:
 - "Enviar, botão"
 - "Menu principal, menu, recolhido"
+- "Nome, campo de texto, obrigatório"
+- "Newsletter, caixa de seleção, não marcada"
 ```
 
-### Durante interação
+### Durante a interação
+
 | Ação | Anúncio |
 |------|---------|
 | Expansão | "expandido" / "recolhido" |
+| Seleção | "selecionado" |
+| Alternância | "ativado" / "desativado" |
+| Carregando | "Carregando" |
+| Sucesso | "{mensagem de sucesso}" |
 | Erro | "Erro: {mensagem}" |
+
+### Conteúdo dinâmico (aria-live)
+
+```html
+<!-- Notificações educadas (não urgentes) -->
+<div aria-live="polite" aria-atomic="true">
+  {mensagem toast}
+</div>
+
+<!-- Notificações urgentes (erros) -->
+<div aria-live="assertive" aria-atomic="true">
+  {mensagem de erro}
+</div>
+```
+
+──────────────────────────────────────────────────────────────
+📏 CONTRASTE (WCAG AAA)
+──────────────────────────────────────────────────────────────
+
+### Texto
+
+| Tipo | Proporção requerida | Verificação |
+|------|---------------------|-------------|
+| Texto normal (< 18px) | ≥ 7:1 | {cor} / {fundo} = {proporção} |
+| Texto grande (≥ 18px ou 14px negrito) | ≥ 4,5:1 | {cor} / {fundo} = {proporção} |
+
+### Elementos de IU
+
+| Elemento | Proporção requerida | Verificação |
+|----------|---------------------|-------------|
+| Bordas | ≥ 3:1 | {cor} / {fundo} = {proporção} |
+| Ícones | ≥ 3:1 | {cor} / {fundo} = {proporção} |
+| Contorno de foco | ≥ 3:1 | {cor} / {fundo} = {proporção} |
+
+### Estados
+
+| Estado | Verificação de contraste |
+|--------|--------------------------|
+| Padrão | ✅ {proporção} |
+| Hover | ✅ {proporção} |
+| Foco | ✅ {proporção} |
+| Desabilitado | ⚠️ Não obrigatório, mas recomendado |
 
 ──────────────────────────────────────────────────────────────
 📐 ALVOS DE TOQUE (WCAG 2.5.5 AAA)
 ──────────────────────────────────────────────────────────────
+
+### Dimensões mínimas
 
 | Critério | Valor | Status |
 |----------|-------|--------|
 | Tamanho mínimo | 44 × 44 pixels CSS | ✅/❌ |
 | Espaçamento entre alvos | ≥ 8px | ✅/❌ |
 
+### Implementação
+
+```css
+.{componente} {
+  min-width: 44px;
+  min-height: 44px;
+  /* OU padding para atingir 44px */
+  padding: 10px 16px; /* se altura do texto ~24px */
+}
+
+/* Botões com ícone */
+.{componente}-icon {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+```
+
+──────────────────────────────────────────────────────────────
+🧪 TESTES A REALIZAR
+──────────────────────────────────────────────────────────────
+
+### Automatizados
+
+- [ ] axe DevTools: 0 violações
+- [ ] Lighthouse Accessibility: 100/100
+- [ ] ESLint jsx-a11y: 0 erros
+
+### Manuais
+
+- [ ] Navegação completa por teclado
+- [ ] Foco visível em cada etapa
+- [ ] Sem armadilha de teclado
+- [ ] Ordem de foco lógica
+
+### Leitor de tela
+
+- [ ] VoiceOver (macOS/iOS): anúncios corretos
+- [ ] NVDA (Windows): navegação em listas/tabelas
+- [ ] TalkBack (Android): se móvel
+
+### Casos extremos
+
+- [ ] Zoom 400%: sem perda de conteúdo
+- [ ] Modo de alto contraste: visível
+- [ ] Movimento reduzido: animações respeitadas
+
+──────────────────────────────────────────────────────────────
+💻 EXEMPLO DE IMPLEMENTAÇÃO
+──────────────────────────────────────────────────────────────
+
+```tsx
+// {Componente}.tsx
+import { forwardRef, useId } from 'react';
+
+interface {Componente}Props {
+  label: string;
+  description?: string;
+  disabled?: boolean;
+  // ...outras props
+}
+
+export const {Componente} = forwardRef<HTML{Elemento}Element, {Componente}Props>(
+  ({ label, description, disabled, ...props }, ref) => {
+    const id = useId();
+    const descriptionId = description ? `${id}-description` : undefined;
+
+    return (
+      <{elemento}
+        ref={ref}
+        id={id}
+        role="{role}"
+        aria-label={label}
+        aria-describedby={descriptionId}
+        aria-disabled={disabled}
+        tabIndex={disabled ? -1 : 0}
+        {...props}
+      >
+        {/* Conteúdo */}
+
+        {description && (
+          <span id={descriptionId} className="sr-only">
+            {description}
+          </span>
+        )}
+      </{elemento}>
+    );
+  }
+);
+
+{Componente}.displayName = '{Componente}';
+```
+
 ──────────────────────────────────────────────────────────────
 ✅ CHECKLIST DE VALIDAÇÃO
 ──────────────────────────────────────────────────────────────
 
 ### Semântica
-- [ ] Elemento HTML nativo usado se possível
-- [ ] Role ARIA correto se custom
+- [ ] Elemento HTML nativo utilizado quando possível
+- [ ] Role ARIA correto se customizado
 - [ ] Estrutura DOM lógica
 
 ### ARIA
-- [ ] Atributos requeridos presentes
-- [ ] Sem excesso de ARIA (nativo > ARIA)
+- [ ] Atributos obrigatórios presentes
+- [ ] Atributos condicionais corretos
+- [ ] Sem sobrecarga de ARIA (nativo > ARIA)
 
 ### Teclado
-- [ ] Focável (tabindex apropriado)
+- [ ] Focalizável (tabindex apropriado)
 - [ ] Todas as ações via teclado
 - [ ] Sem armadilha de teclado
 - [ ] Foco visível conforme
 
+### Anúncios
+- [ ] Rótulo anunciado ao focar
+- [ ] Estados anunciados na mudança
+- [ ] Erros com aria-live assertive
+
 ### Contraste
 - [ ] Texto ≥ 7:1 (AAA)
-- [ ] UI ≥ 3:1
+- [ ] IU ≥ 3:1
+- [ ] Foco ≥ 3:1
+
+### Toque
+- [ ] Alvos ≥ 44×44px
+- [ ] Espaçamento ≥ 8px
 ```

--- a/Dev/i18n/pt/UIUX/commands/design-tokens.md
+++ b/Dev/i18n/pt/UIUX/commands/design-tokens.md
@@ -1,33 +1,33 @@
 ---
 description: Definição de Design Tokens
-argument-hint: [arguments]
+argument-hint: [argumentos]
 ---
 
 # Definição de Design Tokens
 
-Você é um Lead UI Designer. Você deve definir os design tokens para um design system coerente e manutenível.
+Você é um Designer de IU Líder. Você deve definir design tokens para um sistema de design coerente e de fácil manutenção.
 
 ## Argumentos
 $ARGUMENTS
 
 Argumentos:
 - Tipo de tokens a definir: colors, typography, spacing, shadows, all
-- (Opcional) Cor primária base: #HEXCODE
+- (Opcional) Cor primária de base: #HEXCODE
 - (Opcional) Modo: light, dark, both
 
 Exemplo: `/uiux:design-tokens all #3B82F6 both`
 
-## Modo Plano
+## Modo de Planejamento
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+> **O modo de planejamento é obrigatório.** Antes de executar, Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar a sua validação antes de fazer qualquer alteração.
 
 ## MISSÃO
 
 ### Etapa 1: Analisar o contexto
 
-- Stack frontend (React, Vue, Tailwind, CSS vars...)
-- Design system existente?
-- Guia de marca fornecida?
+- Stack de front-end (React, Vue, Tailwind, CSS vars...)
+- Sistema de design existente?
+- Diretrizes de marca fornecidas?
 
 ### Etapa 2: Definir os tokens
 
@@ -46,36 +46,80 @@ Formato: CSS Custom Properties
 
 ### Paleta Semântica
 
-#### Primary (Ação principal)
-| Token | Light | Dark | Uso |
-|-------|-------|------|-----|
+#### Primário (Ação principal)
+| Token | Claro | Escuro | Uso |
+|-------|-------|--------|-----|
 | --color-primary-50 | #eff6ff | #1e3a5f | Fundo sutil |
+| --color-primary-100 | #dbeafe | #1e40af | Fundo |
+| --color-primary-200 | #bfdbfe | #1d4ed8 | Borda |
+| --color-primary-300 | #93c5fd | #2563eb | Borda hover |
+| --color-primary-400 | #60a5fa | #3b82f6 | Ícone |
 | --color-primary-500 | #3b82f6 | #60a5fa | Texto |
 | --color-primary-600 | #2563eb | #93c5fd | Texto hover |
+| --color-primary-700 | #1d4ed8 | #bfdbfe | - |
+| --color-primary-800 | #1e40af | #dbeafe | - |
+| --color-primary-900 | #1e3a5f | #eff6ff | - |
 
-#### Success / Warning / Error
-{Escalas similares}
+#### Sucesso
+| Token | Claro | Escuro |
+|-------|-------|--------|
+| --color-success-50 | #f0fdf4 | #14532d |
+| --color-success-500 | #22c55e | #4ade80 |
+| --color-success-700 | #15803d | #86efac |
 
-#### Neutral (Texto, Fundos)
-| Token | Light | Dark | Uso |
-|-------|-------|------|-----|
+#### Aviso
+| Token | Claro | Escuro |
+|-------|-------|--------|
+| --color-warning-50 | #fffbeb | #78350f |
+| --color-warning-500 | #f59e0b | #fbbf24 |
+| --color-warning-700 | #b45309 | #fcd34d |
+
+#### Erro
+| Token | Claro | Escuro |
+|-------|-------|--------|
+| --color-error-50 | #fef2f2 | #7f1d1d |
+| --color-error-500 | #ef4444 | #f87171 |
+| --color-error-700 | #b91c1c | #fca5a5 |
+
+#### Neutro (Texto, Fundos)
+| Token | Claro | Escuro | Uso |
+|-------|-------|--------|-----|
 | --color-neutral-0 | #ffffff | #0a0a0a | Fundo |
-| --color-neutral-500 | #737373 | #a3a3a3 | Texto muted |
+| --color-neutral-50 | #fafafa | #171717 | Fundo sutil |
+| --color-neutral-100 | #f5f5f5 | #262626 | Fundo atenuado |
+| --color-neutral-200 | #e5e5e5 | #404040 | Borda |
+| --color-neutral-300 | #d4d4d4 | #525252 | Borda hover |
+| --color-neutral-400 | #a3a3a3 | #737373 | Placeholder |
+| --color-neutral-500 | #737373 | #a3a3a3 | Texto atenuado |
+| --color-neutral-600 | #525252 | #d4d4d4 | Texto secundário |
+| --color-neutral-700 | #404040 | #e5e5e5 | Texto primário |
+| --color-neutral-800 | #262626 | #f5f5f5 | Texto de ênfase |
 | --color-neutral-900 | #171717 | #fafafa | Texto forte |
 
-### Tokens Alias (Semânticos)
+### Tokens de Alias (Semânticos)
 ```css
 /* Fundos */
 --color-bg-primary: var(--color-neutral-0);
 --color-bg-secondary: var(--color-neutral-50);
+--color-bg-tertiary: var(--color-neutral-100);
+--color-bg-inverse: var(--color-neutral-900);
 
-/* Textos */
+/* Texto */
 --color-text-primary: var(--color-neutral-900);
 --color-text-secondary: var(--color-neutral-600);
+--color-text-muted: var(--color-neutral-500);
+--color-text-inverse: var(--color-neutral-0);
 
 /* Bordas */
 --color-border-default: var(--color-neutral-200);
+--color-border-hover: var(--color-neutral-300);
 --color-border-focus: var(--color-primary-500);
+
+/* Estados */
+--color-state-focus: var(--color-primary-500);
+--color-state-error: var(--color-error-500);
+--color-state-success: var(--color-success-500);
+--color-state-warning: var(--color-warning-500);
 ```
 
 ──────────────────────────────────────────────────────────────
@@ -84,39 +128,159 @@ Formato: CSS Custom Properties
 
 ### Famílias
 ```css
---font-family-sans: 'Inter', system-ui, sans-serif;
---font-family-mono: 'JetBrains Mono', monospace;
+--font-family-sans: 'Inter', system-ui, -apple-system, sans-serif;
+--font-family-mono: 'JetBrains Mono', 'Fira Code', monospace;
 ```
 
 ### Tamanhos (base 16px)
-| Token | Tamanho | Line Height | Uso |
-|-------|---------|-------------|-----|
-| --font-size-xs | 0.75rem | 1rem | Labels |
-| --font-size-base | 1rem | 1.5rem | Body |
-| --font-size-4xl | 2.25rem | 2.5rem | H1 |
+| Token | Tamanho | Altura da linha | Uso |
+|-------|---------|-----------------|-----|
+| --font-size-xs | 0.75rem (12px) | 1rem | Rótulos, badges |
+| --font-size-sm | 0.875rem (14px) | 1.25rem | Corpo pequeno |
+| --font-size-base | 1rem (16px) | 1.5rem | Corpo |
+| --font-size-lg | 1.125rem (18px) | 1.75rem | Texto de destaque |
+| --font-size-xl | 1.25rem (20px) | 1.75rem | H4 |
+| --font-size-2xl | 1.5rem (24px) | 2rem | H3 |
+| --font-size-3xl | 1.875rem (30px) | 2.25rem | H2 |
+| --font-size-4xl | 2.25rem (36px) | 2.5rem | H1 |
+| --font-size-5xl | 3rem (48px) | 1 | Display |
+
+### Pesos
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --font-weight-normal | 400 | Corpo |
+| --font-weight-medium | 500 | Rótulos, nav |
+| --font-weight-semibold | 600 | Subtítulos |
+| --font-weight-bold | 700 | Títulos |
+
+### Alturas de Linha
+```css
+--line-height-none: 1;
+--line-height-tight: 1.25;
+--line-height-snug: 1.375;
+--line-height-normal: 1.5;
+--line-height-relaxed: 1.625;
+--line-height-loose: 2;
+```
+
+### Espaçamento entre Letras
+```css
+--letter-spacing-tighter: -0.05em;
+--letter-spacing-tight: -0.025em;
+--letter-spacing-normal: 0;
+--letter-spacing-wide: 0.025em;
+--letter-spacing-wider: 0.05em;
+```
 
 ──────────────────────────────────────────────────────────────
-📐 ESPAÇAMENTOS
+📐 ESPAÇAMENTO
 ──────────────────────────────────────────────────────────────
 
 ### Escala (base 4px)
 | Token | Valor | Pixels | Uso |
 |-------|-------|--------|-----|
+| --spacing-0 | 0 | 0px | - |
+| --spacing-px | 1px | 1px | Bordas |
+| --spacing-0.5 | 0.125rem | 2px | Compacto |
 | --spacing-1 | 0.25rem | 4px | XS |
+| --spacing-1.5 | 0.375rem | 6px | - |
+| --spacing-2 | 0.5rem | 8px | S |
+| --spacing-2.5 | 0.625rem | 10px | - |
+| --spacing-3 | 0.75rem | 12px | - |
 | --spacing-4 | 1rem | 16px | M (base) |
+| --spacing-5 | 1.25rem | 20px | - |
+| --spacing-6 | 1.5rem | 24px | L |
 | --spacing-8 | 2rem | 32px | XL |
+| --spacing-10 | 2.5rem | 40px | - |
+| --spacing-12 | 3rem | 48px | 2XL |
+| --spacing-16 | 4rem | 64px | 3XL |
+| --spacing-20 | 5rem | 80px | - |
+| --spacing-24 | 6rem | 96px | 4XL |
 
 ──────────────────────────────────────────────────────────────
-🌗 SOMBRAS / ⭕ RAIOS / ⏱️ TRANSIÇÕES
+🌗 SOMBRAS
 ──────────────────────────────────────────────────────────────
 
-{Tabelas similares com tokens}
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --shadow-xs | 0 1px 2px 0 rgb(0 0 0 / 0.05) | Sutil |
+| --shadow-sm | 0 1px 3px 0 rgb(0 0 0 / 0.1) | Cards |
+| --shadow-md | 0 4px 6px -1px rgb(0 0 0 / 0.1) | Dropdowns |
+| --shadow-lg | 0 10px 15px -3px rgb(0 0 0 / 0.1) | Modais |
+| --shadow-xl | 0 20px 25px -5px rgb(0 0 0 / 0.1) | Diálogos |
+| --shadow-2xl | 0 25px 50px -12px rgb(0 0 0 / 0.25) | Sobreposições |
+| --shadow-inner | inset 0 2px 4px 0 rgb(0 0 0 / 0.05) | Campos |
+| --shadow-none | none | Redefinir |
 
+──────────────────────────────────────────────────────────────
+⭕ RAIOS (Border Radius)
+──────────────────────────────────────────────────────────────
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --radius-none | 0 | Arestas vivas |
+| --radius-sm | 0.125rem (2px) | Sutil |
+| --radius-md | 0.375rem (6px) | Botões, campos |
+| --radius-lg | 0.5rem (8px) | Cards |
+| --radius-xl | 0.75rem (12px) | Modais |
+| --radius-2xl | 1rem (16px) | Cards grandes |
+| --radius-full | 9999px | Pílulas, avatares |
+
+──────────────────────────────────────────────────────────────
+⏱️ TRANSIÇÕES
+──────────────────────────────────────────────────────────────
+
+### Durações
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --duration-75 | 75ms | Micro |
+| --duration-100 | 100ms | Rápido |
+| --duration-150 | 150ms | Padrão |
+| --duration-200 | 200ms | Normal |
+| --duration-300 | 300ms | Lento |
+| --duration-500 | 500ms | Ênfase |
+
+### Easings
+```css
+--ease-linear: linear;
+--ease-in: cubic-bezier(0.4, 0, 1, 1);
+--ease-out: cubic-bezier(0, 0, 0.2, 1);
+--ease-in-out: cubic-bezier(0.4, 0, 0.2, 1);
+--ease-bounce: cubic-bezier(0.68, -0.55, 0.265, 1.55);
+```
+
+### Transições Compostas
+```css
+--transition-none: none;
+--transition-all: all 150ms ease-out;
+--transition-colors: color, background-color, border-color 150ms ease-out;
+--transition-opacity: opacity 150ms ease-out;
+--transition-shadow: box-shadow 150ms ease-out;
+--transition-transform: transform 150ms ease-out;
+```
+
+──────────────────────────────────────────────────────────────
+📦 Z-INDEX
+──────────────────────────────────────────────────────────────
+
+| Token | Valor | Uso |
+|-------|-------|-----|
+| --z-0 | 0 | Base |
+| --z-10 | 10 | Elevado |
+| --z-20 | 20 | Dropdowns |
+| --z-30 | 30 | Fixo ao rolar |
+| --z-40 | 40 | Fixo |
+| --z-50 | 50 | Fundo do modal |
+| --z-60 | 60 | Modal |
+| --z-70 | 70 | Popover |
+| --z-80 | 80 | Toast |
+| --z-90 | 90 | Tooltip |
+| --z-max | 9999 | Máximo |
 ```
 
 ### Etapa 3: Exportar
 
-Gerar arquivos:
-- `tokens.css` - CSS Custom Properties
-- `tokens.json` - Formato Style Dictionary
-- `tailwind.config.js` - Extensão Tailwind (se aplicável)
+Gerar os arquivos:
+- `tokens.css` — CSS Custom Properties
+- `tokens.json` — formato Style Dictionary
+- `tailwind.config.js` — extensão do Tailwind (se aplicável)

--- a/Dev/i18n/pt/UIUX/commands/user-flow.md
+++ b/Dev/i18n/pt/UIUX/commands/user-flow.md
@@ -1,32 +1,32 @@
 ---
 description: Design de Fluxo de Usuário
-argument-hint: [arguments]
+argument-hint: [argumentos]
 ---
 
 # Design de Fluxo de Usuário
 
-Você é um Especialista UX/Ergonomia. Você deve projetar um fluxo de usuário (user flow) completo e otimizado.
+Você é um Especialista em UX/Ergonomia. Você deve projetar um fluxo de usuário completo e otimizado.
 
 ## Argumentos
 $ARGUMENTS
 
 Argumentos:
 - Nome do fluxo a projetar
-- (Opcional) Persona alvo
+- (Opcional) Persona-alvo
 - (Opcional) Restrições específicas
 
-Exemplo: `/uiux:user-flow "Registro de usuário"` ou `/uiux:user-flow "Checkout" persona:"Usuário mobile" restricao:"< 30 segundos"`
+Exemplo: `/uiux:user-flow "Cadastro de usuário"` ou `/uiux:user-flow "Checkout" persona:"Usuário mobile" constraint:"< 30 segundos"`
 
-## Modo Plano
+## Modo de Planejamento
 
-> **O modo plano é recomendado.** Claude ativa o modo plano para estruturar a abordagem, identificar dependências e apresentar uma estratégia de geração antes de criar artefatos.
+> **O modo de planejamento é recomendado.** Claude ativa o modo de planejamento para estruturar a abordagem, identificar dependências e apresentar uma estratégia de geração antes de criar os artefatos.
 
 ## MISSÃO
 
 ### Etapa 1: Definir o contexto
 
 - Objetivo do usuário
-- Persona alvo
+- Persona-alvo
 - Contexto de uso (dispositivo, ambiente)
 - Restrições de negócio
 
@@ -48,8 +48,8 @@ Versão: 1.0
 | Atributo | Valor |
 |----------|-------|
 | Nome | {persona} |
-| Papel | {papel} |
-| Nível técnico | Iniciante / Intermediário / Especialista |
+| Função | {função} |
+| Nível técnico | Iniciante / Intermediário / Avançado |
 | Dispositivo principal | Mobile / Desktop / Ambos |
 | Contexto | {ambiente de uso} |
 
@@ -57,38 +57,195 @@ Versão: 1.0
 > "{O que o usuário quer realizar}"
 
 ### Objetivo de negócio
-> "{O que o negócio quer obter}"
+> "{O que a empresa quer alcançar}"
+
+### Restrições
+- Tempo máximo: {X segundos/minutos}
+- Etapas máximas: {Y}
+- Dispositivo: {restrições técnicas}
+- Offline: Sim / Não
+
+──────────────────────────────────────────────────────────────
+🗺️ VISÃO GERAL
+──────────────────────────────────────────────────────────────
+
+```
+┌──────┐    ┌──────┐    ┌──────┐    ┌──────┐    ┌──────┐
+│Início│───▶│Etapa1│───▶│Etapa2│───▶│Etapa3│───▶│ Fim  │
+└──────┘    └──────┘    └──────┘    └──────┘    └──────┘
+                │            │
+                ▼            ▼
+           ┌────────┐   ┌────────┐
+           │Erro A  │   │Erro B  │
+           └────────┘   └────────┘
+```
 
 ──────────────────────────────────────────────────────────────
 📋 FLUXO DETALHADO
 ──────────────────────────────────────────────────────────────
 
 ### Etapa 0: Gatilho
+
 **Ponto de entrada**: {Como o usuário chega}
+- Via: {menu / link / CTA / deep link}
+- Estado anterior: {autenticado / anônimo / dados existentes}
+- Pré-condições: {o que deve ser verdadeiro}
+
+---
 
 ### Etapa 1: {Nome da etapa}
+
 **Tela**: {Nome da tela}
 **Objetivo**: {O que o usuário deve fazer}
 
 #### Ações disponíveis
-| Ação | Elemento UI | Resultado |
-|------|-------------|-----------|
-| Principal | {botão/link} | Passa para etapa 2 |
+| Ação | Elemento de IU | Resultado |
+|------|----------------|-----------|
+| Primária | {botão/link} | Avança para a etapa 2 |
+| Secundária | {botão/link} | {alternativa} |
+| Terciária | {link} | {outra opção} |
+
+#### Dados necessários
+| Campo | Tipo | Validação | Obrigatório |
+|-------|------|-----------|-------------|
+| {campo} | {tipo} | {regras} | Sim/Não |
 
 #### Feedback do sistema
 | Evento | Feedback | Tipo |
 |--------|----------|------|
+| Foco no campo | {feedback} | Visual |
 | Erro de validação | {mensagem} | Inline |
+| Sucesso | {feedback} | Toast/inline |
+
+#### Pontos de atenção
+- ⚠️ {possível ponto de atrito}
+- 💡 {oportunidade de melhoria}
+
+---
+
+### Etapa 2: {Nome da etapa}
+
+{Mesma estrutura...}
+
+---
+
+### Etapa N: Confirmação (Fim)
+
+**Tela**: {Confirmação / Sucesso}
+**Estado final**: {O que foi realizado}
+
+#### Conteúdo
+- Mensagem de sucesso
+- Resumo da ação
+- Próximos passos sugeridos
+
+#### Próximas ações
+| Ação | Destino |
+|------|---------|
+| CTA Primário | {próximo fluxo} |
+| Voltar | {painel/lista} |
+| Compartilhar | {se aplicável} |
 
 ──────────────────────────────────────────────────────────────
-📊 MÉTRICAS & KPIs
+⚠️ CAMINHOS ALTERNATIVOS
 ──────────────────────────────────────────────────────────────
+
+### Erro: {Tipo de erro}
+
+**Gatilho**: {O que causa o erro}
+**Tela**: {Inline / Modal / Página dedicada}
+
+#### Mensagem de erro
+```
+Título: {Título claro}
+Descrição: {Explicação do problema}
+Ação: {Como resolver}
+```
+
+#### Opções do usuário
+- Tentar novamente: {comportamento}
+- Modificar: {retornar à etapa X}
+- Abandonar: {estado salvo?}
+
+---
+
+### Abandono: Salvamento de estado
+
+**Comportamento**:
+- Rascunho salvo automaticamente
+- Duração de retenção: {X dias}
+- Notificação de lembrete: Sim / Não
+
+---
+
+### Caso extremo: {Descrição}
+
+**Situação**: {Contexto particular}
+**Comportamento**: {Adaptação do fluxo}
+
+──────────────────────────────────────────────────────────────
+📊 MÉTRICAS E KPIs
+──────────────────────────────────────────────────────────────
+
+### Objetivos quantitativos
 
 | Métrica | Objetivo | Medição |
 |---------|----------|---------|
 | Tempo de conclusão | < {X} seg | Time-on-task |
-| Taxa de conclusão | > {Y}% | Funnel analytics |
+| Taxa de conclusão | > {Y}% | Funil analítico |
+| Taxa de erro | < {Z}% | Error rate |
 | Número de cliques | ≤ {N} | Click tracking |
+| Pontuação de satisfação | > {S}/5 | Pesquisa pós-tarefa |
+
+### Pontos de medição
+
+| Etapa | Evento a rastrear |
+|-------|-------------------|
+| Entrada | `flow_started` |
+| Etapa 1 | `step_1_completed` |
+| Etapa 2 | `step_2_completed` |
+| Sucesso | `flow_completed` |
+| Abandono | `flow_abandoned` com `last_step` |
+| Erro | `flow_error` com `error_type` |
+
+──────────────────────────────────────────────────────────────
+🧠 ERGONOMIA
+──────────────────────────────────────────────────────────────
+
+### Carga cognitiva
+
+| Etapa | Complexidade | Justificativa |
+|-------|-------------|---------------|
+| 1 | Baixa | {1-2 ações simples} |
+| 2 | Média | {formulário curto} |
+| 3 | Baixa | {somente confirmação} |
+
+### Princípios aplicados
+
+| Princípio | Aplicação |
+|-----------|-----------|
+| Divulgação progressiva | {como} |
+| Valores padrão | {quais} |
+| Validação inline | {quando} |
+| Salvamento automático | {frequência} |
+
+──────────────────────────────────────────────────────────────
+♿ ACESSIBILIDADE
+──────────────────────────────────────────────────────────────
+
+### Navegação por teclado
+- Ordem de tabulação: {sequência lógica}
+- Links de salto: {se formulário longo}
+- Gestão do foco: {na mudança de etapa}
+
+### Leitor de tela
+- Anúncio de etapa: "Etapa X de Y"
+- Erros: aria-live="assertive"
+- Progresso: aria-describedby
+
+### Tempo
+- Sem limite de tempo automático
+- Se houver atraso: extensível ou desativável
 
 ──────────────────────────────────────────────────────────────
 ✅ CHECKLIST DE VALIDAÇÃO
@@ -96,18 +253,24 @@ Versão: 1.0
 
 ### UX
 - [ ] Objetivo do usuário claro
-- [ ] Etapas mínimas necessárias
+- [ ] Mínimo de etapas necessárias
 - [ ] Feedback em cada ação
 - [ ] Caminhos de erro documentados
+- [ ] Abandono com salvamento
+
+### Mensurabilidade
+- [ ] KPIs definidos
+- [ ] Eventos de rastreamento listados
+- [ ] Objetivos quantificados
 
 ### Acessibilidade
 - [ ] Navegação por teclado
-- [ ] Anúncios SR
+- [ ] Anúncios para leitor de tela
 - [ ] Sem limites de tempo
 ```
 
 ### Etapa 3: Validação
 
-- Revisão com stakeholders
-- Teste de usuário (5 usuários mín)
-- Iteração baseada em feedback
+- Revisão com as partes interessadas
+- Teste com usuários (mínimo 5 usuários)
+- Iteração com base no feedback

--- a/Dev/i18n/pt/VueJS/commands/check-compliance.md
+++ b/Dev/i18n/pt/VueJS/commands/check-compliance.md
@@ -1,128 +1,253 @@
 ---
-description: Audit Vue.js project compliance with coding standards and best practices
+description: Verificar Conformidade Completa do Vue.js
+argument-hint: [arguments]
 ---
 
-# Vue.js Compliance Audit
+# Verificar Conformidade Completa do Vue.js
 
-You are an expert Vue.js auditor. Perform a comprehensive compliance check on this project.
+## Argumentos
 
-## MISSION
+$ARGUMENTS (opcional: caminho para o projeto a analisar)
 
-Audit the project for compliance with Vue.js 3 best practices, Composition API standards, and TypeScript conventions.
+## Modo de Planejamento
 
-## Modo Plano
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou requer investigação transversal.
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
+## MISSÃO
 
-## AUDIT CHECKLIST
+Realizar uma auditoria de conformidade completa do projeto Vue.js orquestrando as 4 verificações principais: Arquitetura, Qualidade de Código, Testes e Segurança. Produzir um relatório consolidado com uma pontuação geral de 100 pontos.
 
-### 1. Project Structure (20 points)
+### Etapa 1: Preparação da Auditoria
+
+Preparar o ambiente de auditoria:
+- [ ] Identificar o caminho do projeto a auditar
+- [ ] Verificar a presença de arquivos de configuração (package.json, tsconfig.json, vite.config.ts)
+- [ ] Listar os diretórios principais (src/, tests/, public/, etc.)
+- [ ] Identificar a estrutura do projeto e a versão do Vue.js
+
+**Nota**: Se $ARGUMENTS for fornecido, utilizá-lo como caminho do projeto; caso contrário, usar o diretório atual.
+
+### Etapa 2: Auditoria de Arquitetura (25 pontos)
+
+Executar a verificação completa de arquitetura:
+
+**Comando**: Usar o slash command `/vuejs:check-architecture` ou seguir manualmente os passos em `check-architecture.md`
+
+**Critérios Avaliados**:
+- Organização de componentes e funcionalidades (6 pts)
+- Estrutura e reutilização de composables (6 pts)
+- Arquitetura da store Pinia (4 pts)
+- Configuração do router e lazy loading (4 pts)
+- Separação do módulo Shared/common (3 pts)
+- Regras de dependência e barrel exports (2 pts)
+
+**Referência**: `check-architecture.md`
+
+### Etapa 3: Auditoria de Qualidade de Código (25 pontos)
+
+Executar a verificação de qualidade de código:
+
+**Comando**: Usar o slash command `/vuejs:check-code-quality` ou seguir manualmente os passos em `check-code-quality.md`
+
+**Critérios Avaliados**:
+- Modo estrito do TypeScript e segurança de tipos (5 pts)
+- Conformidade com ESLint e Prettier (5 pts)
+- Uso da Composition API e script setup (4 pts)
+- Princípios KISS/DRY/YAGNI (4 pts)
+- Convenções de nomenclatura (4 pts)
+- Tratamento de erros (3 pts)
+
+**Referência**: `check-code-quality.md`
+
+### Etapa 4: Auditoria de Testes (25 pontos)
+
+Executar a verificação de testes:
+
+**Comando**: Usar o slash command `/vuejs:check-testing` ou seguir manualmente os passos em `check-testing.md`
+
+**Critérios Avaliados**:
+- Cobertura de código (7 pts)
+- Testes unitários para composables e stores (6 pts)
+- Testes de componentes com Vue Test Utils (4 pts)
+- Testes de integração (3 pts)
+- Qualidade dos testes e padrão AAA (3 pts)
+- Organização de mocks e fixtures (2 pts)
+
+**Referência**: `check-testing.md`
+
+### Etapa 5: Auditoria de Segurança (25 pontos)
+
+Executar a verificação de segurança:
+
+**Comando**: Usar o slash command `/vuejs:check-security` ou seguir manualmente os passos em `check-security.md`
+
+**Critérios Avaliados**:
+- Prevenção de XSS (uso de v-html) (6 pts)
+- Gestão de segredos e credenciais (5 pts)
+- Validação e sanitização de entradas (4 pts)
+- Vulnerabilidades de dependências (4 pts)
+- Autenticação e guardas de rota (3 pts)
+- Comunicação segura com APIs (2 pts)
+- Proteção CSRF (1 pt)
+
+**Referência**: `check-security.md`
+
+### Etapa 6: Consolidação e Pontuação Global
+
+Calcular a pontuação geral e produzir o relatório consolidado:
+- [ ] Somar as 4 pontuações (máximo de 100 pontos)
+- [ ] Identificar categorias críticas (<50%)
+- [ ] Listar todos os problemas transversais críticos
+- [ ] Priorizar ações por impacto/esforço
+- [ ] Produzir o relatório consolidado final
+
+**Escala de Avaliação**:
+- 90-100: Excelente — Projeto de referência
+- 75-89: Muito Bom — Algumas melhorias menores
+- 60-74: Aceitável — Requer melhorias
+- 40-59: Insuficiente — Refatoração significativa necessária
+- 0-39: Crítico — Revisão completa necessária
+
+### Etapa 7: Recomendações e Plano de Ação
+
+Produzir as recomendações finais:
+- [ ] Identificar as 3 ações prioritárias em todas as categorias
+- [ ] Estimar o esforço (Baixo/Médio/Alto) para cada ação
+- [ ] Estimar o impacto (Baixo/Médio/Alto) para cada ação
+- [ ] Propor a ordem de implementação
+- [ ] Sugerir ganhos rápidos (alta relação impacto/esforço)
+
+## FORMATO DE SAÍDA
 
 ```
-[ ] src/components/ - Shared components organized
-[ ] src/composables/ - Composition functions present
-[ ] src/stores/ - Pinia stores properly structured
-[ ] src/router/ - Vue Router configuration
-[ ] src/types/ - TypeScript types defined
-[ ] src/services/ - API services separated
+AUDITORIA DE CONFORMIDADE VUE.JS - RELATÓRIO COMPLETO
+======================================================
+
+PONTUAÇÃO GERAL: XX/100
+
+NÍVEL DE CONFORMIDADE: [Excelente/Muito Bom/Aceitável/Insuficiente/Crítico]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PONTUAÇÕES POR CATEGORIA:
+
+ARQUITETURA        : XX/25  [██████████░░░░░░░░░░] XX%
+QUALIDADE DE CÓDIGO: XX/25  [██████████░░░░░░░░░░] XX%
+TESTES             : XX/25  [██████████░░░░░░░░░░] XX%
+SEGURANÇA          : XX/25  [██████████░░░░░░░░░░] XX%
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PONTOS FORTES GERAIS:
+1. [Ponto forte identificado em múltiplas categorias]
+2. [Outro ponto forte principal]
+3. [Terceiro ponto forte]
+
+MELHORIAS GERAIS:
+1. [Melhoria transversal menor]
+2. [Outra melhoria recomendada]
+3. [Terceira melhoria]
+
+PROBLEMAS CRÍTICOS:
+1. [Problema crítico nº 1 - categoria afetada]
+2. [Problema crítico nº 2 - categoria afetada]
+3. [Problema crítico nº 3 - categoria afetada]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+DETALHES POR CATEGORIA:
+
+┌─────────────────────────────────────────────┐
+│ ARQUITETURA (XX/25)                         │
+└─────────────────────────────────────────────┘
+
+Sub-pontuações:
+  • Organização de componentes/funcionalidades: XX/6
+  • Estrutura de composables               : XX/6
+  • Arquitetura da store Pinia             : XX/4
+  • Router e lazy loading                  : XX/4
+  • Separação do módulo shared             : XX/3
+  • Regras de dependência                  : XX/2
+
+Pontos Fortes:
+- [Pontos fortes de arquitetura]
+
+Problemas:
+- [Problemas de arquitetura]
+
+[Seções semelhantes para Qualidade de Código, Testes e Segurança...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+TOP 3 AÇÕES PRIORITÁRIAS (TODAS AS CATEGORIAS):
+
+1. CRÍTICO - [Ação nº 1]
+   Categoria : [Arquitetura/Qualidade/Testes/Segurança]
+   Impacto   : [Alto/Médio/Baixo]
+   Esforço   : [Alto/Médio/Baixo]
+   Prioridade: IMEDIATA
+
+   Descrição detalhada:
+   [Explicação do problema e solução proposta]
+
+   Arquivos afetados:
+   - [arquivo:linha]
+
+   Exemplo de correção:
+   [Código ou comando de correção]
+
+2. IMPORTANTE - [Ação nº 2]
+   [Mesmo formato...]
+
+3. RECOMENDADO - [Ação nº 3]
+   [Mesmo formato...]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+GANHOS RÁPIDOS (Alto Impacto / Baixo Esforço):
+
+- [Ganho rápido nº 1] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Ganho rápido nº 2] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+- [Ganho rápido nº 3] - Categoria: [X] - Impacto: [X] - Esforço: [X]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+PLANO DE AÇÃO RECOMENDADO:
+
+SEMANA 1 (Imediato):
+- [ ] [Ação crítica nº 1]
+- [ ] [Ganho rápido prioritário]
+
+SEMANAS 2-4 (Curto prazo):
+- [ ] [Ação importante nº 2]
+- [ ] [Outros ganhos rápidos]
+
+MESES 2-3 (Médio prazo):
+- [ ] [Ação recomendada nº 3]
+- [ ] [Melhorias progressivas]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+RESUMO EXECUTIVO:
+
+[Parágrafo de síntese sobre o estado geral do projeto, principais pontos
+fortes, principais pontos fracos e a trajetória recomendada para melhorar
+a conformidade. Indicar se o projeto está pronto para produção,
+requer correções ou necessita de refatoração.]
+
+Recomendação Geral: [Pronto para produção / Correções menores /
+Refatoração significativa / Revisão completa necessária]
+
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 ```
 
-### 2. Component Standards (25 points)
+## NOTAS IMPORTANTES
 
-```
-[ ] Using <script setup> syntax
-[ ] TypeScript with lang="ts"
-[ ] Props defined with defineProps<T>()
-[ ] Emits defined with defineEmits<T>()
-[ ] Components are multi-word named
-[ ] Base components use Base prefix
-```
-
-### 3. Composition API (20 points)
-
-```
-[ ] No Options API in new components
-[ ] Composables follow use* naming
-[ ] Reactive state properly typed
-[ ] Computed properties used correctly
-[ ] Watchers cleaned up
-```
-
-### 4. Pinia Stores (15 points)
-
-```
-[ ] Setup syntax stores (composition style)
-[ ] Proper TypeScript typing
-[ ] Actions are async when needed
-[ ] Getters use computed
-[ ] No direct state mutation from components
-```
-
-### 5. TypeScript Integration (20 points)
-
-```
-[ ] Strict mode enabled
-[ ] No implicit any
-[ ] Props and emits fully typed
-[ ] Interfaces for complex types
-[ ] Type-only imports used
-```
-
-## OUTPUT FORMAT
-
-```
-══════════════════════════════════════════════════════════════
-VUE.JS COMPLIANCE AUDIT
-══════════════════════════════════════════════════════════════
-
-📊 SUMMARY
-──────────────────────────────────────────────────────────────
-Total Score: XX/100
-Status: ✅ COMPLIANT | ⚠️ NEEDS WORK | ❌ NON-COMPLIANT
-
-📁 PROJECT STRUCTURE: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Organized component structure
-[✗] Missing composables directory
-    → Create src/composables/ for reusable logic
-
-🧩 COMPONENT STANDARDS: XX/25
-──────────────────────────────────────────────────────────────
-[✓] Using <script setup>
-[✗] Some components use Options API
-    Files: src/components/OldComponent.vue
-    → Migrate to Composition API
-
-🔧 COMPOSITION API: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Composables properly named
-[✗] Missing cleanup in watchers
-    File: src/composables/useData.ts:45
-
-🏪 PINIA STORES: XX/15
-──────────────────────────────────────────────────────────────
-[✓] Setup syntax used
-[✓] Proper typing
-
-📝 TYPESCRIPT: XX/20
-──────────────────────────────────────────────────────────────
-[✓] Strict mode enabled
-[✗] Implicit any found
-    File: src/utils/helpers.ts:12
-
-📋 RECOMMENDATIONS
-──────────────────────────────────────────────────────────────
-1. [HIGH] Migrate remaining Options API components
-2. [MEDIUM] Add missing type definitions
-3. [LOW] Organize composables by feature
-
-══════════════════════════════════════════════════════════════
-```
-
-## PROCESS
-
-1. Scan project structure
-2. Analyze component files for standards
-3. Check composables and stores
-4. Verify TypeScript configuration
-5. Generate compliance report with score
+- Este comando orquestra as 4 auditorias especializadas
+- Usar Docker para todas as ferramentas de análise
+- Fornecer exemplos concretos com arquivo:linha para cada problema
+- Priorizar ações com base na matriz Impacto/Esforço
+- Problemas de segurança são SEMPRE a prioridade máxima
+- Propor correções automatizáveis (scripts, hooks de pré-commit)
+- O relatório deve ser acionável, não apenas descritivo
+- Adaptar as recomendações ao contexto de negócio do projeto

--- a/Dev/i18n/pt/Workflow/commands/analyze.md
+++ b/Dev/i18n/pt/Workflow/commands/analyze.md
@@ -1,208 +1,209 @@
 ---
 name: workflow-analyze
-description: Executar a fase de Analise - pesquisa, exploracao e identificacao de restricoes
+description: Executar a fase de Análise - pesquisa, exploração e identificação de restrições
 arguments:
   - name: focus
-    description: Area especifica a analisar (mercado, tecnica, concorrentes)
+    description: Área específica a analisar (mercado, técnica, concorrentes)
     required: false
 ---
 
 # /workflow:analyze
 
-## Missao
+## Missão
 
-Executar a fase de Analise do workflow Enterprise. Esta fase foca na pesquisa, exploracao e identificacao de restricoes antes do inicio do planejamento detalhado.
+Executar a fase de Análise do fluxo de trabalho Enterprise. Esta fase foca-se em pesquisa, exploração e identificação de restrições antes de que o planejamento detalhado seja iniciado.
 
-## Modo Plano
+## Quando Usar
 
-> O modo plano é ativado automaticamente quando o escopo abrange vários módulos ou requer investigação transversal.
-
-## Quando Utilizar
-
-- Projetos no track **Enterprise**
+- Projetos do **track Enterprise**
 - Novas plataformas ou iniciativas de grande porte
-- Quando o conhecimento do dominio e limitado
-- Antes de se comprometer com uma abordagem tecnica
+- Quando o conhecimento do domínio é limitado
+- Antes de se comprometer com uma abordagem técnica
 
-## Workflow
+## Modo de Planejamento
 
-### Etapa 1: Configuracao da Analise
+> O modo de planejamento é ativado automaticamente quando o escopo abrange múltiplos módulos ou exige investigação transversal.
 
-```
-+==============================================================+
-|            FASE DE ANALISE - INICIANDO                          |
-+================================================================+
-| Track: Enterprise                                               |
-| Fase: 1 de 4 - Analise                                         |
-|                                                                 |
-| Objetivos:                                                      |
-| - Compreender o dominio do problema                             |
-| - Pesquisar solucoes existentes                                 |
-| - Identificar restricoes tecnicas                               |
-| - Documentar riscos e oportunidades                             |
-+================================================================+
-```
+## Fluxo de Trabalho
 
-### Etapa 2: Areas de Pesquisa
-
-**Perguntas de pesquisa guiadas:**
+### Etapa 1: Configuração da Análise
 
 ```
-+-------------------------------------------------------------+
-| PESQUISA DE DOMINIO                                           |
-+-------------------------------------------------------------+
-| 1. Qual problema estamos resolvendo?                          |
-| 2. Quem sao os principais stakeholders?                       |
-| 3. Quais sao os motivadores de negocio?                       |
-| 4. Como se define o sucesso?                                  |
-+-------------------------------------------------------------+
-
-+-------------------------------------------------------------+
-| PESQUISA DE MERCADO                                           |
-+-------------------------------------------------------------+
-| 1. Quais solucoes existentes ha?                              |
-| 2. O que os concorrentes estao fazendo?                       |
-| 3. Quais sao as melhores praticas do setor?                   |
-| 4. Quais sao as tendencias emergentes?                        |
-+-------------------------------------------------------------+
-
-+-------------------------------------------------------------+
-| PESQUISA TECNICA                                              |
-+-------------------------------------------------------------+
-| 1. Quais tecnologias poderiamos utilizar?                     |
-| 2. Quais sao os requisitos de integracao?                     |
-| 3. Quais sao as necessidades de escalabilidade?               |
-| 4. Quais requisitos de seguranca/conformidade existem?        |
-+-------------------------------------------------------------+
+╔══════════════════════════════════════════════════════════╗
+║            FASE DE ANÁLISE - INICIANDO                    ║
+╠══════════════════════════════════════════════════════════╣
+║ Track: Enterprise                                         ║
+║ Fase: 1 de 4 - Análise                                    ║
+║                                                           ║
+║ Objetivos:                                                ║
+║ • Compreender o domínio do problema                       ║
+║ • Pesquisar soluções existentes                           ║
+║ • Identificar restrições técnicas                         ║
+║ • Documentar riscos e oportunidades                       ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
-### Etapa 3: Pesquisa Context7 (Opcional)
+### Etapa 2: Áreas de Pesquisa
 
-Se o MCP Context7 estiver configurado, utilize-o para pesquisa tecnica:
+**Perguntas-Guia de Pesquisa:**
 
 ```
-Utilizando MCP Context7 para documentacao atualizada...
+┌─────────────────────────────────────────────────────────┐
+│ PESQUISA DE DOMÍNIO                                      │
+├─────────────────────────────────────────────────────────┤
+│ 1. Qual problema estamos resolvendo?                     │
+│ 2. Quais são os principais stakeholders?                 │
+│ 3. Quais são os motivadores do negócio?                  │
+│ 4. Como é definido o sucesso esperado?                   │
+└─────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────┐
+│ PESQUISA DE MERCADO                                      │
+├─────────────────────────────────────────────────────────┤
+│ 1. Quais soluções existentes estão disponíveis?          │
+│ 2. O que os concorrentes estão fazendo?                  │
+│ 3. Quais são as melhores práticas do setor?              │
+│ 4. Quais são as tendências emergentes?                   │
+└─────────────────────────────────────────────────────────┘
+
+┌─────────────────────────────────────────────────────────┐
+│ PESQUISA TÉCNICA                                         │
+├─────────────────────────────────────────────────────────┤
+│ 1. Quais tecnologias poderíamos utilizar?                │
+│ 2. Quais são os requisitos de integração?                │
+│ 3. Quais são as necessidades de escalabilidade?          │
+│ 4. Quais requisitos de segurança/conformidade existem?   │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Etapa 3: Pesquisa com Context7 (Opcional)
+
+Se o MCP Context7 estiver configurado, utilize-o para pesquisa técnica:
+
+```
+Usando Context7 MCP para documentação atualizada...
 
 Pesquisando:
-- Melhores praticas atuais da API Stripe
-- Padroes de seguranca atuais para processamento de pagamentos
-- Requisitos de conformidade PCI DSS
+• Melhores práticas atuais da API Stripe
+• Padrões de segurança vigentes para processamento de pagamentos
+• Requisitos de conformidade PCI DSS
 ```
 
-### Etapa 4: Identificacao de Restricoes
+### Etapa 4: Identificação de Restrições
 
-Documentar as restricoes descobertas:
-
-```
-+==============================================================+
-|               RESTRICOES IDENTIFICADAS                          |
-+================================================================+
-|                                                                 |
-| RESTRICOES TECNICAS:                                            |
-| - Deve integrar com backend Symfony 7.x existente               |
-| - Banco de dados: PostgreSQL (existente, nao pode mudar)        |
-| - Deve suportar apps moveis via API existente                   |
-|                                                                 |
-| RESTRICOES DE NEGOCIO:                                          |
-| - Orcamento: Limitado a equipe existente                        |
-| - Prazo: MVP necessario no Q2 2026                              |
-| - Deve manter compatibilidade retroativa                        |
-|                                                                 |
-| RESTRICOES REGULATORIAS:                                        |
-| - Conformidade LGPD necessaria (usuarios BR)                    |
-| - PCI DSS para processamento de pagamentos                     |
-|                                                                 |
-| RESTRICOES DE RECURSOS:                                         |
-| - Equipe: 2 backend, 1 frontend developer                      |
-| - Sem recurso dedicado de DevOps                                |
-|                                                                 |
-+================================================================+
-```
-
-### Etapa 5: Analise de Riscos e Oportunidades
+Documente as restrições descobertas:
 
 ```
-+==============================================================+
-|            RISCOS E OPORTUNIDADES                               |
-+================================================================+
-|                                                                 |
-| RISCOS:                                                         |
-| +---------+----------+------------+-------------------+         |
-| | Risco   | Impacto  | Prob.      | Mitigacao          |        |
-| +---------+----------+------------+-------------------+         |
-| | Stripe  | Alto     | Baixa      | Provedor fallback  |        |
-| | fora ar |          |            |                    |        |
-| +---------+----------+------------+-------------------+         |
-| | Atraso  | Medio    | Media      | Reducao do escopo  |        |
-| | prazo   |          |            | do MVP             |        |
-| +---------+----------+------------+-------------------+         |
-|                                                                 |
-| OPORTUNIDADES:                                                  |
-| - Possibilidade de usar novos Payment Elements do Stripe        |
-| - Potencial para expansao do modelo de assinatura               |
-| - Pagamento mobile (Apple Pay, Google Pay) pronto               |
-|                                                                 |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║               RESTRIÇÕES IDENTIFICADAS                    ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ RESTRIÇÕES TÉCNICAS:                                      ║
+║ • Deve integrar com o backend Symfony 7.x existente       ║
+║ • Banco de dados: PostgreSQL (existente, não pode mudar)  ║
+║ • Deve suportar apps mobile via API existente             ║
+║                                                           ║
+║ RESTRIÇÕES DE NEGÓCIO:                                    ║
+║ • Orçamento: Limitado à equipe atual                      ║
+║ • Prazo: MVP necessário no Q2 2026                        ║
+║ • Deve manter compatibilidade retroativa                  ║
+║                                                           ║
+║ RESTRIÇÕES REGULATÓRIAS:                                  ║
+║ • Conformidade com LGPD/GDPR obrigatória (usuários UE)    ║
+║ • PCI DSS para processamento de pagamentos                ║
+║                                                           ║
+║ RESTRIÇÕES DE RECURSOS:                                   ║
+║ • Equipe: 2 backend, 1 desenvolvedor frontend             ║
+║ • Sem recurso dedicado de DevOps                          ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
-### Etapa 6: Gerar Artefatos da Analise
+### Etapa 5: Análise de Riscos e Oportunidades
 
-Criar documentos de analise:
+```
+╔══════════════════════════════════════════════════════════╗
+║            RISCOS E OPORTUNIDADES                         ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ RISCOS:                                                   ║
+║ ┌─────────┬──────────┬────────────┬───────────────────┐  ║
+║ │ Risco   │ Impacto  │ Probab.    │ Mitigação         │  ║
+║ ├─────────┼──────────┼────────────┼───────────────────┤  ║
+║ │ Stripe  │ Alto     │ Baixa      │ Provedor de       │  ║
+║ │ fora do │          │            │ contingência      │  ║
+║ │ ar      │          │            │                   │  ║
+║ ├─────────┼──────────┼────────────┼───────────────────┤  ║
+║ │ Atraso  │ Médio    │ Média      │ Redução de        │  ║
+║ │ no prazo│          │            │ escopo do MVP     │  ║
+║ └─────────┴──────────┴────────────┴───────────────────┘  ║
+║                                                           ║
+║ OPORTUNIDADES:                                            ║
+║ • Pode aproveitar os novos Payment Elements do Stripe     ║
+║ • Potencial para expansão do modelo de assinatura         ║
+║ • Pronto para pagamento mobile (Apple Pay, Google Pay)    ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
+```
+
+### Etapa 6: Geração de Artefatos de Análise
+
+Crie os documentos de análise:
 
 ```
 project-management/
 └── analysis/
     ├── research-summary.md      # Principais descobertas
-    ├── constraints.md           # Todas as restricoes identificadas
+    ├── constraints.md           # Todas as restrições identificadas
     ├── risks-opportunities.md   # Registro de riscos e oportunidades
-    └── technical-options.md     # Avaliacao de tecnologias
+    └── technical-options.md     # Avaliação de tecnologias
 ```
 
-### Etapa 7: Conclusao da Fase
+### Etapa 7: Conclusão da Fase
 
 ```
-+==============================================================+
-|            FASE DE ANALISE CONCLUIDA                            |
-+================================================================+
-|                                                                 |
-| Artefatos Criados:                                              |
-| - research-summary.md                                           |
-| - constraints.md                                                |
-| - risks-opportunities.md                                        |
-| - technical-options.md                                          |
-|                                                                 |
-| Principais Descobertas:                                         |
-| - 4 restricoes tecnicas identificadas                           |
-| - 3 restricoes de negocio identificadas                         |
-| - 5 riscos documentados com mitigacoes                          |
-| - 3 oportunidades para consideracao                             |
-|                                                                 |
-| ------------------------------------------------------------- |
-| PROXIMA FASE: Planejamento                                      |
-| Comando: /workflow:plan                                         |
-| ------------------------------------------------------------- |
-|                                                                 |
-| A analise ira informar a criacao do PRD e a arquitetura.        |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║            FASE DE ANÁLISE CONCLUÍDA                      ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Artefatos Criados:                                        ║
+║ ✅ research-summary.md                                    ║
+║ ✅ constraints.md                                         ║
+║ ✅ risks-opportunities.md                                 ║
+║ ✅ technical-options.md                                   ║
+║                                                           ║
+║ Principais Descobertas:                                   ║
+║ • 4 restrições técnicas identificadas                     ║
+║ • 3 restrições de negócio identificadas                   ║
+║ • 5 riscos documentados com mitigações                    ║
+║ • 3 oportunidades para consideração                       ║
+║                                                           ║
+║ ─────────────────────────────────────────────────────────║
+║ PRÓXIMA FASE: Planejamento                                ║
+║ Comando: /workflow:plan                                   ║
+║ ─────────────────────────────────────────────────────────║
+║                                                           ║
+║ A análise embasará a criação do PRD e a arquitetura.      ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
 ## Agentes Envolvidos
 
-- **research-assistant**: Pesquisa tecnica e consulta de documentacao
-- **product-owner**: Contexto de negocio e analise de stakeholders
+- **research-assistant**: Pesquisa técnica e consulta de documentação
+- **product-owner**: Contexto de negócio e análise de stakeholders
 
-## Arquivos de Saida
+## Arquivos de Saída
 
 | Arquivo | Finalidade |
-|---------|------------|
-| `analysis/research-summary.md` | Descobertas de pesquisa consolidadas |
-| `analysis/constraints.md` | Restricoes tecnicas, de negocio, regulatorias |
-| `analysis/risks-opportunities.md` | Registro de riscos com mitigacoes |
-| `analysis/technical-options.md` | Avaliacao e recomendacoes de tecnologias |
+|---------|-----------|
+| `analysis/research-summary.md` | Descobertas consolidadas da pesquisa |
+| `analysis/constraints.md` | Restrições técnicas, de negócio e regulatórias |
+| `analysis/risks-opportunities.md` | Registro de riscos com mitigações |
+| `analysis/technical-options.md` | Avaliação e recomendações de tecnologias |
 
 ## Comandos Relacionados
 
-- `/workflow:init` - Inicializar workflow (deve ser executado primeiro)
-- `/workflow:plan` - Proxima fase: Planejamento
-- `/workflow:status` - Verificar progresso
-- `/common:research-context7` - Pesquisa aprofundada com MCP Context7
+- `/workflow:init` - Inicializar o fluxo de trabalho (deve ser executado primeiro)
+- `/workflow:plan` - Próxima fase: Planejamento
+- `/workflow:status` - Verificar o progresso
+- `/common:research-context7` - Pesquisa aprofundada com Context7 MCP

--- a/Dev/i18n/pt/Workflow/commands/design.md
+++ b/Dev/i18n/pt/Workflow/commands/design.md
@@ -1,6 +1,6 @@
 ---
 name: workflow-design
-description: Executar a fase de Design (Solutioning) - especificacao tecnica e arquitetura
+description: Executar a fase de Design (Solução) - especificação técnica e arquitetura
 arguments:
   - name: continue
     description: Continuar de onde parou
@@ -9,271 +9,272 @@ arguments:
 
 # /workflow:design
 
-## Missao
+## Missão
 
-Executar a fase de Design (Solutioning) do workflow de desenvolvimento. Esta fase foca na criacao da Especificacao Tecnica, no design da arquitetura e na documentacao das principais decisoes tecnicas.
+Executar a fase de Design (Solução) do fluxo de trabalho de desenvolvimento. Esta fase foca-se na criação da Especificação Técnica, no design da arquitetura e na documentação das principais decisões técnicas.
 
-## Modo Plano
-
-> **O modo plano é recomendado.** Claude ativa o modo plano para estruturar a abordagem, identificar dependências e apresentar uma estratégia de geração antes de criar artefatos.
-
-## Quando Utilizar
+## Quando Usar
 
 - Tracks **Standard** e **Enterprise**
-- Apos `/workflow:plan` estar concluido
-- Quando PRD e backlog estao prontos
+- Após a conclusão de `/workflow:plan`
+- Quando o PRD e o backlog estiverem prontos
 
-## Pre-requisitos
+## Pré-requisitos
 
 - PRD existente em `project-management/prd.md`
 - Backlog existente em `project-management/backlog/`
 
-## Workflow
+## Modo de Planejamento
 
-### Etapa 1: Configuracao do Design
+> **O modo de planejamento é recomendado.** O Claude ativa o modo de planejamento para estruturar a abordagem, identificar dependências e apresentar uma estratégia de geração antes de criar os artefatos.
 
-```
-+==============================================================+
-|              FASE DE DESIGN - INICIANDO                         |
-+================================================================+
-| Track: Standard                                                 |
-| Fase: 3 de 4 - Design (Solutioning)                            |
-|                                                                 |
-| Objetivos:                                                      |
-| - Criar Especificacao Tecnica a partir do PRD                   |
-| - Projetar a arquitetura do sistema (diagramas C4)              |
-| - Definir modelo de dados e design de API                       |
-| - Documentar Architecture Decision Records (ADRs)               |
-| - Planejar a estrategia de testes                               |
-+================================================================+
-```
+## Fluxo de Trabalho
 
-### Etapa 2: Carregar Artefatos do Planejamento
+### Etapa 1: Configuração do Design
 
 ```
-+==============================================================+
-|              CARREGANDO ARTEFATOS DO PLANEJAMENTO               |
-+================================================================+
-|                                                                 |
-| Analise do PRD:                                                 |
-| +-- prd.md carregado                                            |
-| +-- Requisitos funcionais: 12                                   |
-| +-- Requisitos nao-funcionais: 8                                |
-| +-- Integracoes necessarias: 2                                  |
-|                                                                 |
-| Resumo do Backlog:                                              |
-| +-- backlog/ carregado                                          |
-| +-- EPICs: 4                                                    |
-| +-- User Stories: 18                                            |
-| +-- Total de Story Points: 89                                   |
-|                                                                 |
-| Restricoes (se Enterprise):                                     |
-| +-- analysis/constraints.md carregado                           |
-|                                                                 |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║              FASE DE DESIGN - INICIANDO                   ║
+╠══════════════════════════════════════════════════════════╣
+║ Track: Standard                                           ║
+║ Fase: 3 de 4 - Design (Solução)                           ║
+║                                                           ║
+║ Objetivos:                                                ║
+║ • Criar Especificação Técnica a partir do PRD             ║
+║ • Projetar arquitetura do sistema (diagramas C4)          ║
+║ • Definir modelo de dados e design de API                 ║
+║ • Documentar Registros de Decisão de Arquitetura (ADRs)   ║
+║ • Planejar estratégia de testes                           ║
+╚══════════════════════════════════════════════════════════╝
+```
+
+### Etapa 2: Carregamento dos Artefatos de Planejamento
+
+```
+╔══════════════════════════════════════════════════════════╗
+║              CARREGANDO ARTEFATOS DE PLANEJAMENTO         ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Análise do PRD:                                           ║
+║ ├── ✅ prd.md carregado                                   ║
+║ ├── Requisitos funcionais: 12                             ║
+║ ├── Requisitos não-funcionais: 8                          ║
+║ └── Integrações necessárias: 2                            ║
+║                                                           ║
+║ Resumo do Backlog:                                        ║
+║ ├── ✅ backlog/ carregado                                 ║
+║ ├── EPICs: 4                                              ║
+║ ├── User Stories: 18                                      ║
+║ └── Total de Story Points: 89                             ║
+║                                                           ║
+║ Restrições (se Enterprise):                               ║
+║ └── ✅ analysis/constraints.md carregado                  ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
 ### Etapa 3: Tarefas de Design
 
-Executar as tarefas de design em ordem:
+Execute as tarefas de design na ordem indicada:
 
 ```
-+==============================================================+
-|                 TAREFAS DE DESIGN                               |
-+================================================================+
-|                                                                 |
-| [ ] Tarefa 1: Gerar Tech Spec                                  |
-|   Comando: /project:generate-tech-spec                          |
-|   Saida: project-management/tech-spec.md                        |
-|                                                                 |
-| [ ] Tarefa 2: Design de Arquitetura                             |
-|   Criar diagramas C4 (contexto, container, componente)          |
-|   Saida: project-management/architecture/                       |
-|                                                                 |
-| [ ] Tarefa 3: Design do Modelo de Dados                        |
-|   ERD e schema do banco de dados                                |
-|   Saida: project-management/architecture/erd.md                 |
-|                                                                 |
-| [ ] Tarefa 4: Design de API                                    |
-|   Endpoints, payloads, autenticacao                             |
-|   Saida: project-management/architecture/api.md                 |
-|                                                                 |
-| [ ] Tarefa 5: Criar ADRs                                       |
-|   Documentar decisoes tecnicas importantes                      |
-|   Saida: docs/adr/                                              |
-|                                                                 |
-| [ ] Tarefa 6: Revisao de Seguranca                             |
-|   Checklist OWASP, estrategia de autenticacao                   |
-|   Saida: project-management/architecture/security.md            |
-|                                                                 |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║                 TAREFAS DE DESIGN                         ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ □ Tarefa 1: Gerar Especificação Técnica                   ║
+║   Comando: /project:generate-tech-spec                    ║
+║   Saída: project-management/tech-spec.md                  ║
+║                                                           ║
+║ □ Tarefa 2: Design de Arquitetura                         ║
+║   Criar diagramas C4 (contexto, container, componente)    ║
+║   Saída: project-management/architecture/                 ║
+║                                                           ║
+║ □ Tarefa 3: Design do Modelo de Dados                     ║
+║   DER e schema do banco de dados                          ║
+║   Saída: project-management/architecture/erd.md           ║
+║                                                           ║
+║ □ Tarefa 4: Design de API                                 ║
+║   Endpoints, payloads, autenticação                       ║
+║   Saída: project-management/architecture/api.md           ║
+║                                                           ║
+║ □ Tarefa 5: Criar ADRs                                    ║
+║   Documentar decisões técnicas principais                 ║
+║   Saída: docs/adr/                                        ║
+║                                                           ║
+║ □ Tarefa 6: Revisão de Segurança                          ║
+║   Checklist OWASP, estratégia de autenticação             ║
+║   Saída: project-management/architecture/security.md      ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
-### Etapa 4: Executar Geracao do Tech Spec
+### Etapa 4: Execução da Geração da Especificação Técnica
 
 ```
 Iniciando /project:generate-tech-spec...
 
 Analisando requisitos do PRD...
-Detectando padroes do codebase existente...
+Detectando padrões do código existente...
 
-[Workflow de geracao do Tech Spec executa com Q&A interativo]
+[Fluxo de geração da Especificação Técnica executa com perguntas interativas]
 
-Tech Spec criado: project-management/tech-spec.md
+✅ Especificação Técnica criada: project-management/tech-spec.md
 ```
 
 ### Etapa 5: Diagramas de Arquitetura
 
-Gerar diagramas de arquitetura C4:
+Gere os diagramas de arquitetura C4:
 
 ```
-+==============================================================+
-|             DIAGRAMAS DE ARQUITETURA                            |
-+================================================================+
-|                                                                 |
-| C4 Nivel 1 - Contexto do Sistema:                              |
-| +-----------------------------------------------------+        |
-| |                                                     |        |
-| |     [User] -------> [Nosso Sistema] -------> [Stripe]|       |
-| |                         |                           |        |
-| |                         v                           |        |
-| |                    [SendGrid]                       |        |
-| |                                                     |        |
-| +-----------------------------------------------------+        |
-|                                                                 |
-| C4 Nivel 2 - Container:                                        |
-| +-----------------------------------------------------+        |
-| |                                                     |        |
-| |  [React SPA] --> [Symfony API] --> [PostgreSQL]     |        |
-| |                       |                             |        |
-| |                       v                             |        |
-| |                    [Redis]                          |        |
-| |                                                     |        |
-| +-----------------------------------------------------+        |
-|                                                                 |
-| Arquivos criados:                                               |
-| +-- architecture/c4-context.md                                  |
-| +-- architecture/c4-container.md                                |
-| +-- architecture/c4-component.md                                |
-|                                                                 |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║             DIAGRAMAS DE ARQUITETURA                      ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ C4 Nível 1 - Contexto do Sistema:                         ║
+║ ┌─────────────────────────────────────────────────────┐  ║
+║ │                                                     │  ║
+║ │  [Usuário] ──────► [Nosso Sistema] ──────► [Stripe] │  ║
+║ │                          │                          │  ║
+║ │                          ▼                          │  ║
+║ │                     [SendGrid]                      │  ║
+║ │                                                     │  ║
+║ └─────────────────────────────────────────────────────┘  ║
+║                                                           ║
+║ C4 Nível 2 - Container:                                   ║
+║ ┌─────────────────────────────────────────────────────┐  ║
+║ │                                                     │  ║
+║ │  [React SPA] ──► [Symfony API] ──► [PostgreSQL]    │  ║
+║ │                       │                             │  ║
+║ │                       ▼                             │  ║
+║ │                    [Redis]                          │  ║
+║ │                                                     │  ║
+║ └─────────────────────────────────────────────────────┘  ║
+║                                                           ║
+║ Arquivos criados:                                         ║
+║ ├── architecture/c4-context.md                            ║
+║ ├── architecture/c4-container.md                          ║
+║ └── architecture/c4-component.md                          ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
-### Etapa 6: Criacao de ADRs
+### Etapa 6: Criação de ADRs
 
-Documentar decisoes de arquitetura importantes:
-
-```
-+==============================================================+
-|        ARCHITECTURE DECISION RECORDS (ADRs)                     |
-+================================================================+
-|                                                                 |
-| ADRs Criados:                                                   |
-|                                                                 |
-| +-----------------------------------------------------+        |
-| | ADR-001: Escolha do Banco de Dados                   |        |
-| | Decisao: PostgreSQL                                  |        |
-| | Justificativa: Conformidade ACID, suporte JSON       |        |
-| +-----------------------------------------------------+        |
-|                                                                 |
-| +-----------------------------------------------------+        |
-| | ADR-002: Estilo de API                               |        |
-| | Decisao: REST com JSON:API                           |        |
-| | Justificativa: Expertise da equipe, cache, simplicid.|        |
-| +-----------------------------------------------------+        |
-|                                                                 |
-| +-----------------------------------------------------+        |
-| | ADR-003: Autenticacao                                |        |
-| | Decisao: JWT com refresh tokens                      |        |
-| | Justificativa: Stateless, mobile-friendly, padrao    |        |
-| +-----------------------------------------------------+        |
-|                                                                 |
-| Arquivos: docs/adr/ADR-001.md, ADR-002.md, ADR-003.md          |
-|                                                                 |
-+================================================================+
-```
-
-### Etapa 7: Gate de Revisao do Design
+Documente as principais decisões de arquitetura:
 
 ```
-+==============================================================+
-|              GATE DE REVISAO DO DESIGN                          |
-+================================================================+
-|                                                                 |
-| Checklist:                                                      |
-| [x] Tech Spec cobre todos os requisitos do PRD                 |
-| [x] Arquitetura suporta NFRs (performance, seguranca)          |
-| [x] Modelo de dados contempla todas as entidades               |
-| [x] Design de API cobre todas as user stories                  |
-| [x] Consideracoes de seguranca documentadas                    |
-| [x] Estrategia de testes definida                              |
-| [x] Abordagem de deploy documentada                            |
-|                                                                 |
-| Perguntas de Revisao:                                           |
-| 1. A arquitetura e adequada para a escala?                      |
-| 2. Ha integracoes faltando?                                     |
-| 3. A abordagem de seguranca e suficiente?                       |
-| 4. Os ADRs estao completos e justificados?                      |
-|                                                                 |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║        REGISTROS DE DECISÃO DE ARQUITETURA (ADRs)         ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ ADRs Criados:                                             ║
+║                                                           ║
+║ ┌─────────────────────────────────────────────────────┐  ║
+║ │ ADR-001: Escolha do Banco de Dados                   │  ║
+║ │ Decisão: PostgreSQL                                  │  ║
+║ │ Justificativa: conformidade ACID, suporte a JSON,    │  ║
+║ │ já existente na infraestrutura                       │  ║
+║ └─────────────────────────────────────────────────────┘  ║
+║                                                           ║
+║ ┌─────────────────────────────────────────────────────┐  ║
+║ │ ADR-002: Estilo de API                               │  ║
+║ │ Decisão: REST com JSON:API                           │  ║
+║ │ Justificativa: expertise da equipe, cache, simplic.  │  ║
+║ └─────────────────────────────────────────────────────┘  ║
+║                                                           ║
+║ ┌─────────────────────────────────────────────────────┐  ║
+║ │ ADR-003: Autenticação                                │  ║
+║ │ Decisão: JWT com refresh tokens                      │  ║
+║ │ Justificativa: stateless, amigável ao mobile, padrão │  ║
+║ └─────────────────────────────────────────────────────┘  ║
+║                                                           ║
+║ Arquivos: docs/adr/ADR-001.md, ADR-002.md, ADR-003.md    ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
-### Etapa 8: Conclusao da Fase
+### Etapa 7: Gate de Revisão do Design
 
 ```
-+==============================================================+
-|              FASE DE DESIGN CONCLUIDA                           |
-+================================================================+
-|                                                                 |
-| Artefatos Criados:                                              |
-| - tech-spec.md            Especificacao Tecnica                 |
-| - architecture/                                                 |
-|    +-- c4-context.md      Diagrama de contexto do sistema       |
-|    +-- c4-container.md    Diagrama de container                 |
-|    +-- c4-component.md    Diagrama de componente                |
-|    +-- erd.md             Diagrama Entidade-Relacionamento      |
-|    +-- api.md             Design de API                         |
-|    +-- security.md        Consideracoes de seguranca            |
-| - docs/adr/               3 Architecture Decision Records       |
-|                                                                 |
-| Resumo:                                                         |
-| - 24 endpoints de API projetados                                |
-| - 8 entidades de banco de dados definidas                       |
-| - 3 integracoes externas especificadas                          |
-| - Meta de 80% de cobertura de testes definida                   |
-|                                                                 |
-| ------------------------------------------------------------- |
-| PROXIMA FASE: Implementacao                                     |
-| Comando: /workflow:implement                                    |
-| ------------------------------------------------------------- |
-|                                                                 |
-| Pronto para iniciar o desenvolvimento do Sprint 1!              |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║              GATE DE REVISÃO DO DESIGN                    ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Checklist:                                                ║
+║ ✅ Especificação Técnica cobre todos os requisitos do PRD ║
+║ ✅ Arquitetura suporta RNFs (desempenho, segurança)       ║
+║ ✅ Modelo de dados contempla todas as entidades           ║
+║ ✅ Design de API cobre todas as user stories              ║
+║ ✅ Considerações de segurança documentadas                ║
+║ ✅ Estratégia de testes definida                          ║
+║ ✅ Abordagem de implantação documentada                   ║
+║                                                           ║
+║ Perguntas de Revisão:                                     ║
+║ 1. A arquitetura é adequada para a escala esperada?       ║
+║ 2. Há alguma integração faltando?                         ║
+║ 3. A abordagem de segurança é suficiente?                 ║
+║ 4. Os ADRs estão completos e justificados?                ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
+```
+
+### Etapa 8: Conclusão da Fase
+
+```
+╔══════════════════════════════════════════════════════════╗
+║              FASE DE DESIGN CONCLUÍDA                     ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Artefatos Criados:                                        ║
+║ ✅ tech-spec.md            Especificação Técnica          ║
+║ ✅ architecture/                                          ║
+║    ├── c4-context.md       Diagrama de contexto do sistema║
+║    ├── c4-container.md     Diagrama de containers         ║
+║    ├── c4-component.md     Diagrama de componentes        ║
+║    ├── erd.md              Diagrama Entidade-Relacionamento║
+║    ├── api.md              Design de API                  ║
+║    └── security.md         Considerações de segurança     ║
+║ ✅ docs/adr/               3 Registros de Decisão de Arq. ║
+║                                                           ║
+║ Resumo:                                                   ║
+║ • 24 endpoints de API projetados                          ║
+║ • 8 entidades de banco de dados definidas                 ║
+║ • 3 integrações externas especificadas                    ║
+║ • Meta de 80% de cobertura de testes estabelecida         ║
+║                                                           ║
+║ ─────────────────────────────────────────────────────────║
+║ PRÓXIMA FASE: Implementação                               ║
+║ Comando: /workflow:implement                              ║
+║ ─────────────────────────────────────────────────────────║
+║                                                           ║
+║ Pronto para iniciar o desenvolvimento do Sprint 1!        ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
 ## Agentes Envolvidos
 
-- **tech-lead**: Design tecnico geral e criacao de ADRs
+- **tech-lead**: Design técnico geral e criação de ADRs
 - **api-designer**: Design de API REST/GraphQL
-- **database-architect**: Modelo de dados e design de schema
-- **ui-designer**: Arquitetura frontend (se aplicavel)
-- **devops-engineer**: Design de deploy e infraestrutura
+- **database-architect**: Design do modelo de dados e schema
+- **ui-designer**: Arquitetura frontend (quando aplicável)
+- **devops-engineer**: Design de implantação e infraestrutura
 
-## Arquivos de Saida
+## Arquivos de Saída
 
 | Arquivo | Finalidade |
-|---------|------------|
-| `tech-spec.md` | Especificacao Tecnica completa |
+|---------|-----------|
+| `tech-spec.md` | Especificação Técnica completa |
 | `architecture/c4-*.md` | Diagramas de arquitetura C4 |
 | `architecture/erd.md` | Diagrama Entidade-Relacionamento |
-| `architecture/api.md` | Documentacao de endpoints da API |
-| `architecture/security.md` | Design de seguranca |
-| `docs/adr/*.md` | Architecture Decision Records |
+| `architecture/api.md` | Documentação dos endpoints de API |
+| `architecture/security.md` | Design de segurança |
+| `docs/adr/*.md` | Registros de Decisão de Arquitetura |
 
 ## Comandos Relacionados
 
 - `/workflow:plan` - Fase anterior
-- `/workflow:implement` - Proxima fase
-- `/workflow:status` - Verificar progresso
-- `/project:generate-tech-spec` - Geracao direta do tech spec
+- `/workflow:implement` - Próxima fase
+- `/workflow:status` - Verificar o progresso
+- `/project:generate-tech-spec` - Geração direta da especificação técnica
 - `/common:architecture-decision` - Criar ADRs individuais

--- a/Dev/i18n/pt/Workflow/commands/implement.md
+++ b/Dev/i18n/pt/Workflow/commands/implement.md
@@ -1,245 +1,245 @@
 ---
 name: workflow-implement
-description: Executar a fase de Implementacao - desenvolvimento em sprints com TDD/BDD
+description: Executar a fase de Implementação - desenvolvimento por sprint com TDD/BDD
 arguments:
   - name: sprint
-    description: Numero especifico do sprint a trabalhar
+    description: Número específico do sprint a trabalhar
     required: false
 ---
 
 # /workflow:implement
 
-## Missao
+## Missão
 
-Executar a fase de Implementacao do workflow de desenvolvimento. Esta fase foca no desenvolvimento sprint a sprint utilizando praticas TDD/BDD, seguindo o design tecnico estabelecido nas fases anteriores.
+Executar a fase de Implementação do fluxo de trabalho de desenvolvimento. Esta fase foca-se no desenvolvimento sprint a sprint com práticas de TDD/BDD, seguindo o design técnico estabelecido nas fases anteriores.
 
-## Modo Plano
+## Quando Usar
 
-> **O modo plano é obrigatório.** Antes de executar, Claude ativa o modo plano para analisar o código impactado, propor um plano de implementação e aguardar sua validação antes de realizar qualquer alteração.
+- Após a conclusão de `/workflow:design` (tracks Standard/Enterprise)
+- Após `/workflow:init` para o track Quick Flow
+- Quando estiver pronto para começar a codar
 
-## Quando Utilizar
+## Pré-requisitos
 
-- Apos `/workflow:design` estar concluido (tracks Standard/Enterprise)
-- Apos `/workflow:init` para o track Quick Flow
-- Quando estiver pronto para comecar a codificar
-
-## Pre-requisitos
-
-Para tracks Standard/Enterprise:
-- Tech Spec existente em `project-management/tech-spec.md`
+Para os tracks Standard/Enterprise:
+- Especificação Técnica existente em `project-management/tech-spec.md`
 - Backlog existente em `project-management/backlog/`
-- Estrutura de sprint definida em `project-management/sprints/`
+- Estrutura de sprints definida em `project-management/sprints/`
 
-Para Quick Flow:
-- Compreensao clara do bug/funcionalidade a implementar
+Para o Quick Flow:
+- Compreensão clara do bug ou funcionalidade a implementar
 
-## Workflow
+## Modo de Planejamento
 
-### Etapa 1: Configuracao da Implementacao
+> **O modo de planejamento é obrigatório.** Antes de executar, o Claude ativa o modo de planejamento para analisar o código impactado, propor um plano de implementação e aguardar a sua validação antes de realizar qualquer alteração.
 
-```
-+==============================================================+
-|           FASE DE IMPLEMENTACAO - INICIANDO                     |
-+================================================================+
-| Track: Standard                                                 |
-| Fase: 4 de 4 - Implementacao                                   |
-|                                                                 |
-| Objetivos:                                                      |
-| - Executar desenvolvimento em sprint com TDD/BDD                |
-| - Implementar user stories seguindo o tech spec                 |
-| - Manter qualidade de codigo e cobertura de testes              |
-| - Completar Definition of Done para cada story                  |
-+================================================================+
-```
+## Fluxo de Trabalho
 
-### Etapa 2: Selecao de Sprint
+### Etapa 1: Configuração da Implementação
 
 ```
-+==============================================================+
-|               VISAO GERAL DOS SPRINTS                           |
-+================================================================+
-|                                                                 |
-| Sprints Disponiveis:                                            |
-|                                                                 |
-| +-----------------------------------------------------+        |
-| | Sprint 1: Walking Skeleton                           |        |
-| | Status: Pronto para iniciar                          |        |
-| | Stories: 5 | Pontos: 21                              |        |
-| | Foco: Infraestrutura + primeira feature end-to-end   |        |
-| +-----------------------------------------------------+        |
-|                                                                 |
-| +-----------------------------------------------------+        |
-| | Sprint 2: Core Features                              |        |
-| | Status: Planejado                                    |        |
-| | Stories: 6 | Pontos: 28                              |        |
-| | Foco: Gestao de usuarios, autenticacao               |        |
-| +-----------------------------------------------------+        |
-|                                                                 |
-| +-----------------------------------------------------+        |
-| | Sprint 3: Integracao de Pagamento                    |        |
-| | Status: Planejado                                    |        |
-| | Stories: 4 | Pontos: 24                              |        |
-| | Foco: Integracao Stripe, fluxo de checkout           |        |
-| +-----------------------------------------------------+        |
-|                                                                 |
-| Selecione o sprint (padrao: Sprint 1)                           |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║           FASE DE IMPLEMENTAÇÃO - INICIANDO               ║
+╠══════════════════════════════════════════════════════════╣
+║ Track: Standard                                           ║
+║ Fase: 4 de 4 - Implementação                              ║
+║                                                           ║
+║ Objetivos:                                                ║
+║ • Executar desenvolvimento dos sprints com TDD/BDD        ║
+║ • Implementar user stories seguindo a especificação téc.  ║
+║ • Manter qualidade do código e cobertura de testes        ║
+║ • Concluir a Definição de Pronto para cada story          ║
+╚══════════════════════════════════════════════════════════╝
+```
+
+### Etapa 2: Seleção do Sprint
+
+```
+╔══════════════════════════════════════════════════════════╗
+║               VISÃO GERAL DOS SPRINTS                     ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Sprints Disponíveis:                                      ║
+║                                                           ║
+║ ┌─────────────────────────────────────────────────────┐  ║
+║ │ Sprint 1: Walking Skeleton                           │  ║
+║ │ Status: Pronto para iniciar                          │  ║
+║ │ Stories: 5 | Pontos: 21                              │  ║
+║ │ Foco: Infraestrutura + primeira feature ponta a ponta│  ║
+║ └─────────────────────────────────────────────────────┘  ║
+║                                                           ║
+║ ┌─────────────────────────────────────────────────────┐  ║
+║ │ Sprint 2: Funcionalidades Principais                 │  ║
+║ │ Status: Planejado                                    │  ║
+║ │ Stories: 6 | Pontos: 28                              │  ║
+║ │ Foco: Gestão de usuários, autenticação               │  ║
+║ └─────────────────────────────────────────────────────┘  ║
+║                                                           ║
+║ ┌─────────────────────────────────────────────────────┐  ║
+║ │ Sprint 3: Integração de Pagamento                    │  ║
+║ │ Status: Planejado                                    │  ║
+║ │ Stories: 4 | Pontos: 24                              │  ║
+║ │ Foco: Integração Stripe, fluxo de checkout           │  ║
+║ └─────────────────────────────────────────────────────┘  ║
+║                                                           ║
+║ Selecionar sprint para trabalhar (padrão: Sprint 1)       ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
 ### Etapa 3: Redirecionamento para Desenvolvimento do Sprint
 
-Para execucao completa do sprint, este comando redireciona para o comando especializado sprint-dev:
+Para execução completa do sprint, este comando redireciona para o comando especializado sprint-dev:
 
 ```
-+==============================================================+
-|           INICIANDO DESENVOLVIMENTO DO SPRINT                   |
-+================================================================+
-|                                                                 |
-| Invocando: /sprint:dev sprint-001-walking-skeleton      |
-|                                                                 |
-| Funcionalidades do Modo de Desenvolvimento do Sprint:           |
-| - Plan mode obrigatorio antes de cada tarefa                    |
-| - Ciclo TDD: RED -> GREEN -> REFACTOR                           |
-| - Atualizacoes automaticas de status                            |
-| - Conventional commits com referencias de stories               |
-| - Validacao de Definition of Done                               |
-|                                                                 |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║           INICIANDO DESENVOLVIMENTO DO SPRINT             ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Invocando: /sprint:dev sprint-001-walking-skeleton        ║
+║                                                           ║
+║ Funcionalidades do Modo de Desenvolvimento de Sprint:     ║
+║ • Modo de planejamento obrigatório antes de cada tarefa   ║
+║ • Ciclo TDD: RED → GREEN → REFACTOR                       ║
+║ • Atualizações automáticas de status                      ║
+║ • Commits convencionais com referências às stories        ║
+║ • Validação da Definição de Pronto                        ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
-### Etapa 4: Orientacao de Implementacao
+### Etapa 4: Orientações de Implementação
 
-Fornecer contexto da fase de design:
+Forneça contexto da fase de design:
 
 ```
-+==============================================================+
-|           CONTEXTO DE IMPLEMENTACAO                             |
-+================================================================+
-|                                                                 |
-| Do Tech Spec:                                                   |
-| +-- Arquitetura: Clean Architecture (Hexagonal)                 |
-| +-- Estilo API: REST com JSON:API                               |
-| +-- Autenticacao: JWT com refresh tokens                        |
-| +-- Banco de dados: PostgreSQL com Doctrine ORM                 |
-| +-- Testes: PHPUnit + Jest + Playwright                         |
-|                                                                 |
-| ADRs Relevantes:                                                |
-| +-- ADR-001: Escolha do banco (PostgreSQL)                      |
-| +-- ADR-002: Estilo de API (REST)                               |
-| +-- ADR-003: Autenticacao (JWT)                                 |
-|                                                                 |
-| Padroes de Codigo:                                              |
-| +-- Seguir padroes existentes no codebase                       |
-| +-- Meta de cobertura de testes: 80%                            |
-| +-- Utilizar regras especificas da tecnologia:                  |
-|     /symfony:*, /react:*, etc.                                  |
-|                                                                 |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║           CONTEXTO DE IMPLEMENTAÇÃO                       ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Da Especificação Técnica:                                 ║
+║ ├── Arquitetura: Clean Architecture (Hexagonal)           ║
+║ ├── Estilo de API: REST com JSON:API                      ║
+║ ├── Auth: JWT com refresh tokens                          ║
+║ ├── Banco de dados: PostgreSQL com Doctrine ORM           ║
+║ └── Testes: PHPUnit + Jest + Playwright                   ║
+║                                                           ║
+║ ADRs Relevantes:                                          ║
+║ ├── ADR-001: Escolha do banco de dados (PostgreSQL)       ║
+║ ├── ADR-002: Estilo de API (REST)                         ║
+║ └── ADR-003: Autenticação (JWT)                           ║
+║                                                           ║
+║ Padrões de Código:                                        ║
+║ ├── Seguir padrões existentes no código                   ║
+║ ├── Meta de cobertura de testes: 80%                      ║
+║ └── Utilizar regras específicas de tecnologia:            ║
+║     /symfony:*, /react:*, etc.                            ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
 ### Etapa 5: Modo Quick Flow
 
-Para o track Quick Flow (bug fixes, features pequenas):
+Para o track Quick Flow (correção de bugs, pequenas funcionalidades):
 
 ```
-+==============================================================+
-|           QUICK FLOW - IMPLEMENTACAO DIRETA                     |
-+================================================================+
-|                                                                 |
-| Sem necessidade de estrutura de sprint para Quick Flow.         |
-|                                                                 |
-| Comandos Disponiveis:                                           |
-|                                                                 |
-| Para Bug Fixes:                                                 |
-| - /qa:tdd        - Corrigir com abordagem TDD      |
-|                                                                 |
-| Para Features Pequenas:                                         |
-| - /{tech}:* comandos         - Especificos por tecnologia       |
-|                                                                 |
-| Acompanhamento:                                                 |
-| - /project:add-task          - Registrar como tarefa            |
-| - /project:move-task done    - Marcar como concluida            |
-|                                                                 |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║           QUICK FLOW - IMPLEMENTAÇÃO DIRETA               ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Sem estrutura de sprint necessária para o Quick Flow.     ║
+║                                                           ║
+║ Comandos Disponíveis:                                     ║
+║                                                           ║
+║ Para Correção de Bugs:                                    ║
+║ • /qa:tdd        - Corrigir com abordagem TDD             ║
+║                                                           ║
+║ Para Pequenas Funcionalidades:                            ║
+║ • /{tech}:* commands         - Específicos por tecnologia ║
+║                                                           ║
+║ Rastreamento:                                             ║
+║ • /project:add-task          - Registrar como tarefa      ║
+║ • /project:move-task done    - Marcar como concluído      ║
+║                                                           ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
-### Etapa 6: Conclusao do Sprint
+### Etapa 6: Conclusão do Sprint
 
-Apos a conclusao do sprint:
-
-```
-+==============================================================+
-|           SPRINT CONCLUIDO                                      |
-+================================================================+
-|                                                                 |
-| Sprint 1: Walking Skeleton                                      |
-| Status: Concluido                                               |
-|                                                                 |
-| Metricas:                                                       |
-| +-- Stories concluidas: 5/5                                     |
-| +-- Pontos entregues: 21                                        |
-| +-- Velocidade: 21 pts/sprint                                   |
-| +-- Cobertura de testes: 82%                                    |
-| +-- Commits: 23                                                 |
-|                                                                 |
-| Artefatos:                                                      |
-| +-- sprint-review.md gerado                                     |
-| +-- sprint-retro.md template pronto                             |
-|                                                                 |
-| ------------------------------------------------------------- |
-| PROXIMAS ACOES:                                                 |
-| ------------------------------------------------------------- |
-|                                                                 |
-| 1. /workflow:review     - Conduzir revisao do sprint       |
-| 2. /workflow:retro      - Executar retrospectiva           |
-| 3. /workflow:implement 2     - Iniciar Sprint 2                 |
-|                                                                 |
-| Ou verificar progresso geral: /workflow:status                  |
-+================================================================+
-```
-
-### Etapa 7: Conclusao do Workflow
-
-Quando todos os sprints estao concluidos:
+Após a conclusão do sprint:
 
 ```
-+==============================================================+
-|           FASE DE IMPLEMENTACAO CONCLUIDA                       |
-+================================================================+
-|                                                                 |
-| Todos os sprints planejados concluidos!                         |
-|                                                                 |
-| Resumo do Projeto:                                              |
-| +-- Total de Sprints: 4                                         |
-| +-- Total de Stories: 18                                        |
-| +-- Total de Pontos: 89                                         |
-| +-- Velocidade Media: 22 pts/sprint                             |
-| +-- Cobertura de Testes: 84%                                    |
-| +-- Total de Commits: 87                                        |
-|                                                                 |
-| Proximos Passos:                                                |
-| - /common:release-checklist  - Preparar para lancamento         |
-| - /common:generate-changelog - Gerar notas de lancamento        |
-| - Deploy para staging/producao                                  |
-|                                                                 |
-| =============================================================  |
-|           WORKFLOW DO PROJETO CONCLUIDO!                         |
-| =============================================================  |
-+================================================================+
+╔══════════════════════════════════════════════════════════╗
+║           SPRINT CONCLUÍDO                                ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Sprint 1: Walking Skeleton                                ║
+║ Status: ✅ Concluído                                      ║
+║                                                           ║
+║ Métricas:                                                 ║
+║ ├── Stories concluídas: 5/5                               ║
+║ ├── Pontos entregues: 21                                  ║
+║ ├── Velocidade: 21 pts/sprint                             ║
+║ ├── Cobertura de testes: 82%                              ║
+║ └── Commits: 23                                           ║
+║                                                           ║
+║ Artefatos:                                                ║
+║ ├── sprint-review.md gerado                               ║
+║ └── template sprint-retro.md pronto                       ║
+║                                                           ║
+║ ─────────────────────────────────────────────────────────║
+║ PRÓXIMAS AÇÕES:                                           ║
+║ ─────────────────────────────────────────────────────────║
+║                                                           ║
+║ 1. /workflow:review     - Conduzir a revisão do sprint    ║
+║ 2. /workflow:retro      - Realizar a retrospectiva        ║
+║ 3. /workflow:implement 2 - Iniciar o Sprint 2             ║
+║                                                           ║
+║ Ou verificar o progresso geral: /workflow:status          ║
+╚══════════════════════════════════════════════════════════╝
+```
+
+### Etapa 7: Conclusão do Fluxo de Trabalho
+
+Quando todos os sprints estiverem concluídos:
+
+```
+╔══════════════════════════════════════════════════════════╗
+║           FASE DE IMPLEMENTAÇÃO CONCLUÍDA                 ║
+╠══════════════════════════════════════════════════════════╣
+║                                                           ║
+║ Todos os sprints planejados foram concluídos!             ║
+║                                                           ║
+║ Resumo do Projeto:                                        ║
+║ ├── Total de Sprints: 4                                   ║
+║ ├── Total de Stories: 18                                  ║
+║ ├── Total de Pontos: 89                                   ║
+║ ├── Velocidade Média: 22 pts/sprint                       ║
+║ ├── Cobertura de Testes: 84%                              ║
+║ └── Total de Commits: 87                                  ║
+║                                                           ║
+║ Próximos Passos:                                          ║
+║ • /common:release-checklist  - Preparar para o release    ║
+║ • /common:generate-changelog - Gerar notas de versão      ║
+║ • Implantar em staging/produção                           ║
+║                                                           ║
+║ ═══════════════════════════════════════════════════════  ║
+║           🎉 FLUXO DE TRABALHO DO PROJETO CONCLUÍDO! 🎉  ║
+║ ═══════════════════════════════════════════════════════  ║
+╚══════════════════════════════════════════════════════════╝
 ```
 
 ## Agentes Envolvidos
 
-- **tech-lead**: Decomposicao de tarefas, orientacao de arquitetura
-- **tdd-coach**: Orientacao na metodologia TDD/BDD
-- **{tech}-reviewer**: Code review (Symfony, Flutter, React, Python, ReactNative)
-- **devops-engineer**: CI/CD e deploy
+- **tech-lead**: Decomposição de tarefas, orientação de arquitetura
+- **tdd-coach**: Orientação de metodologia TDD/BDD
+- **{tech}-reviewer**: Revisão de código (Symfony, Flutter, React, Python, ReactNative)
+- **devops-engineer**: CI/CD e implantação
 
 ## Comandos Relacionados
 
 - `/workflow:design` - Fase anterior
-- `/workflow:status` - Verificar progresso
-- `/sprint:dev` - Modo completo de desenvolvimento do sprint
-- `/qa:tdd` - Correcoes rapidas de bugs
-- `/workflow:review` - Cerimonia de revisao do sprint
+- `/workflow:status` - Verificar o progresso
+- `/sprint:dev` - Modo completo de desenvolvimento de sprint
+- `/qa:tdd` - Correção rápida de bugs
+- `/workflow:review` - Cerimônia de revisão do sprint
 - `/workflow:retro` - Retrospectiva do sprint

--- a/Project/i18n/de/Sprint/commands/dev.md
+++ b/Project/i18n/de/Sprint/commands/dev.md
@@ -1,9 +1,9 @@
 ---
 name: sprint-dev
-description: Startet TDD/BDD-Entwicklung eines Sprints mit automatischer Statusaktualisierung
+description: TDD/BDD-Entwicklung eines Sprints starten mit automatischen Statusaktualisierungen
 arguments:
   - name: sprint
-    description: Sprint-Nummer, "next" fur nachsten unvollstandigen, oder "current"
+    description: Sprint-Nummer, „next" für den nächsten unvollständigen Sprint oder „current"
     required: true
 ---
 
@@ -11,23 +11,23 @@ arguments:
 
 ## Zweck
 
-Vollstandige Sprint-Entwicklung im TDD/BDD-Modus orchestrieren mit:
-- **Obligatorischer Plan-Modus** vor jeder Implementierung
-- **TDD-Zyklus** (RED → GREEN → REFACTOR)
-- **Automatische Statusaktualisierung** (Task → User Story → Sprint)
+Vollständige Sprint-Entwicklung im TDD/BDD-Modus orchestrieren mit:
+- **Obligatorischem Plan-Modus** vor jeder Aufgaben-Implementierung
+- **TDD-Zyklus** (ROT → GRÜN → REFACTOR)
+- **Automatischen Statusaktualisierungen** (Aufgabe → User Story → Sprint)
 - **Fortschrittsverfolgung** und Metriken
 
 ## Voraussetzungen
 
 - Sprint existiert mit zerlegten Aufgaben
 - Dateien vorhanden: `sprint-backlog.md`, `tasks/*.md`
-- `/project:decompose-tasks N` zuerst ausfuhren falls notig
+- Zuerst `/project:decompose-tasks N` ausführen, falls erforderlich
 
 ## Argumente
 
 ```bash
 /sprint:dev 1        # Sprint 1
-/sprint:dev next     # Nachster unvollstandiger Sprint
+/sprint:dev next     # Nächster unvollständiger Sprint
 /sprint:dev current  # Aktuell aktiver Sprint
 ```
 
@@ -38,157 +38,410 @@ Vollstandige Sprint-Entwicklung im TDD/BDD-Modus orchestrieren mit:
 ### Phase 1: Initialisierung
 
 1. Sprint aus `project-management/sprints/sprint-N-*/` laden
-2. `sprint-backlog.md` lesen fur User Stories
-3. Aufgaben pro US auflisten (nach Abhangigkeiten sortiert)
-4. Initiales Board anzeigen
-
-### Phase 2: User Story Schleife
-
-Fur jede US in To Do oder In Progress Status:
-1. US → In Progress markieren
-2. Akzeptanzkriterien anzeigen (Gherkin)
-3. Jede Aufgabe der US bearbeiten
-
-### Phase 3: Aufgaben Schleife (TDD Workflow)
-
-Fur jede Aufgabe in To Do:
-
-#### 3.1 Plan-Modus (OBLIGATORISCH)
-
-⚠️ **IMMER Plan-Modus vor Implementierung aktivieren**
-
-- Betroffenen Code erkunden
-- Analyse dokumentieren
-- Implementierungsplan vorschlagen
-- Auf Benutzervalidierung warten
-
-#### 3.2 TDD-Zyklus
+2. `sprint-backlog.md` lesen, um User Stories zu erhalten
+3. Aufgaben pro US auflisten (sortiert nach Abhängigkeiten)
+4. Anfängliches Board anzeigen
 
 ```
-🔴 RED    : Fehlschlagende Tests schreiben
-🟢 GREEN  : Minimalen Code implementieren
-🔧 REFACTOR : Verbessern ohne Tests zu brechen
+📋 Sprint 1: Walking Skeleton
+   Ziel: Vollständigen Authentifizierungsfluss von Ende zu Ende abschließen
+
+   3 User Stories, 17 Aufgaben
+
+   🔴 Zu erledigen: 15 | 🟡 In Bearbeitung: 2 | 🟢 Erledigt: 0
 ```
 
-#### 3.3 Definition of Done
+### Phase 2: User-Story-Schleife
 
-- [ ] Code geschrieben und funktional
-- [ ] Tests bestehen
-- [ ] Code reviewed (wenn [REV] Aufgabe existiert)
+Für jede User Story mit Status „Zu erledigen" oder „In Bearbeitung":
 
-#### 3.4 Aufgabe → Done markieren
+1. **US → In Bearbeitung markieren** (falls „Zu erledigen")
+2. **Akzeptanzkriterien anzeigen** (Gherkin-Format)
+3. **Jede Aufgabe** dieser US verarbeiten
 
-- Metadaten aktualisieren
-- Konventioneller Commit
-- Board aktualisieren
+```
+🎯 US-001: Benutzerauthentifizierung (5 Pkt.)
+   Status: 🟡 In Bearbeitung
 
-### Phase 4: US Validierung
+   Akzeptanzkriterien:
+   ┌─────────────────────────────────────────────────────┐
+   │ GEGEBEN DASS ein registrierter Benutzer gültige    │
+   │ Anmeldedaten hat                                    │
+   │ WENN er das Anmeldeformular absendet               │
+   │ DANN sollte er sein Dashboard sehen                 │
+   │ UND eine Sitzung sollte erstellt werden            │
+   └─────────────────────────────────────────────────────┘
 
-Wenn alle Aufgaben einer US Done sind:
-- Akzeptanzkriterien verifizieren
-- E2E Tests ausfuhren
-- US → Done markieren
+   Aufgaben:
+   └─ TASK-001 [DB] User-Entität erstellen .............. 🔴 Zu erledigen
+   └─ TASK-002 [BE] Authentifizierungsservice ........... 🔴 Zu erledigen
+   └─ TASK-003 [FE-WEB] Anmeldeformular ................. 🔴 Zu erledigen
+   └─ TASK-004 [TEST] E2E-Authentifizierungstests ....... 🔴 Zu erledigen
+```
 
-### Phase 5: Sprint Abschluss
+### Phase 3: Aufgaben-Schleife (TDD-Workflow)
 
-Wenn alle US Done sind:
-- Zusammenfassung anzeigen
-- sprint-review.md generieren
-- sprint-retro.md generieren
+Für jede Aufgabe mit Status „Zu erledigen":
+
+#### 3.1 Aufgabendetails anzeigen
+
+```
+▶️ Starting TASK-001 [DB] User-Entität erstellen
+
+   Schätzung: 2 Std.
+   Beschreibung: User-Entität mit E-Mail, Passwort-Hash, Rollen erstellen
+   Zu ändernde Dateien: src/Entity/User.php, migrations/
+
+   Definition of Done:
+   - [ ] Code geschrieben und funktionsfähig
+   - [ ] Tests bestehen
+   - [ ] Code überprüft (falls [REV]-Aufgabe existiert)
+```
+
+#### 3.2 Plan-Modus (OBLIGATORISCH)
+
+⚠️ **Plan-Modus IMMER vor der Implementierung aktivieren**
+
+```
+⚠️ PLAN-MODUS AKTIVIERT
+
+   Aufgabe TASK-001 wird analysiert...
+
+   📁 Zu analysierende Dateien:
+   - src/Entity/ (Muster bestehender Entitäten)
+   - config/packages/doctrine.yaml
+   - migrations/ (neueste Migration)
+
+   🔍 Analyse läuft...
+```
+
+Der Plan-Modus MUSS:
+1. **Betroffenen Code und Abhängigkeiten erkunden**
+2. **Analyseergebnisse dokumentieren**
+3. **Implementierungsplan vorschlagen** mit:
+   - Zu erstellenden/ändernden Dateien
+   - Zu schreibenden Tests (TDD)
+   - Risiken und Gegenmaßnahmen
+4. **Auf Benutzerbestätigung warten**, bevor fortgefahren wird
+
+```
+📋 Implementierungsplan für TASK-001
+
+   1. User-Entität mit Eigenschaften erstellen:
+      - id (UUID)
+      - email (eindeutig)
+      - password_hash
+      - roles (JSON-Array)
+      - created_at, updated_at
+
+   2. ZUERST zu schreibende Tests (TDD):
+      - UserTest::test_user_creation()
+      - UserTest::test_email_validation()
+      - UserTest::test_password_hashing()
+
+   3. Zu erstellende Dateien:
+      - src/Entity/User.php
+      - tests/Unit/Entity/UserTest.php
+      - migrations/VersionXXX.php
+
+   ⏳ Warte auf Bestätigung...
+
+   [continue] Mit Implementierung fortfahren
+   [skip] Diese Aufgabe überspringen
+   [block] Als blockiert markieren
+   [stop] sprint-dev stoppen
+```
+
+#### 3.3 Aufgabe → In Bearbeitung markieren
+
+Nach Plan-Bestätigung:
+- Aufgabenstatus auf „In Bearbeitung" aktualisieren
+- board.md aktualisieren
+- index.md aktualisieren
+
+#### 3.4 TDD-Zyklus
+
+```
+🧪 TDD-ZYKLUS - TASK-001
+
+🔴 ROT-Phase: Fehlschlagende Tests schreiben
+   tests/Unit/Entity/UserTest.php wird erstellt...
+
+   Tests ausführen... FEHLGESCHLAGEN (erwartet)
+   ✗ test_user_creation
+   ✗ test_email_validation
+   ✗ test_password_hashing
+
+🟢 GRÜN-Phase: Minimalen Code implementieren
+   src/Entity/User.php wird erstellt...
+
+   Tests ausführen... BESTANDEN
+   ✓ test_user_creation
+   ✓ test_email_validation
+   ✓ test_password_hashing
+
+🔧 REFACTOR-Phase: Code-Qualität verbessern
+   - E-Mail-Validierung in ValueObject auslagern? [j/n]
+   - Factory-Methode hinzufügen? [j/n]
+
+   Tests ausführen... BESTANDEN (keine Regression)
+```
+
+#### 3.5 Definition-of-Done-Prüfung
+
+```
+✅ Definition of Done - TASK-001
+
+- [x] Code geschrieben und funktionsfähig
+- [x] Tests bestehen (3/3)
+- [ ] Code überprüft → Behandelt durch TASK-XXX [REV]
+
+Alle Prüfungen bestanden!
+```
+
+#### 3.6 Aufgabe → Erledigt markieren
+
+```
+📊 Aufgabenabschluss
+
+TASK-001 [DB] User-Entität erstellen
+├─ Status: 🟢 Erledigt
+├─ Geschätzt: 2 Std.
+├─ Tatsächlich: 1,5 Std.
+└─ Effizienz: 133%
+
+Tatsächlich aufgewendete Zeit eingeben (Stunden): 1.5
+```
+
+Aktualisierungen:
+- Aufgaben-Datei-Metadaten (Status, time_spent, updated_at)
+- board.md
+- index.md
+- Sprint-Metriken
+
+#### 3.7 Conventional Commit
+
+```
+📝 Commit erstellen...
+
+feat(entity): create User entity with authentication support
+
+- Add User entity with email, password_hash, roles
+- Add UUID primary key strategy
+- Add timestamps (created_at, updated_at)
+- Add unit tests for User entity
+
+Refs: TASK-001, US-001
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### Phase 4: User-Story-Validierung
+
+Wenn alle Aufgaben einer US erledigt sind:
+
+```
+🎯 US-001 Validierung
+
+Alle Aufgaben abgeschlossen (4/4)
+
+Akzeptanzkriterien prüfen:
+┌─────────────────────────────────────────────────────┐
+│ ✓ GEGEBEN DASS ein registrierter Benutzer gültige  │
+│   Anmeldedaten hat                                  │
+│ ✓ WENN er das Anmeldeformular absendet             │
+│ ✓ DANN sollte er sein Dashboard sehen               │
+│ ✓ UND eine Sitzung sollte erstellt werden          │
+└─────────────────────────────────────────────────────┘
+
+E2E-Tests ausführen, falls vorhanden...
+✓ tests/E2E/AuthenticationTest.php bestanden
+
+US-001 → 🟢 Erledigt
+
+EPIC-001-Fortschritt aktualisieren: 1/3 US abgeschlossen (33%)
+```
+
+### Phase 5: Sprint-Abschluss
+
+Wenn alle User Stories erledigt sind:
+
+```
+🏁 Sprint 1 abgeschlossen!
+
+📊 Zusammenfassung
+├─ Dauer: 8 Tage (geplant: 10)
+├─ Velocity: 15 Punkte
+├─ Aufgaben: 17/17 abgeschlossen
+└─ Stunden: 38 Std. tatsächlich vs. 42 Std. geschätzt (110% Effizienz)
+
+📈 Metriken nach Typ
+├─ [DB]: 4 Aufgaben, 6 Std.
+├─ [BE]: 5 Aufgaben, 12 Std.
+├─ [FE-WEB]: 4 Aufgaben, 10 Std.
+├─ [TEST]: 3 Aufgaben, 8 Std.
+└─ [DOC]: 1 Aufgabe, 2 Std.
+
+📝 sprint-review.md wird generiert...
+📝 sprint-retro.md-Template wird generiert...
+
+Weiter: /sprint:dev 2 oder /sprint:dev next ausführen
+```
 
 ---
 
-## Bearbeitungsreihenfolge
+## Aufgaben-Verarbeitungsreihenfolge
+
+Aufgaben werden nach Typ verarbeitet, um Abhängigkeiten zu respektieren:
 
 | Reihenfolge | Typ | Beschreibung |
 |-------------|-----|--------------|
-| 1 | `[DB]` | Datenbank |
-| 2 | `[BE]` | Backend |
-| 3 | `[FE-WEB]` | Frontend Web |
-| 4 | `[FE-MOB]` | Frontend Mobile |
-| 5 | `[TEST]` | Zusatzliche Tests |
+| 1 | `[DB]` | Datenbank (Entitäten, Migrationen, Repositories) |
+| 2 | `[BE]` | Backend (Services, APIs, Geschäftslogik) |
+| 3 | `[FE-WEB]` | Frontend Web (Controller, Templates, JS) |
+| 4 | `[FE-MOB]` | Frontend Mobile (Screens, Blocs, Widgets) |
+| 5 | `[TEST]` | Zusätzliche Tests (E2E, Performance) |
 | 6 | `[DOC]` | Dokumentation |
 | 7 | `[REV]` | Code Review |
 
 ---
 
-## Steuerungsbefehle
+## Steuerbefehle
+
+Während der sprint-dev-Ausführung:
 
 | Befehl | Aktion |
 |--------|--------|
-| `continue` | Plan validieren und fortfahren |
-| `skip` | Diese Aufgabe uberspringen |
-| `block [grund]` | Als blockiert markieren |
-| `stop` | Sprint-dev stoppen |
-| `status` | Fortschritt anzeigen |
-| `board` | Kanban anzeigen |
+| `continue` | Plan bestätigen und mit Implementierung fortfahren |
+| `skip` | Diese Aufgabe überspringen (bleibt „Zu erledigen") |
+| `block [Grund]` | Aufgabe mit Grund als „Blockiert" markieren |
+| `stop` | sprint-dev stoppen (aktuellen Zustand speichern) |
+| `status` | Aktuellen Fortschritt anzeigen |
+| `board` | Kanban-Board anzeigen |
 
 ---
 
 ## Blockierungsbehandlung
 
 ```
-⚠️ Aufgabe Blockiert
+⚠️ Aufgabe blockiert
 
-TASK-003 kann nicht fortfahren.
-Grund: Warten auf API-Spezifikationen
+TASK-003 kann nicht fortgeführt werden.
+Grund: Warten auf API-Spezifikation vom Backend-Team
 
 Optionen:
-[1] Uberspringen und mit nachster Aufgabe fortfahren
-[2] Versuchen die Blockierung zu losen
-[3] Sprint-dev stoppen
+[1] Überspringen und mit der nächsten nicht blockierten Aufgabe fortfahren
+[2] Versuchen, die Blockierung zu lösen
+[3] sprint-dev stoppen
+
+Auswahl: 1
+
+TASK-003 wird als „Blockiert" markiert...
+Weiter zu TASK-004...
 ```
 
 ---
 
 ## Automatische Aktualisierungen
 
-Bei jeder Statusanderung:
-1. Aufgabendatei: status, time_spent
-2. US-Datei: Aufgabenfortschritt
-3. EPIC-Datei: US-Fortschritt
-4. board.md: Kanban-Spalten
-5. index.md: Globale Metriken
+Bei jeder Statusänderung:
+
+1. **Aufgaben-Datei**: Status, time_spent, updated_at aktualisieren
+2. **User-Story-Datei**: Aufgabenfortschritt aktualisieren, Status wenn alle erledigt
+3. **EPIC-Datei**: US-Fortschritt aktualisieren
+4. **board.md**: Kanban-Spalten aktualisieren
+5. **index.md**: Globale Metriken aktualisieren
+6. **sprint-status**: Metriken neu berechnen
 
 ---
 
-## Beispiel
+## Fortfahren nach Stopp
+
+```bash
+/sprint:dev current
+
+📋 Sprint 1 fortsetzen: Walking Skeleton
+
+Fortschritt: 8/17 Aufgaben (47%)
+
+Zuletzt abgeschlossen: TASK-008 [BE] JWT-Token-Service
+Nächste Aufgabe: TASK-009 [FE-WEB] Login-Controller
+
+Von TASK-009 fortfahren? [j/n]
+```
+
+---
+
+## Beispiel-Sitzung
 
 ```bash
 > /sprint:dev 1
 
 📋 Sprint 1: Walking Skeleton
    3 US, 17 Aufgaben
+   🔴 Zu erledigen: 17 | 🟡 In Bearbeitung: 0 | 🟢 Erledigt: 0
 
-🎯 Starte US-001: Authentifizierung (5 Pkt)
+🎯 US-001 starten: Benutzerauthentifizierung (5 Pkt.)
+   Als „In Bearbeitung" markieren...
 
-▶️ TASK-001 [DB] User Entity erstellen
+▶️ TASK-001 [DB] User-Entität erstellen
 
 ⚠️ PLAN-MODUS AKTIVIERT
-   Analysiere...
+   Analysieren...
+
+   [Plandetails werden angezeigt]
 
 > continue
 
+   TASK-001 wird als „In Bearbeitung" markiert...
+
 🧪 TDD-ZYKLUS
-🔴 RED: Tests schreiben...
-🟢 GREEN: Implementieren...
-🔧 REFACTOR: Verbesserungen?
+
+🔴 ROT: Tests schreiben...
+   [Test-Code erstellt]
+   Tests: 0/3 bestanden (erwartet)
+
+🟢 GRÜN: Implementieren...
+   [Implementierungscode]
+   Tests: 3/3 bestanden
+
+🔧 REFACTOR: Verbesserungen? [überspringen]
 
 ✅ Definition of Done: BESTANDEN
 
-📝 Commit erstellt
+   Tatsächliche Zeit eingeben (geschätzt 2 Std.): 1.5
 
-▶️ TASK-002 [BE] Authentifizierungs-Service...
+📝 Commit erstellt: feat(entity): create User entity
+
+▶️ TASK-002 [BE] Authentifizierungsservice
+
+⚠️ PLAN-MODUS AKTIVIERT
+   ...
 ```
+
+---
+
+## Aktualisierte Dateien
+
+| Datei | Aktualisierungen |
+|-------|-----------------|
+| `project-management/backlog/user-stories/US-XXX.md` | Status, Aufgabenfortschritt |
+| `project-management/backlog/epics/EPIC-XXX.md` | US-Fortschritt |
+| `project-management/sprints/sprint-N-*/board.md` | Kanban-Spalten |
+| `project-management/sprints/sprint-N-*/tasks/*.md` | Aufgabenstatus, Zeit |
+| `project-management/backlog/index.md` | Globale Metriken |
+| `project-management/sprints/sprint-N-*/sprint-review.md` | Am Ende generiert |
 
 ---
 
 ## Verwandte Befehle
 
 | Befehl | Verwendung |
-|--------|------------|
-| `/project:decompose-tasks N` | Aufgaben vorher erstellen |
-| `/project:board N` | Kanban anzeigen |
-| `/sprint:status N` | Metriken anzeigen |
-| `/project:move-task` | Aufgabenstatus andern |
-| `/sprint:transition` | US-Status andern |
+|--------|-----------|
+| `/project:decompose-tasks N` | Aufgaben vor sprint-dev erstellen |
+| `/project:board N` | Kanban-Board anzeigen |
+| `/sprint:status N` | Sprint-Metriken anzeigen |
+| `/project:move-task` | Aufgabenstatus manuell ändern |
+| `/sprint:transition` | US-Status manuell ändern |

--- a/Project/i18n/es/Sprint/commands/dev.md
+++ b/Project/i18n/es/Sprint/commands/dev.md
@@ -1,25 +1,25 @@
 ---
 name: sprint-dev
-description: Inicia el desarrollo TDD/BDD de un sprint con actualizacion automatica de estados
+description: Iniciar el desarrollo TDD/BDD de un sprint con actualizaciones automáticas de estado
 arguments:
   - name: sprint
-    description: Numero de sprint, "next" para el proximo incompleto, o "current"
+    description: Número de sprint, "next" para el siguiente sprint incompleto, o "current"
     required: true
 ---
 
 # /sprint:dev
 
-## Objetivo
+## Propósito
 
 Orquestar el desarrollo completo de un sprint en modo TDD/BDD con:
-- **Plan mode obligatorio** antes de cada implementacion
+- **Modo plan obligatorio** antes de cada implementación de tarea
 - **Ciclo TDD** (RED → GREEN → REFACTOR)
-- **Actualizacion automatica** de estados (Tarea → User Story → Sprint)
-- **Seguimiento de progreso** y metricas
+- **Actualizaciones automáticas de estado** (Tarea → Historia de Usuario → Sprint)
+- **Seguimiento de progreso** y métricas
 
 ## Prerrequisitos
 
-- Sprint existente con tareas descompuestas
+- El sprint existe con tareas descompuestas
 - Archivos presentes: `sprint-backlog.md`, `tasks/*.md`
 - Ejecutar `/project:decompose-tasks N` primero si es necesario
 
@@ -27,159 +27,410 @@ Orquestar el desarrollo completo de un sprint en modo TDD/BDD con:
 
 ```bash
 /sprint:dev 1        # Sprint 1
-/sprint:dev next     # Proximo sprint incompleto
+/sprint:dev next     # Siguiente sprint incompleto
 /sprint:dev current  # Sprint actualmente activo
 ```
 
 ---
 
-## Workflow
+## Flujo de Trabajo
 
-### Fase 1: Inicializacion
+### Fase 1: Inicialización
 
-1. Cargar sprint desde `project-management/sprints/sprint-N-*/`
-2. Leer `sprint-backlog.md` para obtener User Stories
-3. Listar tareas por US (ordenadas por dependencias)
-4. Mostrar board inicial
-
-### Fase 2: Bucle User Story
-
-Para cada US en estado To Do o In Progress:
-1. Marcar US → In Progress
-2. Mostrar criterios de aceptacion (Gherkin)
-3. Procesar cada tarea de la US
-
-### Fase 3: Bucle Tarea (Workflow TDD)
-
-Para cada tarea en To Do:
-
-#### 3.1 Plan Mode (OBLIGATORIO)
-
-⚠️ **SIEMPRE activar plan mode antes de implementar**
-
-- Explorar codigo impactado
-- Documentar analisis
-- Proponer plan de implementacion
-- Esperar validacion del usuario
-
-#### 3.2 Ciclo TDD
+1. Cargar el sprint desde `project-management/sprints/sprint-N-*/`
+2. Leer `sprint-backlog.md` para obtener las Historias de Usuario
+3. Listar tareas por HU (ordenadas por dependencias)
+4. Mostrar el tablero inicial
 
 ```
-🔴 RED    : Escribir tests que fallan
-🟢 GREEN  : Implementar codigo minimo
-🔧 REFACTOR : Mejorar sin romper tests
+📋 Sprint 1: Walking Skeleton
+   Objetivo: Completar el flujo de autenticación de extremo a extremo
+
+   3 Historias de Usuario, 17 Tareas
+
+   🔴 Por Hacer: 15 | 🟡 En Progreso: 2 | 🟢 Hecho: 0
 ```
 
-#### 3.3 Definition of Done
+### Fase 2: Bucle de Historias de Usuario
 
-- [ ] Codigo escrito y funcional
-- [ ] Tests pasan
-- [ ] Codigo revisado (si existe tarea [REV])
+Para cada Historia de Usuario en estado Por Hacer o En Progreso:
 
-#### 3.4 Marcar Tarea → Done
+1. **Marcar HU → En Progreso** (si estaba Por Hacer)
+2. **Mostrar los criterios de aceptación** (formato Gherkin)
+3. **Procesar cada tarea** de esta HU
 
-- Actualizar metadatos
-- Commit convencional
-- Actualizar board
+```
+🎯 HU-001: Autenticación de Usuario (5 pts)
+   Estado: 🟡 En Progreso
 
-### Fase 4: Validacion US
+   Criterios de Aceptación:
+   ┌─────────────────────────────────────────────────────┐
+   │ DADO un usuario registrado con credenciales válidas │
+   │ CUANDO envía el formulario de inicio de sesión      │
+   │ ENTONCES debería ver su panel de control            │
+   │ Y se debería crear una sesión                       │
+   └─────────────────────────────────────────────────────┘
 
-Cuando todas las tareas de una US estan Done:
-- Verificar criterios de aceptacion
-- Ejecutar tests E2E
-- Marcar US → Done
+   Tareas:
+   └─ TAREA-001 [DB] Crear entidad User .............. 🔴 Por Hacer
+   └─ TAREA-002 [BE] Servicio de autenticación ....... 🔴 Por Hacer
+   └─ TAREA-003 [FE-WEB] Formulario de inicio de sesión 🔴 Por Hacer
+   └─ TAREA-004 [TEST] Pruebas E2E de autenticación .. 🔴 Por Hacer
+```
 
-### Fase 5: Cierre Sprint
+### Fase 3: Bucle de Tareas (Flujo de Trabajo TDD)
 
-Cuando todas las US estan Done:
-- Mostrar resumen
-- Generar sprint-review.md
-- Generar sprint-retro.md
+Para cada tarea en Por Hacer:
+
+#### 3.1 Mostrar Detalles de la Tarea
+
+```
+▶️ Iniciando TAREA-001 [DB] Crear entidad User
+
+   Estimación: 2h
+   Descripción: Crear entidad User con email, password_hash, roles
+   Archivos a modificar: src/Entity/User.php, migrations/
+
+   Definición de Hecho:
+   - [ ] Código escrito y funcional
+   - [ ] Las pruebas pasan
+   - [ ] Código revisado (si existe tarea [REV])
+```
+
+#### 3.2 Modo Plan (OBLIGATORIO)
+
+⚠️ **SIEMPRE activar el modo plan antes de implementar**
+
+```
+⚠️ MODO PLAN ACTIVADO
+
+   Analizando tarea TAREA-001...
+
+   📁 Archivos a analizar:
+   - src/Entity/ (patrón de entidades existentes)
+   - config/packages/doctrine.yaml
+   - migrations/ (última migración)
+
+   🔍 Análisis en progreso...
+```
+
+El modo plan DEBE:
+1. **Explorar** el código impactado y las dependencias
+2. **Documentar** los hallazgos del análisis
+3. **Proponer** un plan de implementación con:
+   - Archivos a crear/modificar
+   - Pruebas a escribir (TDD)
+   - Riesgos y mitigaciones
+4. **Esperar** la validación del usuario antes de proceder
+
+```
+📋 Plan de Implementación para TAREA-001
+
+   1. Crear entidad User con propiedades:
+      - id (UUID)
+      - email (único)
+      - password_hash
+      - roles (array JSON)
+      - created_at, updated_at
+
+   2. Pruebas a escribir PRIMERO (TDD):
+      - UserTest::test_user_creation()
+      - UserTest::test_email_validation()
+      - UserTest::test_password_hashing()
+
+   3. Archivos a crear:
+      - src/Entity/User.php
+      - tests/Unit/Entity/UserTest.php
+      - migrations/VersionXXX.php
+
+   ⏳ Esperando validación...
+
+   [continue] Proceder con la implementación
+   [skip] Omitir esta tarea
+   [block] Marcar como bloqueada
+   [stop] Detener sprint-dev
+```
+
+#### 3.3 Marcar Tarea → En Progreso
+
+Después de la validación del plan:
+- Actualizar el estado de la tarea a En Progreso
+- Actualizar board.md
+- Actualizar index.md
+
+#### 3.4 Ciclo TDD
+
+```
+🧪 CICLO TDD - TAREA-001
+
+🔴 Fase RED: Escribir pruebas que fallen
+   Creando tests/Unit/Entity/UserTest.php...
+
+   Ejecutando pruebas... FALLIDO (esperado)
+   ✗ test_user_creation
+   ✗ test_email_validation
+   ✗ test_password_hashing
+
+🟢 Fase GREEN: Implementar el código mínimo
+   Creando src/Entity/User.php...
+
+   Ejecutando pruebas... APROBADO
+   ✓ test_user_creation
+   ✓ test_email_validation
+   ✓ test_password_hashing
+
+🔧 Fase REFACTOR: Mejorar la calidad del código
+   - ¿Extraer la validación de email a un ValueObject? [s/n]
+   - ¿Agregar método factory? [s/n]
+
+   Ejecutando pruebas... APROBADO (sin regresión)
+```
+
+#### 3.5 Verificación de la Definición de Hecho
+
+```
+✅ Definición de Hecho - TAREA-001
+
+- [x] Código escrito y funcional
+- [x] Las pruebas pasan (3/3)
+- [ ] Código revisado → Gestionado por TAREA-XXX [REV]
+
+¡Todas las verificaciones superadas!
+```
+
+#### 3.6 Marcar Tarea → Hecho
+
+```
+📊 Finalización de Tarea
+
+TAREA-001 [DB] Crear entidad User
+├─ Estado: 🟢 Hecho
+├─ Estimado: 2h
+├─ Real: 1.5h
+└─ Eficiencia: 133%
+
+Introduzca el tiempo real empleado (horas): 1.5
+```
+
+Actualizaciones:
+- Metadatos del archivo de tarea (estado, time_spent, updated_at)
+- board.md
+- index.md
+- Métricas del sprint
+
+#### 3.7 Commit Convencional
+
+```
+📝 Creando commit...
+
+feat(entity): create User entity with authentication support
+
+- Add User entity with email, password_hash, roles
+- Add UUID primary key strategy
+- Add timestamps (created_at, updated_at)
+- Add unit tests for User entity
+
+Refs: TAREA-001, HU-001
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### Fase 4: Validación de la Historia de Usuario
+
+Cuando todas las tareas de una HU estén Hechas:
+
+```
+🎯 Validación HU-001
+
+Todas las tareas completadas (4/4)
+
+Verificando criterios de aceptación:
+┌─────────────────────────────────────────────────────┐
+│ ✓ DADO un usuario registrado con credenciales válidas│
+│ ✓ CUANDO envía el formulario de inicio de sesión     │
+│ ✓ ENTONCES debería ver su panel de control           │
+│ ✓ Y se debería crear una sesión                      │
+└─────────────────────────────────────────────────────┘
+
+Ejecutando pruebas E2E si están presentes...
+✓ tests/E2E/AuthenticationTest.php aprobado
+
+HU-001 → 🟢 Hecho
+
+Actualizando progreso de EPIC-001: 1/3 HU completadas (33%)
+```
+
+### Fase 5: Finalización del Sprint
+
+Cuando todas las Historias de Usuario estén Hechas:
+
+```
+🏁 ¡Sprint 1 Completado!
+
+📊 Resumen
+├─ Duración: 8 días (planificado: 10)
+├─ Velocidad: 15 puntos
+├─ Tareas: 17/17 completadas
+└─ Horas: 38h real vs 42h estimado (110% eficiencia)
+
+📈 Métricas por Tipo
+├─ [DB]: 4 tareas, 6h
+├─ [BE]: 5 tareas, 12h
+├─ [FE-WEB]: 4 tareas, 10h
+├─ [TEST]: 3 tareas, 8h
+└─ [DOC]: 1 tarea, 2h
+
+📝 Generando sprint-review.md...
+📝 Generando plantilla sprint-retro.md...
+
+Siguiente: Ejecutar /sprint:dev 2 o /sprint:dev next
+```
 
 ---
 
-## Orden de Procesamiento
+## Orden de Procesamiento de Tareas
 
-| Orden | Tipo | Descripcion |
+Las tareas se procesan por tipo para respetar las dependencias:
+
+| Orden | Tipo | Descripción |
 |-------|------|-------------|
-| 1 | `[DB]` | Base de datos |
-| 2 | `[BE]` | Backend |
-| 3 | `[FE-WEB]` | Frontend Web |
-| 4 | `[FE-MOB]` | Frontend Mobile |
-| 5 | `[TEST]` | Tests adicionales |
-| 6 | `[DOC]` | Documentacion |
-| 7 | `[REV]` | Code Review |
+| 1 | `[DB]` | Base de datos (entidades, migraciones, repositorios) |
+| 2 | `[BE]` | Backend (servicios, APIs, lógica de negocio) |
+| 3 | `[FE-WEB]` | Frontend Web (controladores, plantillas, JS) |
+| 4 | `[FE-MOB]` | Frontend Móvil (pantallas, blocs, widgets) |
+| 5 | `[TEST]` | Pruebas adicionales (E2E, rendimiento) |
+| 6 | `[DOC]` | Documentación |
+| 7 | `[REV]` | Revisión de Código |
 
 ---
 
 ## Comandos de Control
 
-| Comando | Accion |
+Durante la ejecución de sprint-dev:
+
+| Comando | Acción |
 |---------|--------|
-| `continue` | Validar plan y proceder |
-| `skip` | Saltar esta tarea |
-| `block [razon]` | Marcar como bloqueada |
-| `stop` | Detener sprint-dev |
-| `status` | Mostrar progreso |
-| `board` | Mostrar Kanban |
+| `continue` | Validar el plan y proceder con la implementación |
+| `skip` | Omitir esta tarea (permanece Por Hacer) |
+| `block [razón]` | Marcar la tarea como Bloqueada con razón |
+| `stop` | Detener sprint-dev (guarda el estado actual) |
+| `status` | Mostrar el progreso actual |
+| `board` | Mostrar el tablero Kanban |
 
 ---
 
-## Gestion de Bloqueos
+## Gestión de Bloqueos
 
 ```
 ⚠️ Tarea Bloqueada
 
-TASK-003 no puede continuar.
-Razon: Esperando especificaciones API
+TAREA-003 no puede continuar.
+Razón: Esperando la especificación de API del equipo de backend
 
 Opciones:
-[1] Saltar y continuar con siguiente tarea
+[1] Omitir y continuar con la siguiente tarea desbloqueada
 [2] Intentar resolver el bloqueo
 [3] Detener sprint-dev
+
+Elección: 1
+
+Marcando TAREA-003 como Bloqueada...
+Pasando a TAREA-004...
 ```
 
 ---
 
-## Actualizaciones Automaticas
+## Actualizaciones Automáticas
 
-A cada cambio de estado:
-1. Archivo tarea: status, time_spent
-2. Archivo US: progreso tareas
-3. Archivo EPIC: progreso US
-4. board.md: columnas Kanban
-5. index.md: metricas globales
+En cada cambio de estado:
+
+1. **Archivo de tarea**: Actualizar estado, time_spent, updated_at
+2. **Archivo de Historia de Usuario**: Actualizar progreso de tareas, estado si todas están hechas
+3. **Archivo EPIC**: Actualizar progreso de HU
+4. **board.md**: Actualizar columnas del Kanban
+5. **index.md**: Actualizar métricas globales
+6. **sprint-status**: Recalcular métricas
 
 ---
 
-## Ejemplo
+## Reanudar Después de Detener
+
+```bash
+/sprint:dev current
+
+📋 Reanudando Sprint 1: Walking Skeleton
+
+Progreso: 8/17 tareas (47%)
+
+Última completada: TAREA-008 [BE] Servicio de Token JWT
+Siguiente tarea: TAREA-009 [FE-WEB] Controlador de Inicio de Sesión
+
+¿Continuar desde TAREA-009? [s/n]
+```
+
+---
+
+## Sesión de Ejemplo
 
 ```bash
 > /sprint:dev 1
 
 📋 Sprint 1: Walking Skeleton
-   3 US, 17 tareas
+   3 HU, 17 tareas
+   🔴 Por Hacer: 17 | 🟡 En Progreso: 0 | 🟢 Hecho: 0
 
-🎯 Iniciando US-001: Autenticacion (5 pts)
+🎯 Iniciando HU-001: Autenticación de Usuario (5 pts)
+   Marcando como En Progreso...
 
-▶️ TASK-001 [DB] Crear entidad User
+▶️ TAREA-001 [DB] Crear entidad User
 
-⚠️ PLAN MODE ACTIVADO
+⚠️ MODO PLAN ACTIVADO
    Analizando...
+
+   [Detalles del plan mostrados]
 
 > continue
 
+   Marcando TAREA-001 como En Progreso...
+
 🧪 CICLO TDD
-🔴 RED: Escribiendo tests...
+
+🔴 RED: Escribiendo pruebas...
+   [Código de prueba creado]
+   Pruebas: 0/3 pasando (esperado)
+
 🟢 GREEN: Implementando...
-🔧 REFACTOR: Mejoras?
+   [Código de implementación]
+   Pruebas: 3/3 pasando
 
-✅ Definition of Done: PASADO
+🔧 REFACTOR: ¿Alguna mejora? [omitir]
 
-📝 Commit creado
+✅ Definición de Hecho: APROBADA
 
-▶️ TASK-002 [BE] Servicio autenticacion...
+   Introduzca el tiempo real (estimado 2h): 1.5
+
+📝 Commit creado: feat(entity): create User entity
+
+▶️ TAREA-002 [BE] Servicio de autenticación
+
+⚠️ MODO PLAN ACTIVADO
+   ...
 ```
+
+---
+
+## Archivos Actualizados
+
+| Archivo | Actualizaciones |
+|---------|----------------|
+| `project-management/backlog/user-stories/HU-XXX.md` | Estado, progreso de tareas |
+| `project-management/backlog/epics/EPIC-XXX.md` | Progreso de HU |
+| `project-management/sprints/sprint-N-*/board.md` | Columnas del Kanban |
+| `project-management/sprints/sprint-N-*/tasks/*.md` | Estado de tarea, tiempo |
+| `project-management/backlog/index.md` | Métricas globales |
+| `project-management/sprints/sprint-N-*/sprint-review.md` | Generado al final |
 
 ---
 
@@ -187,8 +438,8 @@ A cada cambio de estado:
 
 | Comando | Uso |
 |---------|-----|
-| `/project:decompose-tasks N` | Crear tareas antes |
-| `/project:board N` | Ver Kanban |
-| `/sprint:status N` | Ver metricas |
-| `/project:move-task` | Cambiar estado tarea |
-| `/sprint:transition` | Cambiar estado US |
+| `/project:decompose-tasks N` | Crear tareas antes de sprint-dev |
+| `/project:board N` | Ver tablero Kanban |
+| `/sprint:status N` | Ver métricas del sprint |
+| `/project:move-task` | Cambiar manualmente el estado de una tarea |
+| `/sprint:transition` | Cambiar manualmente el estado de una HU |

--- a/Project/i18n/pt/Sprint/commands/dev.md
+++ b/Project/i18n/pt/Sprint/commands/dev.md
@@ -1,185 +1,436 @@
 ---
 name: sprint-dev
-description: Inicia o desenvolvimento TDD/BDD de um sprint com atualizacao automatica de status
+description: Iniciar o desenvolvimento TDD/BDD de um sprint com atualizações automáticas de status
 arguments:
   - name: sprint
-    description: Numero do sprint, "next" para o proximo incompleto, ou "current"
+    description: Número do sprint, "next" para o próximo sprint incompleto, ou "current"
     required: true
 ---
 
 # /sprint:dev
 
-## Objetivo
+## Propósito
 
-Orquestrar o desenvolvimento completo de um sprint em modo TDD/BDD com:
-- **Plan mode obrigatorio** antes de cada implementacao
+Orquestrar o desenvolvimento completo do sprint no modo TDD/BDD com:
+- **Modo de planejamento obrigatório** antes de cada implementação de tarefa
 - **Ciclo TDD** (RED → GREEN → REFACTOR)
-- **Atualizacao automatica** de status (Tarefa → User Story → Sprint)
-- **Acompanhamento de progresso** e metricas
+- **Atualizações automáticas de status** (Tarefa → User Story → Sprint)
+- **Rastreamento de progresso** e métricas
 
-## Pre-requisitos
+## Pré-requisitos
 
-- Sprint existente com tarefas decompostas
+- Sprint existe com tarefas decompostas
 - Arquivos presentes: `sprint-backlog.md`, `tasks/*.md`
-- Executar `/project:decompose-tasks N` primeiro se necessario
+- Executar `/project:decompose-tasks N` primeiro se necessário
 
 ## Argumentos
 
 ```bash
 /sprint:dev 1        # Sprint 1
-/sprint:dev next     # Proximo sprint incompleto
+/sprint:dev next     # Próximo sprint incompleto
 /sprint:dev current  # Sprint atualmente ativo
 ```
 
 ---
 
-## Workflow
+## Fluxo de Trabalho
 
-### Fase 1: Inicializacao
+### Fase 1: Inicialização
 
 1. Carregar sprint de `project-management/sprints/sprint-N-*/`
-2. Ler `sprint-backlog.md` para obter User Stories
-3. Listar tarefas por US (ordenadas por dependencias)
-4. Exibir board inicial
-
-### Fase 2: Loop User Story
-
-Para cada US em status To Do ou In Progress:
-1. Marcar US → In Progress
-2. Exibir criterios de aceitacao (Gherkin)
-3. Processar cada tarefa da US
-
-### Fase 3: Loop Tarefa (Workflow TDD)
-
-Para cada tarefa em To Do:
-
-#### 3.1 Plan Mode (OBRIGATORIO)
-
-⚠️ **SEMPRE ativar plan mode antes de implementar**
-
-- Explorar codigo impactado
-- Documentar analise
-- Propor plano de implementacao
-- Aguardar validacao do usuario
-
-#### 3.2 Ciclo TDD
+2. Ler `sprint-backlog.md` para obter as User Stories
+3. Listar tarefas por US (ordenadas por dependências)
+4. Exibir o quadro inicial
 
 ```
-🔴 RED    : Escrever testes que falham
-🟢 GREEN  : Implementar codigo minimo
-🔧 REFACTOR : Melhorar sem quebrar testes
+📋 Sprint 1: Walking Skeleton
+   Objetivo: Completar o fluxo de autenticação end-to-end
+
+   3 User Stories, 17 Tarefas
+
+   🔴 A Fazer: 15 | 🟡 Em Andamento: 2 | 🟢 Concluído: 0
 ```
 
-#### 3.3 Definition of Done
+### Fase 2: Loop de User Story
 
-- [ ] Codigo escrito e funcional
-- [ ] Testes passam
-- [ ] Codigo revisado (se existe tarefa [REV])
+Para cada User Story com status A Fazer ou Em Andamento:
 
-#### 3.4 Marcar Tarefa → Done
+1. **Marcar US → Em Andamento** (se A Fazer)
+2. **Exibir critérios de aceitação** (formato Gherkin)
+3. **Processar cada tarefa** desta US
 
-- Atualizar metadados
-- Commit convencional
-- Atualizar board
+```
+🎯 US-001: Autenticação de Usuário (5 pts)
+   Status: 🟡 Em Andamento
 
-### Fase 4: Validacao US
+   Critérios de Aceitação:
+   ┌─────────────────────────────────────────────────────┐
+   │ DADO um usuário registrado com credenciais válidas  │
+   │ QUANDO ele enviar o formulário de login             │
+   │ ENTÃO ele deve ver seu painel                       │
+   │ E uma sessão deve ser criada                        │
+   └─────────────────────────────────────────────────────┘
 
-Quando todas as tarefas de uma US estao Done:
-- Verificar criterios de aceitacao
-- Executar testes E2E
-- Marcar US → Done
+   Tarefas:
+   └─ TASK-001 [DB] Criar entidade User ................. 🔴 A Fazer
+   └─ TASK-002 [BE] Serviço de autenticação ............. 🔴 A Fazer
+   └─ TASK-003 [FE-WEB] Formulário de login ............. 🔴 A Fazer
+   └─ TASK-004 [TEST] Testes E2E de autenticação ........ 🔴 A Fazer
+```
 
-### Fase 5: Encerramento Sprint
+### Fase 3: Loop de Tarefa (Fluxo TDD)
 
-Quando todas as US estao Done:
-- Exibir resumo
-- Gerar sprint-review.md
-- Gerar sprint-retro.md
+Para cada tarefa A Fazer:
+
+#### 3.1 Exibir Detalhes da Tarefa
+
+```
+▶️ Iniciando TASK-001 [DB] Criar entidade User
+
+   Estimativa: 2h
+   Descrição: Criar entidade User com email, password_hash, roles
+   Arquivos a modificar: src/Entity/User.php, migrations/
+
+   Definição de Pronto:
+   - [ ] Código escrito e funcional
+   - [ ] Testes passam
+   - [ ] Código revisado (se tarefa [REV] existe)
+```
+
+#### 3.2 Modo de Planejamento (OBRIGATÓRIO)
+
+⚠️ **SEMPRE ativar o modo de planejamento antes de implementar**
+
+```
+⚠️ MODO DE PLANEJAMENTO ATIVADO
+
+   Analisando tarefa TASK-001...
+
+   📁 Arquivos a analisar:
+   - src/Entity/ (padrão de entidades existentes)
+   - config/packages/doctrine.yaml
+   - migrations/ (última migração)
+
+   🔍 Análise em progresso...
+```
+
+O modo de planejamento DEVE:
+1. **Explorar** o código impactado e as dependências
+2. **Documentar** os resultados da análise
+3. **Propor** o plano de implementação com:
+   - Arquivos a criar/modificar
+   - Testes a escrever (TDD)
+   - Riscos e mitigações
+4. **Aguardar** a validação do usuário antes de prosseguir
+
+```
+📋 Plano de Implementação para TASK-001
+
+   1. Criar entidade User com propriedades:
+      - id (UUID)
+      - email (único)
+      - password_hash
+      - roles (array JSON)
+      - created_at, updated_at
+
+   2. Testes a escrever PRIMEIRO (TDD):
+      - UserTest::test_user_creation()
+      - UserTest::test_email_validation()
+      - UserTest::test_password_hashing()
+
+   3. Arquivos a criar:
+      - src/Entity/User.php
+      - tests/Unit/Entity/UserTest.php
+      - migrations/VersionXXX.php
+
+   ⏳ Aguardando validação...
+
+   [continue] Prosseguir com a implementação
+   [skip] Pular esta tarefa
+   [block] Marcar como bloqueada
+   [stop] Parar sprint-dev
+```
+
+#### 3.3 Marcar Tarefa → Em Andamento
+
+Após a validação do plano:
+- Atualizar o status da tarefa para Em Andamento
+- Atualizar board.md
+- Atualizar index.md
+
+#### 3.4 Ciclo TDD
+
+```
+🧪 CICLO TDD - TASK-001
+
+🔴 Fase RED: Escrever testes que falham
+   Criando tests/Unit/Entity/UserTest.php...
+
+   Executando testes... FALHOU (esperado)
+   ✗ test_user_creation
+   ✗ test_email_validation
+   ✗ test_password_hashing
+
+🟢 Fase GREEN: Implementar código mínimo
+   Criando src/Entity/User.php...
+
+   Executando testes... PASSOU
+   ✓ test_user_creation
+   ✓ test_email_validation
+   ✓ test_password_hashing
+
+🔧 Fase REFACTOR: Melhorar a qualidade do código
+   - Extrair validação de email para ValueObject? [s/n]
+   - Adicionar método factory? [s/n]
+
+   Executando testes... PASSOU (sem regressão)
+```
+
+#### 3.5 Verificação da Definição de Pronto
+
+```
+✅ Definição de Pronto - TASK-001
+
+- [x] Código escrito e funcional
+- [x] Testes passam (3/3)
+- [ ] Código revisado → Tratado por TASK-XXX [REV]
+
+Todas as verificações passaram!
+```
+
+#### 3.6 Marcar Tarefa → Concluída
+
+```
+📊 Conclusão da Tarefa
+
+TASK-001 [DB] Criar entidade User
+├─ Status: 🟢 Concluído
+├─ Estimado: 2h
+├─ Real: 1.5h
+└─ Eficiência: 133%
+
+Inserir tempo real gasto (horas): 1.5
+```
+
+Atualizações:
+- Metadados do arquivo de tarefa (status, time_spent, updated_at)
+- board.md
+- index.md
+- Métricas do sprint
+
+#### 3.7 Commit Convencional
+
+```
+📝 Criando commit...
+
+feat(entity): create User entity with authentication support
+
+- Add User entity with email, password_hash, roles
+- Add UUID primary key strategy
+- Add timestamps (created_at, updated_at)
+- Add unit tests for User entity
+
+Refs: TASK-001, US-001
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+
+Co-Authored-By: Claude <noreply@anthropic.com>
+```
+
+### Fase 4: Validação de User Story
+
+Quando todas as tarefas de uma US estiverem Concluídas:
+
+```
+🎯 Validação da US-001
+
+Todas as tarefas concluídas (4/4)
+
+Verificando critérios de aceitação:
+┌─────────────────────────────────────────────────────┐
+│ ✓ DADO um usuário registrado com credenciais válidas│
+│ ✓ QUANDO ele enviar o formulário de login           │
+│ ✓ ENTÃO ele deve ver seu painel                     │
+│ ✓ E uma sessão deve ser criada                      │
+└─────────────────────────────────────────────────────┘
+
+Executando testes E2E se presentes...
+✓ tests/E2E/AuthenticationTest.php passou
+
+US-001 → 🟢 Concluída
+
+Atualizando progresso da EPIC-001: 1/3 US concluídas (33%)
+```
+
+### Fase 5: Conclusão do Sprint
+
+Quando todas as User Stories estiverem Concluídas:
+
+```
+🏁 Sprint 1 Concluído!
+
+📊 Resumo
+├─ Duração: 8 dias (planejado: 10)
+├─ Velocidade: 15 pontos
+├─ Tarefas: 17/17 concluídas
+└─ Horas: 38h real vs 42h estimado (110% de eficiência)
+
+📈 Métricas por Tipo
+├─ [DB]: 4 tarefas, 6h
+├─ [BE]: 5 tarefas, 12h
+├─ [FE-WEB]: 4 tarefas, 10h
+├─ [TEST]: 3 tarefas, 8h
+└─ [DOC]: 1 tarefa, 2h
+
+📝 Gerando sprint-review.md...
+📝 Gerando template sprint-retro.md...
+
+Próximo: Executar /sprint:dev 2 ou /sprint:dev next
+```
 
 ---
 
-## Ordem de Processamento
+## Ordem de Processamento de Tarefas
 
-| Ordem | Tipo | Descricao |
+As tarefas são processadas por tipo para respeitar as dependências:
+
+| Ordem | Tipo | Descrição |
 |-------|------|-----------|
-| 1 | `[DB]` | Banco de dados |
-| 2 | `[BE]` | Backend |
-| 3 | `[FE-WEB]` | Frontend Web |
-| 4 | `[FE-MOB]` | Frontend Mobile |
-| 5 | `[TEST]` | Testes adicionais |
-| 6 | `[DOC]` | Documentacao |
-| 7 | `[REV]` | Code Review |
+| 1 | `[DB]` | Banco de dados (entidades, migrações, repositórios) |
+| 2 | `[BE]` | Backend (serviços, APIs, lógica de negócio) |
+| 3 | `[FE-WEB]` | Frontend Web (controllers, templates, JS) |
+| 4 | `[FE-MOB]` | Frontend Mobile (telas, blocs, widgets) |
+| 5 | `[TEST]` | Testes adicionais (E2E, performance) |
+| 6 | `[DOC]` | Documentação |
+| 7 | `[REV]` | Revisão de Código |
 
 ---
 
 ## Comandos de Controle
 
-| Comando | Acao |
+Durante a execução do sprint-dev:
+
+| Comando | Ação |
 |---------|------|
-| `continue` | Validar plano e prosseguir |
-| `skip` | Pular esta tarefa |
-| `block [razao]` | Marcar como bloqueada |
-| `stop` | Parar sprint-dev |
-| `status` | Exibir progresso |
-| `board` | Exibir Kanban |
+| `continue` | Validar plano e prosseguir com a implementação |
+| `skip` | Pular esta tarefa (permanece A Fazer) |
+| `block [reason]` | Marcar tarefa como Bloqueada com motivo |
+| `stop` | Parar o sprint-dev (salva o estado atual) |
+| `status` | Exibir progresso atual |
+| `board` | Mostrar quadro Kanban |
 
 ---
 
-## Gestao de Bloqueios
+## Tratamento de Bloqueios
 
 ```
 ⚠️ Tarefa Bloqueada
 
-TASK-003 nao pode continuar.
-Razao: Aguardando especificacoes da API
+TASK-003 não pode prosseguir.
+Motivo: Aguardando especificação de API da equipe de backend
 
-Opcoes:
-[1] Pular e continuar com proxima tarefa
+Opções:
+[1] Pular e continuar com a próxima tarefa não bloqueada
 [2] Tentar resolver o bloqueio
-[3] Parar sprint-dev
+[3] Parar o sprint-dev
+
+Escolha: 1
+
+Marcando TASK-003 como Bloqueada...
+Avançando para TASK-004...
 ```
 
 ---
 
-## Atualizacoes Automaticas
+## Atualizações Automáticas
 
-A cada mudanca de status:
-1. Arquivo tarefa: status, time_spent
-2. Arquivo US: progresso tarefas
-3. Arquivo EPIC: progresso US
-4. board.md: colunas Kanban
-5. index.md: metricas globais
+A cada mudança de status:
+
+1. **Arquivo de tarefa**: Atualizar status, time_spent, updated_at
+2. **Arquivo de User Story**: Atualizar progresso das tarefas, status se todas concluídas
+3. **Arquivo EPIC**: Atualizar progresso das US
+4. **board.md**: Atualizar colunas Kanban
+5. **index.md**: Atualizar métricas globais
+6. **sprint-status**: Recalcular métricas
 
 ---
 
-## Exemplo
+## Retomar Após Parada
+
+```bash
+/sprint:dev current
+
+📋 Retomando Sprint 1: Walking Skeleton
+
+Progresso: 8/17 tarefas (47%)
+
+Última concluída: TASK-008 [BE] JWT Token Service
+Próxima tarefa: TASK-009 [FE-WEB] Login Controller
+
+Continuar a partir de TASK-009? [s/n]
+```
+
+---
+
+## Sessão de Exemplo
 
 ```bash
 > /sprint:dev 1
 
 📋 Sprint 1: Walking Skeleton
    3 US, 17 tarefas
+   🔴 A Fazer: 17 | 🟡 Em Andamento: 0 | 🟢 Concluído: 0
 
-🎯 Iniciando US-001: Autenticacao (5 pts)
+🎯 Iniciando US-001: Autenticação de Usuário (5 pts)
+   Marcando como Em Andamento...
 
 ▶️ TASK-001 [DB] Criar entidade User
 
-⚠️ PLAN MODE ATIVADO
+⚠️ MODO DE PLANEJAMENTO ATIVADO
    Analisando...
+
+   [Detalhes do plano exibidos]
 
 > continue
 
+   Marcando TASK-001 como Em Andamento...
+
 🧪 CICLO TDD
+
 🔴 RED: Escrevendo testes...
+   [Código de teste criado]
+   Testes: 0/3 passando (esperado)
+
 🟢 GREEN: Implementando...
-🔧 REFACTOR: Melhorias?
+   [Código de implementação]
+   Testes: 3/3 passando
 
-✅ Definition of Done: PASSOU
+🔧 REFACTOR: Alguma melhoria? [pular]
 
-📝 Commit criado
+✅ Definição de Pronto: APROVADA
 
-▶️ TASK-002 [BE] Servico autenticacao...
+   Inserir tempo real (estimado 2h): 1.5
+
+📝 Commit criado: feat(entity): create User entity
+
+▶️ TASK-002 [BE] Serviço de autenticação
+
+⚠️ MODO DE PLANEJAMENTO ATIVADO
+   ...
 ```
+
+---
+
+## Arquivos Atualizados
+
+| Arquivo | Atualizações |
+|---------|--------------|
+| `project-management/backlog/user-stories/US-XXX.md` | Status, progresso de tarefas |
+| `project-management/backlog/epics/EPIC-XXX.md` | Progresso de US |
+| `project-management/sprints/sprint-N-*/board.md` | Colunas Kanban |
+| `project-management/sprints/sprint-N-*/tasks/*.md` | Status da tarefa, tempo |
+| `project-management/backlog/index.md` | Métricas globais |
+| `project-management/sprints/sprint-N-*/sprint-review.md` | Gerado ao final |
 
 ---
 
@@ -187,8 +438,8 @@ A cada mudanca de status:
 
 | Comando | Uso |
 |---------|-----|
-| `/project:decompose-tasks N` | Criar tarefas antes |
-| `/project:board N` | Ver Kanban |
-| `/sprint:status N` | Ver metricas |
-| `/project:move-task` | Alterar status tarefa |
-| `/sprint:transition` | Alterar status US |
+| `/project:decompose-tasks N` | Criar tarefas antes do sprint-dev |
+| `/project:board N` | Ver quadro Kanban |
+| `/sprint:status N` | Ver métricas do sprint |
+| `/project:move-task` | Alterar manualmente o status da tarefa |
+| `/sprint:transition` | Alterar manualmente o status da US |

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -58,7 +58,7 @@ Replace `react` with your technology: `symfony`, `flutter`, `python`, `angular`,
 **What you should see:**
 
 ```
-  Claude Craft v8.8.1 - AI Development Framework
+  Claude Craft v8.8.2 - AI Development Framework
 
   Installing react rules to /home/user/my-project...
   [OK] Common rules installed

--- a/docs/guides/de/01-getting-started.md
+++ b/docs/guides/de/01-getting-started.md
@@ -1,65 +1,84 @@
 # Erste Schritte mit Claude-Craft
 
-Willkommen bei Claude-Craft! Diese Anleitung hilft Ihnen zu verstehen, was Claude-Craft ist und wie Sie Ihr erstes Projekt in nur 5 Minuten starten können.
+Willkommen bei Claude-Craft! Dieser Leitfaden hilft Ihnen zu verstehen, was Claude-Craft ist, und Ihr erstes Projekt in nur 5 Minuten zum Laufen zu bringen.
 
 ---
 
 ## Was ist Claude-Craft?
 
-Claude-Craft ist ein umfassendes Framework für KI-unterstützte Entwicklung mit Claude Code. Es bietet:
+Claude-Craft ist ein umfassendes Framework für KI-gestützte Entwicklung mit Claude Code. Es bietet:
 
-- **125 Slash-Befehle** - Schnelle Aktionen in 15 Namespaces für Codegenerierung, Analyse und Qualitätsprüfungen
-- **70 KI-Agenten (31 spezialisiert + 39 Infra auf Abruf)** - Spezialisierte Assistenten für verschiedene Aufgaben (API-Design, Architektur, Code-Review, DevOps, etc.)
-- **11 Technologie-Stacks** - Von .NET/C# bis Vue.js, mit eigenen Regeln und Agenten
-- **48 Skills** - Best Practices für Architektur, Tests, Sicherheit und Codequalität
-- **21 Vorlagen** - Einsatzbereite Code-Muster
-- **10 Checklisten** - Qualitätstore für Features und Releases
+- **125 Slash-Befehle** – Schnelle Aktionen in 15 Namespaces für Codegenerierung, Analyse und Qualitätsprüfungen
+- **70 KI-Agenten (31 spezialisiert + 39 Infra auf Abruf)** – Spezialisierte Assistenten mit optimierten Aufwandsstufen und dauerhaftem Gedächtnis
+- **11 Technologie-Stacks** – Von .NET/C# bis Vue.js, mit eigenen Regeln und Agenten
+- **48 Skills** – Best Practices für Architektur, Tests und Sicherheit
+- **21 Vorlagen** – Einsatzbereite Code-Muster für gängige Komponenten
+- **10 Checklisten** – Qualitätstore für Features, Releases und Sicherheitsaudits
+- **937 Testsuiten** – Umfassende Validierung (vitest + bats)
 
 ### Unterstützte Technologien
 
 | Technologie | Fokus | Anwendungsfälle |
 |-------------|-------|-----------------|
-| **Symfony / PHP** | Clean Architecture + DDD | APIs, Web-Apps, Backend-Services |
+| **.NET / C#** | Clean Architecture + CQRS | APIs, Enterprise-Anwendungen |
+| **Symfony** | Clean Architecture + DDD | APIs, Web-Apps, Backend-Services |
+| **Flutter** | BLoC-Muster | Mobile Apps (iOS/Android) |
+| **Python** | FastAPI + async/await | APIs, Datendienste, ML-Backends |
 | **React** | Hooks + State Management | Web-SPAs, Dashboards |
-| **Flutter / Dart** | BLoC-Muster | Mobile Apps (iOS/Android) |
-| **Python** | FastAPI + async/await | APIs, Datendienste, ML |
-| **Angular** | Signals + Standalone | Enterprise-SPAs |
-| **Vue.js** | Composition API + Pinia | Web-SPAs, Dashboards |
-| **React Native** | New Architecture | Plattformübergreifende Mobile Apps |
-| **C# / .NET** | Clean Architecture + CQRS | Enterprise-APIs, Microservices |
-| **Laravel** | Actions Pattern | APIs, CMS, E-Commerce |
-| **PHP** | PSR-12 + PHPStan | Bibliotheken, APIs |
-| **Docker** | Containerisierung | Lokale Entwicklung, CI/CD |
-| **Coolify** | Self-hosted PaaS | Einfache Deployments |
-| **Kubernetes** | Orchestrierung | Microservices, Skalierung |
-| **OpenTofu** | IaC | Multi-Cloud |
-| **Ansible** | Automatisierung | Konfigurationsmanagement |
-| **Hcloud** | Hetzner Cloud | Europäisches Hosting |
-| **PgBouncer** | Connection Pooling | PostgreSQL Hochlast |
-| **FrankenPHP** | PHP/Go-Server | PHP-Performance |
+| **React Native** | Plattformübergreifend Mobile | Mobile Apps mit JS |
+| **Angular** | Signals + Standalone | Enterprise-Web-Apps |
+| **Vue.js** | Composition API + Pinia | Web-SPAs, Progressive Apps |
+| **Laravel** | Clean Architecture + Actions | APIs, Web-Apps |
+| **PHP** | PSR-12 + PHPStan | Bibliotheken, Backend-Services |
+| **Docker** | Infrastruktur | Containerisierung, CI/CD |
 
 ### Unterstützte Sprachen
 
-Alle Inhalte sind in 5 Sprachen verfügbar: Englisch (en), Französisch (fr), Spanisch (es), Deutsch (de), Portugiesisch (pt)
+Alle Inhalte sind in 5 Sprachen verfügbar:
+- Englisch (en)
+- Französisch (fr)
+- Spanisch (es)
+- Deutsch (de)
+- Portugiesisch (pt)
 
 ---
 
 ## Voraussetzungen
 
 ### Erforderlich
-- **Bash** - Shell zum Ausführen von Installationsskripten
-- **Claude Code** - Der KI-Coding-Assistent von Anthropic
+
+- **Bash** – Shell zum Ausführen von Installationsskripten
+- **Claude Code** – Der KI-Coding-Assistent von Anthropic
+
+### Claude Code Kompatibilität
+
+| Version | Status |
+|---------|--------|
+| **2.1.159** | Empfohlen (volle Feature-Unterstützung) |
+| **2.1.97+** | Mindestversion (CVE-2025-59536 gepatcht) |
 
 ### Optional (Empfohlen)
-```bash
-# yq - YAML-Prozessor
-brew install yq  # macOS
-sudo apt install yq  # Linux
 
-# jq - JSON-Prozessor (für StatusLine)
-brew install jq  # macOS
-sudo apt install jq  # Linux
-```
+- **yq** – YAML-Prozessor für Konfigurationsdateien
+  ```bash
+  # macOS
+  brew install yq
+
+  # Linux (Debian/Ubuntu)
+  sudo apt install yq
+
+  # Linux (snap)
+  sudo snap install yq
+  ```
+
+- **jq** – JSON-Prozessor (für das StatusLine-Tool)
+  ```bash
+  # macOS
+  brew install jq
+
+  # Linux
+  sudo apt install jq
+  ```
 
 ---
 
@@ -68,90 +87,200 @@ sudo apt install jq  # Linux
 ### Methode 1: Makefile (Empfohlen)
 
 ```bash
+# Claude-Craft klonen
 git clone https://github.com/thebeardedcto/claude-craft.git
 cd claude-craft
 
-# Für Symfony-Projekt installieren (auf Deutsch)
-make install-symfony TARGET=~/mein-projekt LANG=de
+# Für ein Symfony-Projekt installieren (auf Französisch)
+make install-symfony TARGET=~/my-project LANG=fr
+
+# Oder für ein Flutter-Projekt (auf Englisch)
+make install-flutter TARGET=~/my-app LANG=en
 ```
 
 ### Methode 2: Direktes Skript
 
 ```bash
-./Dev/scripts/install-symfony-rules.sh --lang=de ~/mein-projekt
+# Zum Claude-Craft-Verzeichnis navigieren
+cd claude-craft
+
+# Installationsskript ausführen
+./Dev/scripts/install-symfony-rules.sh --lang=fr ~/my-project
 ```
 
 ### Methode 3: YAML-Konfiguration (für Monorepos)
 
 ```bash
+# Konfigurationsdatei erstellen
 cp claude-projects.yaml.example claude-projects.yaml
+
+# Mit Ihren Projekten bearbeiten
 nano claude-projects.yaml
-make config-install CONFIG=claude-projects.yaml PROJECT=mein-projekt
+
+# Aus Konfiguration installieren
+make config-install CONFIG=claude-projects.yaml PROJECT=my-project
 ```
 
 ---
 
 ## Ihr erstes Projekt in 5 Minuten
 
+Erstellen wir ein neues Symfony-API-Projekt mit französischen Regeln.
+
+### Schritt 1: Projektverzeichnis erstellen
+
 ```bash
-# Schritt 1: Projektverzeichnis erstellen
-mkdir ~/meine-api && cd ~/meine-api && git init
-
-# Schritt 2: Claude-Craft-Regeln installieren
-make install-symfony TARGET=~/meine-api LANG=de
-
-# Schritt 3: Installation überprüfen
-ls -la ~/meine-api/.claude/
-
-# Schritt 4: Projektkontext konfigurieren (wählen Sie eine Option)
-# Option A: Interaktiv (empfohlen)
-cd ~/meine-api && claude
-# Dann ausführen: /common:setup-project-context
-
-# Option B: Manuell
-nano ~/meine-api/.claude/rules/00-project-context.md
-
-# Schritt 5: Claude Code starten
-cd ~/meine-api && claude
+mkdir ~/my-api
+cd ~/my-api
+git init
 ```
+
+### Schritt 2: Claude-Craft-Regeln installieren
+
+```bash
+# Aus dem claude-craft-Verzeichnis heraus
+make install-symfony TARGET=~/my-api LANG=fr
+```
+
+### Schritt 3: Installation überprüfen
+
+```bash
+ls -la ~/my-api/.claude/
+```
+
+Sie sollten Folgendes sehen:
+```
+.claude/
+├── CLAUDE.md           # Hauptkonfiguration
+├── .claudeignore       # Ignoriermuster zur Kontextreduzierung
+├── settings.json       # Optimierte Standardwerte mit PostCompact-Hook
+├── settings.local.json # Lokale Berechtigungen (Wildcard-Muster)
+├── rules/              # 21 Regeldateien
+├── agents/             # KI-Agenten mit Aufwands-/Gedächtnisoptimierung
+├── commands/           # Slash-Befehle
+│   ├── common/         # Übergreifende Befehle
+│   └── symfony/        # Symfony-spezifische Befehle
+├── templates/          # Code-Vorlagen
+└── checklists/         # Qualitätstore
+```
+
+### Schritt 4: Projektkontext konfigurieren
+
+Sie können den Projektkontext interaktiv oder manuell konfigurieren:
+
+**Option A: Interaktiv (Empfohlen)**
+```bash
+cd ~/my-api && claude
+# Dann ausführen:
+/common:setup-project-context
+```
+
+**Option B: Manuell**
+```bash
+nano ~/my-api/.claude/rules/00-project-context.md
+```
+
+Aktualisieren Sie diese Abschnitte:
+- Projektname und Beschreibung
+- Details zum Technologie-Stack
+- Team-Konventionen
+- Spezifische Einschränkungen
+
+### Schritt 5: Claude Code starten
+
+```bash
+cd ~/my-api
+claude
+```
+
+Jetzt können Sie alle installierten Befehle und Agenten verwenden!
 
 ---
 
-## Struktur verstehen
+## Die Struktur verstehen
 
 ### Regeln (`rules/`)
-Richtlinien, denen Claude bei der Arbeit an Ihrem Projekt folgt, nach Priorität nummeriert (00-12+).
+
+Regeln sind Richtlinien, denen Claude bei der Arbeit an Ihrem Projekt folgt. Sie sind nach Priorität nummeriert:
+
+| Nummer | Thema |
+|--------|-------|
+| 00 | Projektkontext (diesen anpassen!) |
+| 01 | Workflow und Analyse |
+| 02 | Architektur |
+| 03 | Coding-Standards |
+| 04 | SOLID-Prinzipien |
+| 05 | KISS, DRY, YAGNI |
+| 06 | Docker und Tooling |
+| 07 | Testing |
+| 08 | Qualitätswerkzeuge |
+| 09 | Git-Workflow |
+| 10 | Dokumentation |
+| 11 | Sicherheit |
+| 12+ | Fortgeschrittene Themen (DDD, CQRS, usw.) |
 
 ### Agenten (`agents/`)
+
+Agenten sind spezialisierte KI-Personas, die Sie für bestimmte Aufgaben aufrufen können:
+
 ```markdown
-@api-designer Entwerfe die REST-API für Benutzerverwaltung
-@database-architect Erstelle das Schema für das Bestell-Aggregat
-@symfony-reviewer Überprüfe meine UserService-Implementierung
+@api-designer Design the REST API for user management
+@database-architect Create the schema for the Order aggregate
+@symfony-reviewer Review my UserService implementation
+@tdd-coach Help me write tests for the authentication flow
 ```
 
 ### Befehle (`commands/`)
+
+Slash-Befehle sind Schnellaktionen:
+
 ```bash
+# Code generieren
 /symfony:generate-crud User
+
+# Qualität prüfen
 /symfony:check-compliance
+
+# Architektur analysieren
 /common:architecture-decision
 ```
 
 ### Vorlagen (`templates/`)
-service.md, value-object.md, aggregate-root.md, test-unit.md
+
+Vorlagen stellen Code-Muster bereit:
+- `service.md` – Vorlage für Service-Klassen
+- `value-object.md` – Vorlage für Value Objects
+- `aggregate-root.md` – Vorlage für DDD-Aggregate-Roots
+- `test-unit.md` – Vorlage für Unit-Tests
 
 ### Checklisten (`checklists/`)
-feature-checklist.md, pre-commit.md, release.md, security-audit.md
+
+Qualitätstore für verschiedene Szenarien:
+- `feature-checklist.md` – Vor dem Abschluss eines Features
+- `pre-commit.md` – Vor dem Commit von Code
+- `release.md` – Vor einem Release
+- `security-audit.md` – Sicherheitsüberprüfung
 
 ---
 
 ## Schlüsselkonzepte
 
 ### 1. TDD-Workflow
+
+Claude-Craft setzt testgetriebene Entwicklung durch:
+
 ```
-1. Analysieren → 2. Tests → 3. Implementieren → 4. Refactoring → 5. Review
+1. Anforderungen analysieren
+2. Fehlschlagende Tests schreiben
+3. Code implementieren
+4. Refaktorieren
+5. Überprüfen
 ```
 
 ### 2. Clean Architecture
+
+Alle Technologie-Stacks folgen den Prinzipien der Clean Architecture:
+
 ```
 ┌─────────────────────────────────────┐
 │           Präsentation              │
@@ -165,19 +294,82 @@ feature-checklist.md, pre-commit.md, release.md, security-audit.md
 ```
 
 ### 3. Qualität zuerst
-- 80%+ Testabdeckung
+
+Jedes Feature muss Qualitätstore passieren:
+- 80 %+ Testabdeckung
 - Statische Analyse bestanden
 - Sicherheitsaudit bestanden
 - Dokumentation aktualisiert
 
 ---
 
-## Nächste Schritte
+## Automatische Optimierungen (v8.7)
 
-1. **[Anleitung zur Projekterstellung](02-project-creation.md)**
-2. **[Anleitung zur Feature-Entwicklung](03-feature-development.md)**
-3. **[Anleitung zur Fehlerbehebung](04-bug-fixing.md)**
+Claude-Craft enthält jetzt standardmäßig optimierte Voreinstellungen:
+
+**Automatisch installiert:**
+- ✓ `.claudeignore` zur Reduzierung des Kontextrauschens
+- ✓ `settings.json` mit PostCompact-Hook für Kontext-Reinjektion
+- ✓ `settings.local.json` mit Wildcard-Berechtigungen
+- ✓ `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` für Kosteneinsparungen erzwungen
+- ✓ RTK `--ultra-compact` wird automatisch bei der Installation gepatcht
+
+**Optional: RTK-Integration**
+
+Für maximale CLI-Output-Reduzierung (60–90 % Einsparungen):
+
+```bash
+# In Claude Code den Setup-Befehl ausführen
+/common:setup-rtk
+```
+
+**Erwartete Einsparungen:** 55–65 % Gesamttoken-Reduzierung mit vollständigem RTK + Optimierungen. Weitere Informationen finden Sie im [Setup-Leitfaden](08-setup-new-project.md).
 
 ---
 
-[Weiter: Projekterstellung &rarr;](02-project-creation.md)
+## Nächste Schritte
+
+Jetzt, da Sie die Grundlagen verstehen, fahren Sie fort mit:
+
+1. **[Leitfaden zur Projekterstellung](02-project-creation.md)** – Detailliertes Setup für verschiedene Szenarien
+2. **[Leitfaden zur Feature-Entwicklung](03-feature-development.md)** – TDD-Workflow mit Agenten und Befehlen
+3. **[Leitfaden zur Fehlerbehebung](04-bug-fixing.md)** – Diagnose und Regressionstests-Workflow
+
+---
+
+## Kurzreferenz
+
+### Gängige Befehle
+
+```bash
+# Installation
+make install-{tech} TARGET=path LANG=xx
+
+# Verfügbare Optionen auflisten
+make help
+
+# YAML-Konfiguration validieren
+make config-validate CONFIG=file.yaml
+```
+
+### Nützliche Agenten
+
+| Agent | Zweck |
+|-------|-------|
+| `@api-designer` | API-Design und Dokumentation |
+| `@database-architect` | Datenbankschema-Design |
+| `@tdd-coach` | Unterstützung beim Schreiben von Tests |
+| `@{tech}-reviewer` | Code-Review für bestimmte Technologien |
+
+### Wesentliche Befehle
+
+| Befehl | Zweck |
+|--------|-------|
+| `/common:analyze-feature` | Anforderungen analysieren |
+| `/{tech}:generate-crud` | CRUD-Code generieren |
+| `/{tech}:check-compliance` | Vollständiges Qualitätsaudit |
+| `/common:security-audit` | Sicherheitsüberprüfung |
+
+---
+
+[Weiter: Leitfaden zur Projekterstellung &rarr;](02-project-creation.md)

--- a/docs/guides/de/02-project-creation.md
+++ b/docs/guides/de/02-project-creation.md
@@ -1,183 +1,604 @@
-# Anleitung zur Projekterstellung
+# Leitfaden zur Projekterstellung
 
-Diese Anleitung begleitet Sie bei der Einrichtung eines neuen Projekts mit Claude-Craft.
+Dieser Leitfaden führt Sie durch die Einrichtung eines neuen Projekts mit Claude-Craft, von der Wahl des Technologie-Stacks bis zur Konfiguration Ihrer Entwicklungsumgebung.
 
 ---
 
-## Technologie wählen
+## Inhaltsverzeichnis
 
-Claude-Craft unterstützt **11 Technologie-Stacks** (Anwendungen) + 8 Infrastruktur-Stacks:
+1. [Ihre Technologie auswählen](#ihre-technologie-auswählen)
+2. [Installationsmethoden](#installationsmethoden)
+3. [Einzelne Technologieprojekte](#einzelne-technologieprojekte)
+4. [Monorepo-Projekte](#monorepo-projekte)
+5. [Konfiguration nach der Installation](#konfiguration-nach-der-installation)
+6. [Checkliste für den Projektstart](#checkliste-für-den-projektstart)
 
-### Entwicklungs-Stacks
+---
 
-| Technologie | Ideal für | Architektur | Hauptmerkmale |
-|-------------|-----------|-------------|---------------|
-| **C# / .NET** | Backend-APIs, Enterprise | Clean Architecture | CQRS, MediatR, EF Core |
-| **Symfony / PHP** | Backend-APIs, Web-Apps | Clean Architecture + DDD | Doctrine, Messenger, API Platform |
-| **Laravel / PHP** | Web-Apps, schnelle APIs | Clean Architecture | Actions, Pest PHP, Sanctum |
-| **PHP** | Generische Clean Architecture | Clean Architecture | PSR-12, PHPStan, Pest PHP |
-| **Flutter / Dart** | Mobile Apps | Feature-basiert + BLoC | Material/Cupertino, State Management |
+## Ihre Technologie auswählen
+
+### Technologievergleich
+
+| Technologie | Am besten für | Architektur | Hauptmerkmale |
+|-------------|---------------|-------------|---------------|
+| **.NET / C#** | Enterprise-APIs | Clean Architecture + CQRS | MediatR, EF Core, C# 14 |
+| **Symfony** | Backend-APIs, Web-Apps | Clean Architecture + DDD | Doctrine, Messenger, API Platform |
+| **Flutter** | Mobile Apps | Feature-basiert + BLoC | Material/Cupertino, State Management |
 | **Python** | APIs, Datendienste | Clean Architecture | FastAPI, async/await, Pydantic |
-| **React** | Web-SPAs | Feature-basiert + Hooks | Zustand, React Query, Barrierefreiheit |
-| **React Native** | Plattformübergreifend | Feature-basiert | Navigation 7, Reanimated 4 |
-| **Angular** | Unternehmensanwendungen | Domain-driven | Signals, Standalone, RxJS |
+| **React** | Web-SPAs | Feature-basiert + Hooks | State Management, Barrierefreiheit |
+| **React Native** | Plattformübergreifende Mobile-Apps | Navigationsbasiert | Native Module, plattformspezifischer Code |
+| **Angular** | Enterprise-Web-Apps | Domain-driven | Signals, Standalone, RxJS |
 | **Vue.js** | Web-SPAs | Composition API | Pinia, Vitest, TypeScript |
+| **Laravel** | PHP-APIs, Web-Apps | Clean Architecture | Actions, Pest PHP, Sanctum |
+| **PHP** | Bibliotheken, Backend | Clean Architecture | PSR-12, PHPStan, Pest PHP |
 
-### Infrastruktur-Stacks
-
-Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hetzner Cloud, PgBouncer, FrankenPHP
-
-### Wahl nach Projekttyp
+### Auswahl nach Projekttyp
 
 | Projekttyp | Empfohlener Stack |
 |------------|-------------------|
-| REST-API | Symfony, Laravel oder Python |
-| Mobile App (nativ) | Flutter |
+| REST-API | Symfony oder Python |
+| Mobile App (natives Erscheinungsbild) | Flutter |
 | Mobile App (JS-Team) | React Native |
-| Web-SPA | React, Vue.js oder Angular |
-| Full-Stack Web | Symfony + React |
-| Full-Stack Mobile | Symfony + Flutter |
+| Web-SPA | React |
+| Full-Stack-Web | Symfony + React |
+| Full-Stack-Mobile | Symfony + Flutter |
 | Microservices | Python (FastAPI) |
-| Enterprise | C# / .NET oder Angular |
+
+### Häufige Kombinationen
+
+```
+Web-Anwendung:          Symfony (Backend) + React (Frontend)
+Mobile-Anwendung:       Symfony (API) + Flutter (Mobile)
+Vollständige Plattform: Symfony (API) + React (Web) + Flutter (Mobile)
+Datenplattform:         Python (API) + React (Dashboard)
+```
 
 ---
 
 ## Installationsmethoden
 
+Claude-Craft bietet mehrere Installationsmethoden für verschiedene Workflows.
+
 ### Methode 1: Makefile (Empfohlen)
 
+Der einfachste und flexibelste Ansatz.
+
 ```bash
-make install-{technologie} TARGET=pfad LANG=sprache
+# Grundlegende Syntax
+make install-{technology} TARGET=path LANG=language
 
 # Beispiele
-make install-symfony TARGET=./backend LANG=de
-make install-flutter TARGET=./mobile LANG=de
+make install-symfony TARGET=./backend LANG=en
+make install-flutter TARGET=./mobile LANG=fr
+make install-python TARGET=./api LANG=es
+make install-react TARGET=./frontend LANG=de
+make install-reactnative TARGET=./app LANG=pt
 ```
 
-#### Optionen
+#### Verfügbare Optionen
+
+| Option | Beschreibung | Beispiel |
+|--------|-------------|---------|
+| `TARGET` | Installationspfad | `TARGET=~/projects/myapp` |
+| `LANG` | Sprachcode | `LANG=fr` |
+| `OPTIONS` | Zusätzliche Flags | `OPTIONS="--force --backup"` |
+
+#### Options-Flags
+
 ```bash
-OPTIONS="--dry-run"      # Vorschau ohne Änderungen
-OPTIONS="--force"        # Dateien überschreiben
-OPTIONS="--backup"       # Backup erstellen
-OPTIONS="--interactive"  # Interaktiver Modus
-OPTIONS="--update"       # Nur aktualisieren
+# Änderungen in der Vorschau ansehen ohne anzuwenden
+make install-symfony TARGET=./backend OPTIONS="--dry-run"
+
+# Vorhandene Dateien überschreiben (erstellt Backup)
+make install-symfony TARGET=./backend OPTIONS="--force"
+
+# Backup vor der Installation erstellen
+make install-symfony TARGET=./backend OPTIONS="--backup"
+
+# Interaktiver Modus (fragt nach Projektinformationen)
+make install-symfony TARGET=./backend OPTIONS="--interactive"
+
+# Nur aktualisieren (projektspezifische Dateien beibehalten)
+make install-symfony TARGET=./backend OPTIONS="--update"
 ```
 
-### Methode 2: Direktes Skript
+### Methode 2: Direktes Skript-Ausführen
+
+Installationsskripte direkt ausführen für mehr Kontrolle.
 
 ```bash
-./Dev/scripts/install-symfony-rules.sh --lang=de ~/mein-projekt
+# Syntax
+./Dev/scripts/install-{technology}-rules.sh [OPTIONS] [TARGET]
+
+# Beispiele
+./Dev/scripts/install-symfony-rules.sh --lang=fr ~/my-project
+./Dev/scripts/install-flutter-rules.sh --lang=en --dry-run .
+./Dev/scripts/install-python-rules.sh --force --backup ~/api
+```
+
+#### Skript-Optionen
+
+```bash
+--lang=XX       # Sprache (en, fr, es, de, pt)
+--install       # Vollständiger Installationsmodus
+--update        # Nur gemeinsame Regeln aktualisieren
+--force         # Alle Dateien überschreiben
+--dry-run       # Vorschau ohne Änderungen
+--backup        # Zuerst Backup erstellen
+--interactive   # Nach Projektinformationen fragen
+--help          # Hilfe anzeigen
+--version       # Version anzeigen
 ```
 
 ### Methode 3: YAML-Konfiguration
 
-```yaml
-# claude-projects.yaml
-settings:
-  default_lang: "de"
-
-projects:
-  - name: "meine-plattform"
-    path: "~/Projekte/meine-plattform"
-    modules:
-      - name: "api"
-        path: "backend"
-        technologies: ["symfony"]
-      - name: "mobile"
-        path: "app"
-        technologies: ["flutter"]
-```
+Am besten für Monorepos und Multi-Projekt-Setups.
 
 ```bash
-make config-install CONFIG=claude-projects.yaml PROJECT=meine-plattform
+# Konfiguration erstellen
+cp claude-projects.yaml.example claude-projects.yaml
+
+# Konfiguration bearbeiten
+nano claude-projects.yaml
+
+# Konfiguration validieren
+make config-validate CONFIG=claude-projects.yaml
+
+# Bestimmtes Projekt installieren
+make config-install CONFIG=claude-projects.yaml PROJECT=my-project
+
+# Alle Projekte installieren
+make config-install-all CONFIG=claude-projects.yaml
 ```
 
 ---
 
-## Einzeltechnologie-Projekte
+## Einzelne Technologieprojekte
 
 ### Symfony-Projekt
+
 ```bash
-mkdir ~/meine-api && cd ~/meine-api && git init
-make install-symfony TARGET=. LANG=de
+# Projektverzeichnis erstellen
+mkdir ~/my-symfony-api
+cd ~/my-symfony-api
+composer create-project symfony/skeleton .
+git init
+
+# Claude-Craft-Regeln installieren
+make install-symfony TARGET=. LANG=fr
+
+# Installation verifizieren
+ls -la .claude/
 ```
+
+**Installierter Inhalt:**
+- 21 Symfony-spezifische Regeln (Clean Architecture, DDD, CQRS usw.)
+- 10+ Symfony-Befehle (`/symfony:generate-crud`, `/symfony:check-compliance` usw.)
+- Symfony-Reviewer-Agent
+- Code-Templates (Service, ValueObject, Aggregate usw.)
+- Qualitäts-Checklisten
 
 ### Flutter-Projekt
+
 ```bash
-flutter create meine_app && cd meine_app && git init
-make install-flutter TARGET=. LANG=de
+# Projekt erstellen
+flutter create my_flutter_app
+cd my_flutter_app
+git init
+
+# Claude-Craft-Regeln installieren
+make install-flutter TARGET=. LANG=en
+
+# Verifizieren
+ls -la .claude/
 ```
 
+**Installierter Inhalt:**
+- 13 Flutter-spezifische Regeln (BLoC, State Management, Testing)
+- 10 Flutter-Befehle
+- Flutter-Reviewer-Agent
+- Widget- und BLoC-Templates
+- Qualitäts-Checklisten
+
 ### Python-Projekt
+
 ```bash
-mkdir ~/meine-python-api && cd ~/meine-python-api && git init
-make install-python TARGET=. LANG=de
+# Projekt erstellen
+mkdir ~/my-python-api
+cd ~/my-python-api
+python -m venv venv
+git init
+
+# Claude-Craft-Regeln installieren
+make install-python TARGET=. LANG=en
+
+# Verifizieren
+ls -la .claude/
+```
+
+**Installierter Inhalt:**
+- 12 Python-spezifische Regeln (FastAPI, async, Typisierung)
+- 10 Python-Befehle
+- Python-Reviewer-Agent
+- Service- und API-Templates
+- Qualitäts-Checklisten
+
+### React-Projekt
+
+```bash
+# Projekt erstellen
+npx create-react-app my-react-app
+cd my-react-app
+
+# Claude-Craft-Regeln installieren
+make install-react TARGET=. LANG=en
+
+# Verifizieren
+ls -la .claude/
+```
+
+### React-Native-Projekt
+
+```bash
+# Projekt erstellen
+npx react-native init MyApp
+cd MyApp
+
+# Claude-Craft-Regeln installieren
+make install-reactnative TARGET=. LANG=en
+
+# Verifizieren
+ls -la .claude/
+```
+
+---
+
+## Monorepo-Projekte
+
+### Monorepo-Struktur verstehen
+
+Ein typisches Monorepo könnte so aussehen:
+
+```
+my-platform/
+├── backend/          # Symfony API
+├── web/              # React Frontend
+├── mobile/           # Flutter App
+├── shared/           # Gemeinsame Typen/Verträge
+└── claude-projects.yaml
+```
+
+### YAML-Konfigurationsstruktur
+
+```yaml
+# claude-projects.yaml
+
+settings:
+  default_lang: "fr"              # Standardsprache für alle Projekte
+  claude_craft_path: "~/claude-craft"  # Pfad zu claude-craft (optional)
+
+projects:
+  - name: "my-platform"
+    description: "Full-stack SaaS platform"
+    path: "~/Projects/my-platform"
+    modules:
+      - name: "api"
+        path: "backend"
+        technologies: ["symfony"]
+        lang: "en"                # Standardsprache überschreiben
+
+      - name: "web"
+        path: "web"
+        technologies: ["react"]
+
+      - name: "mobile"
+        path: "mobile"
+        technologies: ["flutter"]
+```
+
+### Konfigurationsfelder
+
+#### Projektebene
+
+| Feld | Pflicht | Beschreibung |
+|------|---------|-------------|
+| `name` | Ja | Projekt-Bezeichner |
+| `description` | Nein | Projektbeschreibung |
+| `path` | Ja | Absoluter Pfad zum Projektstamm |
+| `lang` | Nein | Sprachüberschreibung |
+| `modules` | Nein | Liste von Modulen (für Monorepos) |
+| `technologies` | Nein | Technologien ohne Module |
+
+#### Modulebene
+
+| Feld | Pflicht | Beschreibung |
+|------|---------|-------------|
+| `name` | Ja | Modul-Bezeichner |
+| `path` | Ja | Relativer Pfad vom Projektstamm |
+| `technologies` | Ja | Liste der Technologien |
+| `lang` | Nein | Sprachüberschreibung |
+| `skip_common` | Nein | Gemeinsame Regeln überspringen (Standard: false) |
+
+### Installationsbefehle
+
+```bash
+# Konfiguration validieren
+make config-validate CONFIG=claude-projects.yaml
+
+# Konfigurierte Projekte auflisten
+make config-list CONFIG=claude-projects.yaml
+
+# Bestimmtes Projekt installieren
+make config-install CONFIG=claude-projects.yaml PROJECT=my-platform
+
+# Bestimmtes Modul installieren
+make config-install CONFIG=claude-projects.yaml PROJECT=my-platform MODULE=api
+
+# Dry-run zur Vorschau
+make config-install CONFIG=claude-projects.yaml PROJECT=my-platform OPTIONS="--dry-run"
+
+# Alle Projekte installieren
+make config-install-all CONFIG=claude-projects.yaml
+```
+
+### Praxisbeispiele
+
+#### Beispiel 1: SaaS-Plattform
+
+```yaml
+projects:
+  - name: "saas-platform"
+    path: "~/Projects/saas"
+    modules:
+      - name: "api"
+        path: "services/api"
+        technologies: ["symfony"]
+      - name: "admin"
+        path: "apps/admin"
+        technologies: ["react"]
+      - name: "mobile"
+        path: "apps/mobile"
+        technologies: ["flutter"]
+```
+
+#### Beispiel 2: Microservices
+
+```yaml
+projects:
+  - name: "microservices"
+    path: "~/Projects/micro"
+    modules:
+      - name: "gateway"
+        path: "gateway"
+        technologies: ["python"]
+      - name: "users"
+        path: "services/users"
+        technologies: ["symfony"]
+      - name: "orders"
+        path: "services/orders"
+        technologies: ["symfony"]
+      - name: "analytics"
+        path: "services/analytics"
+        technologies: ["python"]
+```
+
+#### Beispiel 3: Mehrere unabhängige Projekte
+
+```yaml
+settings:
+  default_lang: "fr"
+
+projects:
+  - name: "client-a"
+    path: "~/Clients/client-a"
+    technologies: ["symfony", "react"]
+
+  - name: "client-b"
+    path: "~/Clients/client-b"
+    technologies: ["flutter"]
+    lang: "en"
+
+  - name: "internal-tool"
+    path: "~/Internal/tool"
+    technologies: ["python"]
 ```
 
 ---
 
 ## Konfiguration nach der Installation
 
+Konfigurieren Sie nach der Installation diese Dateien für Ihr konkretes Projekt.
+
 ### 1. Projektkontext (`rules/00-project-context.md`)
 
-Dies ist die wichtigste Datei zum Anpassen.
+Dies ist die wichtigste Datei zum Anpassen. Sie informiert Claude über Ihr spezifisches Projekt.
 
 **Option A: Interaktive Einrichtung (Empfohlen)**
 
-Führen Sie diesen Befehl in Claude Code aus, um Ihren Stack zu erkennen und gezielte Fragen zu beantworten:
+Führen Sie diesen Befehl in Claude Code aus, um Ihren Stack automatisch zu erkennen und gezielte Fragen zu beantworten:
 ```bash
 /common:setup-project-context
 ```
 
 **Option B: Manuelle Konfiguration**
 
-Bearbeiten Sie die Datei direkt mit Ihren Projektdetails:
+Datei direkt mit Ihren Projektdetails bearbeiten:
 
 ```markdown
-# Projektkontext
+# Project Context
 
-## Informationen
-- **Name**: Meine E-Commerce-API
-- **Typ**: REST-API für E-Commerce-Plattform
+## Project Information
+- **Name**: My Awesome API
+- **Type**: REST API for e-commerce platform
+- **Team Size**: 3 developers
 
-## Technischer Stack
-- PHP 8.3 mit Symfony 7.0
+## Technical Stack
+- PHP 8.3 with Symfony 7.0
 - PostgreSQL 16
-- Redis für Caching
+- Redis for caching
+- RabbitMQ for messaging
 
-## Konventionen
-- Code auf Englisch, Dokumentation auf Deutsch
+## Conventions
+- PSR-12 coding standard
+- Strict typing enabled
+- English code, French documentation
+
+## Constraints
+- RGPD compliance required
+- Must support multi-tenant architecture
+- Maximum response time: 200ms
+
+## External Dependencies
+- Stripe for payments
+- SendGrid for emails
+- S3 for file storage
 ```
 
 ### 2. Hauptkonfiguration (`CLAUDE.md`)
 
-Überprüfen und anpassen:
-- Spracheinstellungen
-- Architekturanforderungen
-- Qualitätsanforderungen
-- Docker-Anforderungen
+Die Datei CLAUDE.md im Verzeichnis `.claude/` enthält die Hauptkonfiguration. Wichtige Abschnitte zum Prüfen:
+
+```markdown
+# Project Configuration
+
+## Language Settings
+- Code: English
+- Documentation: French
+- Comments: English
+
+## Architecture
+Clean Architecture + DDD + Hexagonal
+
+## Quality Requirements
+- Test coverage: 80%+
+- PHPStan level: 9
+- No critical security issues
+
+## Docker Requirements
+All commands must use Docker via make targets.
+```
+
+### 3. Agentenkonfiguration
+
+Installierte Agenten in `.claude/agents/` prüfen und bei Bedarf anpassen:
+
+```bash
+ls .claude/agents/
+# api-designer.md
+# database-architect.md
+# symfony-reviewer.md
+# tdd-coach.md
+# ...
+```
 
 ---
 
-## Start-Checkliste
+## Checkliste für den Projektstart
+
+Verwenden Sie diese Checkliste bei der Einrichtung eines neuen Projekts:
 
 ### Vor der Installation
+
 - [ ] Projektverzeichnis erstellt
 - [ ] Git-Repository initialisiert
 - [ ] Technologie-Stack entschieden
+- [ ] Sprachpräferenz gewählt
 
 ### Installation
+
 - [ ] Claude-Craft-Regeln installiert
-- [ ] Installation überprüft (`ls .claude/`)
+- [ ] Installation verifiziert (`ls .claude/`)
+- [ ] Keine Fehler in der Installationsausgabe
 
 ### Konfiguration
-- [ ] `00-project-context.md` angepasst
-- [ ] `CLAUDE.md` überprüft
+
+- [ ] `00-project-context.md` mit Projektdetails angepasst
+- [ ] `CLAUDE.md` geprüft und angepasst
+- [ ] Team-Konventionen dokumentiert
+- [ ] Einschränkungen und Anforderungen aufgelistet
 
 ### Verifizierung
-- [ ] Claude Code im Verzeichnis gestartet
-- [ ] Befehle verfügbar
-- [ ] Agenten reagieren
+
+- [ ] Claude Code im Projektverzeichnis gestartet
+- [ ] Befehle verfügbar (z. B. `/symfony:check-compliance` testen)
+- [ ] Agenten reagieren (z. B. `@symfony-reviewer hello` testen)
+
+### Team-Einrichtung
+
+- [ ] `.claude/`-Verzeichnis in Git committet
+- [ ] Team-Mitglieder über verfügbare Befehle informiert
+- [ ] README mit Claude-Craft-Nutzungshinweisen aktualisiert
+
+---
+
+## Gängige Muster
+
+### Nur gemeinsame Regeln installieren
+
+Für gemeinsame Bibliotheken oder Pakete, die keiner spezifischen Technologie entsprechen:
+
+```bash
+make install-common TARGET=./shared-lib LANG=en
+```
+
+### Projektmanagement-Tools installieren
+
+Für Sprint-Tracking und Backlog-Verwaltung:
+
+```bash
+make install-project TARGET=. LANG=fr
+```
+
+### Infrastruktur-Tools installieren
+
+Für Docker- und CI/CD-Unterstützung:
+
+```bash
+make install-infra TARGET=. LANG=en
+```
+
+### Vollständige Installation (alle Technologien)
+
+```bash
+make install-all TARGET=. LANG=fr
+```
+
+---
+
+### Token-Optimierungs-Setup
+
+Nach der Installation der Regeln können Sie optional RTK für Token-Einsparungen konfigurieren:
+
+```bash
+# In einer Claude Code-Session
+/common:setup-rtk
+```
+
+Dies richtet den RTK-Proxy, die Sub-Agent-Modelloptimierung und Hook-Templates für eine Gesamtreduktion von 55–65 % der Token ein.
+
+---
+
+## Regeln aktualisieren
+
+Wenn Claude-Craft neue Versionen veröffentlicht:
+
+```bash
+# Auf die neueste Version aktualisieren (projektspezifische Dateien werden beibehalten)
+make install-symfony TARGET=./backend OPTIONS="--update"
+
+# Vollständige Neuinstallation erzwingen (Backup wird automatisch erstellt)
+make install-symfony TARGET=./backend OPTIONS="--force"
+```
+
+---
+
+## Nächste Schritte
+
+Ihr Projekt ist jetzt eingerichtet! Fahren Sie fort mit:
+
+1. **[Leitfaden zur Feature-Entwicklung](03-feature-development.md)** – Den TDD-Workflow kennenlernen
+2. **[Leitfaden zur Fehlerbehebung](04-bug-fixing.md)** – Bugs effektiv beheben
+3. **[Tools-Referenz](05-tools-reference.md)** – Weitere Tools erkunden
 
 ---
 

--- a/docs/guides/de/03-feature-development.md
+++ b/docs/guides/de/03-feature-development.md
@@ -1,174 +1,655 @@
-# Anleitung zur Feature-Entwicklung
+# Leitfaden zur Feature-Entwicklung
 
-Vollständiger Workflow zur Entwicklung neuer Features mit Claude-Craft.
+Dieser Leitfaden beschreibt den vollständigen Workflow für die Entwicklung neuer Features mit Claude-Craft, von der ersten Analyse bis zum abschließenden Review.
 
 ---
 
-## TDD-Workflow
+## Inhaltsverzeichnis
+
+1. [TDD-Workflow – Überblick](#tdd-workflow-überblick)
+2. [Phase 1: Analyse](#phase-1-analyse)
+3. [Phase 2: Design](#phase-2-design)
+4. [Phase 3: Tests schreiben](#phase-3-tests-schreiben)
+5. [Phase 4: Implementierung](#phase-4-implementierung)
+6. [Phase 5: Refactoring](#phase-5-refactoring)
+7. [Phase 6: Review](#phase-6-review)
+8. [Vollständiges Beispiel](#vollständiges-beispiel)
+9. [Verfügbare Ressourcen](#verfügbare-ressourcen)
+
+---
+
+## TDD-Workflow – Überblick
+
+Claude-Craft setzt einen testgetriebenen Entwicklungs-Workflow durch:
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ 1. Analysieren│ -->│ 2. Entwerfen│ --> │  3. Tests   │
+│  1. Analyse │ --> │  2. Design  │ --> │  3. Tests   │
 └─────────────┘     └─────────────┘     └─────────────┘
                                               │
                                               v
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│  6. Prüfen  │ <-- │5. Refactoring│ <--│4. Implementieren│
+│  6. Review  │ <-- │ 5. Refactor │ <-- │ 4. Implment.│
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
+
+### Warum TDD?
+
+- **Sicherheit**: Tests beweisen, dass Ihr Code funktioniert
+- **Dokumentation**: Tests beschreiben das erwartete Verhalten
+- **Design**: Tests zuerst zu schreiben führt zu besseren APIs
+- **Regression**: Tests decken künftige Bugs auf
 
 ---
 
 ## Phase 1: Analyse
 
+Bevor Sie Code schreiben, verstehen Sie zunächst, was gebaut werden muss.
+
+### Aufwandsstufe festlegen
+
+Für Analysephasen, die tiefes Nachdenken erfordern, wählen Sie einen hohen Aufwand:
+
 ```bash
-/common:analyze-feature "Benutzerauthentifizierung mit JWT-Tokens"
+/effort high
 ```
 
-```markdown
-@research-assistant Recherchiere Best Practices für JWT-Authentifizierung in Symfony 7
+Verwenden Sie `/effort low` für einfache Nachschläge und `/effort medium` für Standard-Implementierungsarbeiten.
+
+### Den Analysebefehl verwenden
+
+```bash
+/common:analyze-feature "User authentication with JWT tokens and role-based access"
 ```
+
+Dieser Befehl wird:
+1. Das Feature in Komponenten aufschlüsseln
+2. Technische Anforderungen identifizieren
+3. Mögliche Randfälle auflisten
+4. Einen Implementierungsansatz vorschlagen
+
+### Den Research-Agenten verwenden
+
+```markdown
+@research-assistant Research best practices for JWT authentication in Symfony 7
+```
+
+Der Research-Agent wird:
+- Dokumentation und Best Practices durchsuchen
+- Ergebnisse zusammenfassen
+- Code-Beispiele bereitstellen
+- Sicherheitsaspekte hervorheben
+
+### Analyse-Checkliste
+
+- [ ] User Story klar definiert
+- [ ] Abnahmekriterien dokumentiert
+- [ ] Randfälle identifiziert
+- [ ] Technischer Ansatz gewählt
+- [ ] Abhängigkeiten identifiziert
+- [ ] Sicherheitsimplikationen geprüft
 
 ---
 
-## Phase 2: Entwurf
+## Phase 2: Design
 
-### Datenbank
+Entwerfen Sie die Architektur vor der Implementierung.
+
+### Datenbankdesign
+
 ```markdown
-@database-architect Entwerfe das Schema für die User-Entität mit Rollen und Berechtigungen
+@database-architect Design the schema for User entity with roles and permissions
+
+Requirements:
+- User can have multiple roles
+- Roles have permissions
+- Support for soft delete
+- Audit trail for changes
 ```
 
-### API
+Der Datenbankarchitekt wird:
+- Ein normalisiertes Schema entwerfen
+- Indizes vorschlagen
+- Beziehungen berücksichtigen
+- Migrationen planen
+
+### API-Design
+
 ```markdown
-@api-designer Entwerfe die REST-API für Benutzerverwaltung
+@api-designer Design the REST API for user management
+
+Endpoints needed:
+- CRUD operations for users
+- Role assignment
+- Authentication (login/logout)
+- Password reset flow
 ```
+
+Der API-Designer wird:
+- Endpunkte und Methoden definieren
+- Request-/Response-Formate festlegen
+- Authentifizierungsanforderungen dokumentieren
+- Fehlerantworten planen
 
 ### Architekturentscheidung
+
 ```bash
-/common:architecture-decision "Wie implementiert man rollenbasierte Zugriffskontrolle"
+/common:architecture-decision "How to implement role-based access control"
 ```
+
+Verwenden Sie diesen Befehl für wichtige Architekturentscheidungen. Er erstellt einen Architecture Decision Record (ADR), der Folgendes dokumentiert:
+- Kontext und Problem
+- Betrachtete Optionen
+- Gewählte Lösung
+- Konsequenzen
+
+### Design-Checkliste
+
+- [ ] Datenbankschema entworfen
+- [ ] API-Endpunkte definiert
+- [ ] Architekturentscheidungen dokumentiert
+- [ ] Sicherheitsmodell definiert
+- [ ] Strategie für Fehlerbehandlung geplant
 
 ---
 
 ## Phase 3: Tests schreiben
 
+Schreiben Sie Tests VOR der Implementierung. Das ist das „TDD" in TDD.
+
+### Den TDD-Coach verwenden
+
 ```markdown
-@tdd-coach Hilf mir, Tests für die Authentifizierungsmethode von UserService zu schreiben
+@tdd-coach Help me write tests for the UserService authentication method
+
+The method should:
+- Accept email and password
+- Return JWT token on success
+- Throw exception on invalid credentials
+- Lock account after 5 failed attempts
 ```
 
-### Testarten
+Der TDD-Coach wird:
+- Testfälle vorschlagen
+- Testcode-Beispiele schreiben
+- Assertions erklären
+- Randfälle identifizieren
 
-**Unit-Tests:**
+### Testkategorien
+
+#### Unit-Tests
+
+Einzelne Komponenten isoliert testen:
+
 ```php
+// tests/Unit/Domain/User/UserTest.php
 public function test_user_can_change_password(): void
 {
-    $user = User::create('test@example.com', 'old-password');
+    $user = User::create(
+        email: 'test@example.com',
+        password: 'old-password'
+    );
+
     $user->changePassword('new-password');
+
     $this->assertTrue($user->verifyPassword('new-password'));
+    $this->assertFalse($user->verifyPassword('old-password'));
 }
 ```
 
-**Integrationstests:**
+#### Integrationstests
+
+Zusammenspiel von Komponenten testen:
+
 ```php
+// tests/Integration/UserServiceTest.php
 public function test_user_service_creates_user_in_database(): void
 {
     $service = $this->container->get(UserService::class);
-    $user = $service->createUser('test@example.com', 'password');
+
+    $user = $service->createUser(
+        email: 'test@example.com',
+        password: 'secure-password'
+    );
+
     $this->assertNotNull($user->getId());
+    $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
 }
 ```
+
+#### BDD-/Funktionale Tests
+
+Geschäftliche Szenarien testen:
+
+```gherkin
+# features/authentication.feature
+Feature: User Authentication
+  As a user
+  I want to log in with my credentials
+  So that I can access protected resources
+
+  Scenario: Successful login
+    Given I have a registered user with email "user@example.com"
+    When I submit valid credentials
+    Then I should receive a JWT token
+    And the token should be valid for 1 hour
+```
+
+### Technologiespezifische Testbefehle
+
+```bash
+# Symfony
+/symfony:check-testing
+
+# Flutter
+/flutter:check-testing
+
+# Python
+/python:check-testing
+
+# React
+/react:check-testing
+```
+
+### Checkliste für das Schreiben von Tests
+
+- [ ] Unit-Tests für die Domänenlogik
+- [ ] Integrationstests für Services
+- [ ] API-Tests für Endpunkte
+- [ ] Randfälle abgedeckt
+- [ ] Fehlerszenarien getestet
+- [ ] Alle Tests schlagen fehl (noch nicht implementiert)
 
 ---
 
 ## Phase 4: Implementierung
 
-### Generierungsbefehle
+Jetzt implementieren Sie den Code, damit die Tests bestehen.
+
+### Codegenerierungsbefehle
+
+#### Symfony
 
 ```bash
-# Symfony
+# CRUD mit Tests generieren
 /symfony:generate-crud User
+
+# API-Endpunkt generieren
 /symfony:api-endpoint POST /api/users CreateUserRequest
 
-# Flutter
-/flutter:generate-feature Authentication
-/flutter:generate-widget LoginScreen
+# Command generieren
+/symfony:generate-command SendWelcomeEmailCommand
+```
 
-# Python
+#### Flutter
+
+```bash
+# BLoC generieren
+/flutter:generate-bloc Authentication
+
+# Screen generieren
+/flutter:generate-screen LoginScreen
+
+# Widget generieren
+/flutter:generate-widget UserAvatar
+```
+
+#### Python
+
+```bash
+# FastAPI-Endpunkt generieren
 /python:generate-endpoint POST /users CreateUser
-/python:generate-model User
 
-# React
+# Service generieren
+/python:generate-service UserService
+
+# Modell generieren
+/python:generate-model User
+```
+
+#### React
+
+```bash
+# Komponente generieren
 /react:generate-component UserProfile
+
+# Hook generieren
 /react:generate-hook useAuth
 
-# Angular
-/angular:generate-component UserProfile
-
-# Vue.js
-/vuejs:generate-component UserProfile
-
-# C# / .NET
-/csharp:generate-feature User
-
-# Laravel
-/laravel:generate-controller UserController
-
-# React Native
-/reactnative:generate-screen LoginScreen
+# Context generieren
+/react:generate-context AuthContext
 ```
+
+### Templates verwenden
+
+Templates stellen einsatzbereite Code-Muster bereit. Zugriff mit:
+
+```markdown
+Show me the service template for Symfony
+```
+
+Verfügbare Templates nach Technologie:
+
+| Symfony | Flutter | Python | React |
+|---------|---------|--------|-------|
+| service.md | bloc.md | service.md | component.md |
+| value-object.md | widget.md | repository.md | hook.md |
+| aggregate-root.md | screen.md | endpoint.md | context.md |
+| domain-event.md | state.md | model.md | reducer.md |
+| repository.md | cubit.md | schema.md | - |
+
+### Best Practices bei der Implementierung
+
+1. **Ein Test nach dem anderen**: Lassen Sie einen Test bestehen, bevor Sie zum nächsten übergehen
+2. **Minimaler Code**: Schreiben Sie gerade genug Code, um den Test zu bestehen
+3. **Keine vorzeitige Optimierung**: Konzentrieren Sie sich zunächst auf Korrektheit
+4. **Bestehende Muster befolgen**: Verwenden Sie Templates und Konventionen
+
+### Implementierungs-Checkliste
+
+- [ ] Alle Unit-Tests bestehen
+- [ ] Alle Integrationstests bestehen
+- [ ] Alle API-Tests bestehen
+- [ ] Keine hartkodierten Werte
+- [ ] Fehlerbehandlung implementiert
+- [ ] Logging hinzugefügt
 
 ---
 
 ## Phase 5: Refactoring
 
+Nachdem die Tests bestehen, verbessern Sie die Codequalität.
+
+### Refactoring-Befehle
+
 ```bash
+# Codequalität prüfen
 /symfony:check-code-quality
+/flutter:check-code-quality
+/python:check-code-quality
+/react:check-code-quality
+
+# Architekturkonformität prüfen
 /symfony:check-architecture
+/flutter:check-architecture
 ```
 
+### Den Refactoring-Spezialisten verwenden
+
 ```markdown
-@refactoring-specialist Überprüfe diese Service-Klasse auf mögliche Verbesserungen
+@refactoring-specialist Review this service class for potential improvements
+
+[paste code here]
 ```
+
+Der Refactoring-Spezialist wird:
+- Code Smells identifizieren
+- Verbesserungen vorschlagen
+- Refaktorierte Beispiele zeigen
+- Kompromisse erläutern
+
+### Gängige Refactoring-Muster
+
+1. **Methode extrahieren**: Lange Methoden in kleinere aufteilen
+2. **Klasse extrahieren**: Große Klassen aufsplitten
+3. **Value Object einführen**: Primitive durch Domänentypen ersetzen
+4. **Conditional durch Polymorphismus ersetzen**: Strategy-Muster verwenden
+5. **Methode verschieben**: Methoden dort platzieren, wo sie hingehören
+
+### Refactoring-Checkliste
+
+- [ ] Keine Code-Duplikation
+- [ ] Methoden unter 20 Zeilen
+- [ ] Klassen unter 200 Zeilen
+- [ ] Klare Benennung
+- [ ] Konsistenter Stil
+- [ ] Alle Tests bestehen weiterhin
 
 ---
 
-## Phase 6: Überprüfung
+## Phase 6: Review
+
+Abschließende Qualitätsprüfung vor dem Abschluss.
+
+### Compliance-Audit
 
 ```bash
-# Vollständiges Audit (Punktzahl /100)
+# Vollständige Compliance-Prüfung (gibt Score /100 zurück)
 /symfony:check-compliance
+/flutter:check-compliance
+/python:check-compliance
+/react:check-compliance
 ```
 
+Dieses umfassende Audit prüft:
+- Architekturkonformität
+- Codequalität
+- Testabdeckung
+- Sicherheitsprobleme
+- Dokumentation
+
+### Code Review mit Agenten
+
 ```markdown
-@symfony-reviewer Überprüfe meine vollständige User-Authentifizierungsimplementierung
+@symfony-reviewer Review my complete User authentication implementation
+
+Files changed:
+- src/Domain/User/User.php
+- src/Application/Service/AuthenticationService.php
+- src/Infrastructure/Security/JwtTokenGenerator.php
+- tests/Unit/Domain/User/UserTest.php
+- tests/Integration/AuthenticationServiceTest.php
 ```
+
+Der Reviewer wird:
+- Architekturkonformität prüfen
+- Potenzielle Probleme identifizieren
+- Verbesserungen vorschlagen
+- Best Practices überprüfen
+
+### Sicherheits-Audit
 
 ```bash
 /common:security-audit
 ```
 
----
+Oder den sicherheitsfokussierten Agenten verwenden:
 
-## Feature-Checkliste
+```markdown
+@devops-engineer Review security of the authentication system
 
-- [ ] User Story definiert
-- [ ] Tests geschrieben (TDD)
-- [ ] Code implementiert
-- [ ] Tests bestanden (80%+ Abdeckung)
-- [ ] Review durchgeführt
+Concerns:
+- JWT token security
+- Password storage
+- Rate limiting
+- CORS configuration
+```
+
+### Feature-Checkliste
+
+Die eingebaute Checkliste verwenden:
+
+```bash
+cat .claude/checklists/feature-checklist.md
+```
+
+Wichtige Punkte:
+- [ ] User-Story-Anforderungen erfüllt
+- [ ] Alle Abnahmekriterien verifiziert
+- [ ] Tests geschrieben und bestanden (≥80 % Abdeckung)
+- [ ] Code reviewed
+- [ ] Sicherheits-Audit bestanden
 - [ ] Dokumentation aktualisiert
+- [ ] Keine kritischen Probleme in der statischen Analyse
+- [ ] Performance akzeptabel
+- [ ] Bereit für Code Review
 
 ---
 
-## Agenten-Übersicht
+## Vollständiges Beispiel
 
-| Agent | Verwendung |
-|-------|------------|
-| `@api-designer` | API-Endpoint-Design |
+Lassen Sie uns ein vollständiges Feature durchgehen: Benutzerregistrierung hinzufügen.
+
+### Schritt 1: Analyse
+
+```markdown
+/common:analyze-feature "User registration with email verification"
+
+Expected:
+- User submits email and password
+- System sends verification email
+- User clicks link to verify
+- Account becomes active
+```
+
+### Schritt 2: Datenbank designen
+
+```markdown
+@database-architect Design schema for User with email verification
+
+Fields needed:
+- id, email, password_hash
+- email_verified_at (nullable timestamp)
+- verification_token
+- created_at, updated_at
+```
+
+### Schritt 3: API designen
+
+```markdown
+@api-designer Design registration API endpoints
+
+POST /api/register - Create account
+POST /api/verify-email - Verify email with token
+POST /api/resend-verification - Resend verification email
+```
+
+### Schritt 4: Tests schreiben
+
+```markdown
+@tdd-coach Help me write tests for UserRegistrationService
+
+Test cases:
+1. Successful registration creates user
+2. Duplicate email returns error
+3. Weak password returns error
+4. Verification email is sent
+5. Verification token activates account
+6. Expired token returns error
+```
+
+### Schritt 5: Code generieren
+
+```bash
+/symfony:generate-crud User --with-api
+/symfony:generate-command SendVerificationEmailCommand
+```
+
+### Schritt 6: Implementieren
+
+Tests einen nach dem anderen bestehen lassen:
+
+```php
+// Test 1 bestehen lassen
+public function register(string $email, string $password): User
+{
+    $user = User::create($email, $password);
+    $this->repository->save($user);
+    return $user;
+}
+
+// Test 2 bestehen lassen
+public function register(string $email, string $password): User
+{
+    if ($this->repository->findByEmail($email)) {
+        throw new DuplicateEmailException($email);
+    }
+    // ...
+}
+
+// Für jeden Test fortfahren...
+```
+
+### Schritt 7: Refactoring
+
+```bash
+/symfony:check-code-quality
+```
+
+Identifizierte Probleme beheben.
+
+### Schritt 8: Review
+
+```markdown
+@symfony-reviewer Review my user registration implementation
+
+Complete implementation including:
+- Domain: User entity, ValueObjects
+- Application: RegistrationService
+- Infrastructure: DoctrineUserRepository
+- API: RegisterController
+- Tests: Unit, Integration, API
+```
+
+### Schritt 9: Abschließende Prüfung
+
+```bash
+/symfony:check-compliance
+```
+
+Ziel: Score 90+/100
+
+---
+
+## Verfügbare Ressourcen
+
+### Agentenübersicht
+
+| Agent | Verwendung für |
+|-------|----------------|
+| `@api-designer` | API-Endpunkt-Design |
 | `@database-architect` | Datenbankschema-Design |
-| `@tdd-coach` | Anleitung zum Testschreiben |
+| `@tdd-coach` | Anleitung zum Schreiben von Tests |
 | `@refactoring-specialist` | Code-Verbesserung |
-| `@{tech}-reviewer` | Code-Review |
+| `@{tech}-reviewer` | Code Review |
+| `@devops-engineer` | Infrastruktur-Review |
+| `@research-assistant` | Recherche zu Best Practices |
+
+### Befehlsübersicht
+
+| Phase | Befehle |
+|-------|---------|
+| Analyse | `/common:analyze-feature` |
+| Design | `/common:architecture-decision` |
+| Tests | `/{tech}:check-testing` |
+| Generierung | `/{tech}:generate-*` |
+| Qualität | `/{tech}:check-code-quality` |
+| Review | `/{tech}:check-compliance` |
+| Sicherheit | `/common:security-audit` |
+
+### Speicherort der Templates
+
+```bash
+ls .claude/templates/
+```
+
+### Speicherort der Checklisten
+
+```bash
+ls .claude/checklists/
+```
+
+---
+
+## Tipps für den Erfolg
+
+1. **Tests nicht überspringen**: Sie sind Ihr Sicherheitsnetz
+2. **Agenten verwenden**: Sie bieten Expertenbegleitung
+3. **Compliance-Prüfungen regelmäßig ausführen**: Probleme frühzeitig erkennen
+4. **Den Workflow befolgen**: Jede Phase hat einen Zweck
+5. **Entscheidungen dokumentieren**: ADRs für wichtige Entscheidungen verwenden
+6. **Kontext verwalten**: `/context` für Optimierungsvorschläge nutzen, `/clear` zwischen den Phasen
+7. **Aufwand anpassen**: `/effort high` für Analyse/Design, `/effort low` für die Code-Generierung
 
 ---
 

--- a/docs/guides/de/04-bug-fixing.md
+++ b/docs/guides/de/04-bug-fixing.md
@@ -1,67 +1,264 @@
-# Anleitung zur Fehlerbehebung
+# Leitfaden zur Fehlerbehebung
 
-Systematischer Ansatz zur Fehlerbehebung mit Claude-Craft.
+Dieser Leitfaden beschreibt den systematischen Ansatz zur Fehlerbehebung mit Claude-Craft – von der Diagnose bis zur Validierung.
+
+---
+
+## Inhaltsverzeichnis
+
+1. [Workflow zur Fehlerbehebung](#workflow-zur-fehlerbehebung)
+2. [Phase 1: Reproduzieren](#phase-1-reproduzieren)
+3. [Phase 2: Diagnostizieren](#phase-2-diagnostizieren)
+4. [Phase 3: Regressionstest schreiben](#phase-3-regressionstest-schreiben)
+5. [Phase 4: Beheben](#phase-4-beheben)
+6. [Phase 5: Validieren](#phase-5-validieren)
+7. [Phase 6: Dokumentieren](#phase-6-dokumentieren)
+8. [Hotfix-Verfahren](#hotfix-verfahren)
+9. [Vollständiges Beispiel](#vollständiges-beispiel)
 
 ---
 
 ## Workflow zur Fehlerbehebung
 
+Der systematische Ansatz zur Fehlerbehebung:
+
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ 1. Reproduzieren│ -->│2. Diagnostizieren│ --> │  3. Test    │
+│ 1. Reproduzieren│ --> │ 2. Diagnostizieren│ --> │ 3. Test     │
 └─────────────┘     └─────────────┘     └─────────────┘
                                               │
                                               v
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ 6. Dokumentieren│ <--│  5. Validieren│ <--│ 4. Beheben  │
+│ 6. Dokumentieren│ <-- │ 5. Validieren│ <-- │ 4. Beheben  │
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
+
+### Warum dieser Ansatz?
+
+1. **Erst reproduzieren**: Man kann nicht beheben, was man nicht sehen kann
+2. **Test vor Korrektur**: Beweist, dass der Fehler existiert und behoben wurde
+3. **Gründlich validieren**: Stellt sicher, dass keine Regression entsteht
+4. **Dokumentieren**: Hilft, ähnliche Fehler zu vermeiden
 
 ---
 
 ## Phase 1: Reproduzieren
 
-- Informationen aus dem Fehlerbericht sammeln
-- Reproduktionsumgebung erstellen
-- Überprüfen, ob der Fehler konsistent ist
+Bevor man mit der Behebung beginnt, muss der Fehler zuverlässig reproduziert werden.
+
+### Informationen sammeln
+
+Aus dem Fehlerbericht sammeln:
+- Schritte zur Reproduktion
+- Erwartetes Verhalten
+- Tatsächliches Verhalten
+- Umgebung (Version, Betriebssystem usw.)
+- Fehlermeldungen/Protokolle
+- Screenshots, falls zutreffend
+
+### Reproduktionsumgebung erstellen
+
+```bash
+# Problematische Version auschecken
+git checkout <commit-oder-tag>
+
+# Identische Umgebung einrichten
+make docker-up
+
+# Mit exakten Schritten reproduzieren
+```
+
+### Reproduktion bestätigen
+
+Lässt sich der Fehler konsistent auslösen?
+
+- [ ] Fehler tritt mit den gemeldeten Schritten auf
+- [ ] Fehler tritt in derselben Umgebung auf
+- [ ] Fehler ist deterministisch (nicht zufällig)
+
+### Wenn die Reproduktion nicht gelingt
+
+```markdown
+@research-assistant Hilf mir zu verstehen, warum dieser Fehler möglicherweise umgebungsspezifisch ist
+
+Fehlerbericht:
+- Benutzer sieht Fehler X beim Ausführen von Y
+- Ich kann den Fehler lokal nicht reproduzieren
+- Benutzer befindet sich in Umgebung Z
+
+Mögliche Ursachen?
+```
 
 ---
 
 ## Phase 2: Diagnostizieren
 
+Die Grundursache des Fehlers finden.
+
+### Analysebefehl verwenden
+
 ```bash
-/common:analyze-bug "Benutzer können sich nach Passwort-Reset nicht anmelden"
+/common:analyze-bug "Benutzer können sich nach dem Passwort-Reset nicht mit richtigen Anmeldedaten anmelden"
 ```
+
+Dieser Befehl wird:
+1. Bereiche vorschlagen, die untersucht werden sollten
+2. Mögliche Ursachen identifizieren
+3. Debugging-Schritte empfehlen
+4. Verwandte Codebereiche auflisten
+
+### TDD-Coach für die Diagnose verwenden
 
 ```markdown
 @tdd-coach Hilf mir, diesen Authentifizierungsfehler zu diagnostizieren
+
+Symptome:
+- Benutzer setzt Passwort erfolgreich zurück
+- Neues Passwort wird gespeichert (in der Datenbank bestätigt)
+- Anmeldung schlägt mit "Ungültige Anmeldedaten" fehl
+- Altes Passwort funktioniert ebenfalls nicht
+
+Was sollte ich untersuchen?
 ```
+
+### Debugging-Techniken
+
+#### Protokollierung hinzufügen
+
+```php
+// Temporäre Debug-Protokollierung
+$this->logger->debug('Password verification', [
+    'user_id' => $user->getId(),
+    'stored_hash' => substr($user->getPasswordHash(), 0, 20) . '...',
+    'verification_result' => $result,
+]);
+```
+
+#### Datenbankzustand prüfen
+
+```sql
+-- Benutzerzustand nach Passwort-Reset prüfen
+SELECT id, email, password_hash, updated_at
+FROM users
+WHERE email = 'user@example.com';
+```
+
+#### Ausführungspfad verfolgen
+
+```php
+// Stack-Trace an verdächtigen Stellen hinzufügen
+debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+```
+
+### Grundursache identifizieren
+
+Häufige Kategorien:
+- **Logikfehler**: Falsche Bedingung oder Berechnung
+- **Zustandsfehler**: Falscher Datenzustand
+- **Race Condition**: Zeitabhängiges Verhalten
+- **Integrationsfehler**: Problem mit externem Dienst
+- **Konfigurationsfehler**: Falsche Einstellungen
+
+### Diagnose-Checkliste
+
+- [ ] Fehler konsistent reproduziert
+- [ ] Fehlerort identifiziert
+- [ ] Grundursache verstanden
+- [ ] Verwandte Codebereiche identifiziert
+- [ ] Behebungsansatz festgelegt
 
 ---
 
-## Phase 3: Regressionstest
+## Phase 3: Regressionstest schreiben
+
+Einen Test schreiben, der VOR der Korrektur fehlschlägt und NACH der Korrektur bestanden wird.
+
+### Warum zuerst testen?
+
+1. **Beweist, dass der Fehler existiert**: Test schlägt mit aktuellem Code fehl
+2. **Beweist, dass die Korrektur funktioniert**: Test besteht nach der Korrektur
+3. **Verhindert Regression**: Test erkennt künftige Regressionen
+4. **Dokumentiert Verhalten**: Test beschreibt erwartetes Verhalten
+
+### TDD-Coach verwenden
+
+```markdown
+@tdd-coach Hilf mir, einen Regressionstest für diesen Fehler zu schreiben
+
+Fehler: Passwort-Reset aktualisiert den Passwort-Hash nicht korrekt
+
+Erwartetes Verhalten:
+- Benutzer beantragt Passwort-Reset
+- Benutzer setzt neues Passwort
+- Benutzer kann sich mit neuem Passwort anmelden
+
+Tatsächliches Verhalten:
+- Anmeldung schlägt nach Passwort-Reset fehl
+```
+
+### Beispiel für einen Regressionstest
 
 ```php
 /**
  * @test
  * @see https://github.com/company/project/issues/123
  *
- * Bug: Benutzer konnten sich nach Reset nicht anmelden
+ * Bug: Benutzer konnten sich nach dem Passwort-Reset nicht anmelden
+ * Grundursache: Passwort-Hash wurde nicht korrekt persistiert
  */
 public function test_user_can_login_after_password_reset(): void
 {
+    // Arrange: Benutzer mit bekanntem Passwort erstellen
     $user = $this->createUser('user@example.com', 'old-password');
+
+    // Act: Passwort zurücksetzen
     $this->passwordResetService->resetPassword($user, 'new-password');
 
+    // Assert: Kann sich mit neuem Passwort anmelden
     $result = $this->authService->authenticate('user@example.com', 'new-password');
 
     $this->assertTrue($result->isSuccess());
+    $this->assertNotNull($result->getToken());
+}
+
+/**
+ * @test
+ * Verwandt: Sicherstellen, dass altes Passwort nach Reset nicht mehr funktioniert
+ */
+public function test_old_password_fails_after_reset(): void
+{
+    $user = $this->createUser('user@example.com', 'old-password');
+
+    $this->passwordResetService->resetPassword($user, 'new-password');
+
+    $result = $this->authService->authenticate('user@example.com', 'old-password');
+
+    $this->assertFalse($result->isSuccess());
 }
 ```
+
+### Checkliste für das Schreiben von Tests
+
+- [ ] Test reproduziert den Fehler (schlägt vor Korrektur fehl)
+- [ ] Test hat einen beschreibenden Namen
+- [ ] Test referenziert die Issue-Nummer
+- [ ] Test dokumentiert die Grundursache im Kommentar
+- [ ] Verwandte Grenzfälle werden getestet
 
 ---
 
 ## Phase 4: Beheben
+
+Die minimale Korrektur für den Fehler implementieren.
+
+### Richtlinien für die Korrektur
+
+1. **Minimale Änderung**: Nur den Fehler beheben, nicht refaktorieren
+2. **Klare Absicht**: Code sollte zeigen, was falsch war
+3. **Keine Nebenwirkungen**: Kein Ändern von unverknüpftem Verhalten
+4. **Stil beibehalten**: Vorhandene Codemuster beibehalten
+
+### Beispielkorrektur
 
 ```php
 // VORHER (fehlerhaft)
@@ -82,67 +279,381 @@ public function resetPassword(User $user, string $newPassword): void
 }
 ```
 
+### Regressionstest ausführen
+
+```bash
+# Test sollte jetzt bestanden werden
+make test-unit TEST=tests/Unit/PasswordResetTest.php
+
+# Oder bestimmten Test ausführen
+./vendor/bin/phpunit --filter test_user_can_login_after_password_reset
+```
+
+### Korrektur-Checkliste
+
+- [ ] Regressionstest besteht jetzt
+- [ ] Korrektur ist minimal und fokussiert
+- [ ] Keine nicht zusammenhängenden Änderungen enthalten
+- [ ] Codestil beibehalten
+
 ---
 
 ## Phase 5: Validieren
 
+Sicherstellen, dass die Korrektur nichts anderes zerstört.
+
+### Vollständige Test-Suite ausführen
+
 ```bash
+# Alle Unit-Tests
+make test-unit
+
+# Alle Integrationstests
+make test-integration
+
+# Vollständige Test-Suite
 make test
+```
+
+### Qualitätsprüfungen
+
+```bash
+# Codequalität (je nach Technologie)
+/symfony:check-code-quality
+/flutter:check-code-quality
+/python:check-code-quality
+
+# Sicherheit (wenn die Korrektur sicherheitsrelevanten Code berührt)
+/common:security-audit
+
+# Vollständige Konformität
 /symfony:check-compliance
 ```
 
+### Manuelles Testen
+
+Auch mit automatisierten Tests manuell überprüfen:
+
+1. Originale Reproduktionsschritte des Fehlers ausführen
+2. Bestätigen, dass der Fehler nicht mehr auftritt
+3. Verwandte Funktionalität testen
+4. Grenzfälle prüfen
+
+### Reviewer-Agent verwenden
+
 ```markdown
-@symfony-reviewer Überprüfe meine Korrektur für Issue #123
+@symfony-reviewer Überprüfe meine Fehlerkorrektur für Issue #123
+
+Fehler: Benutzer konnten sich nach dem Passwort-Reset nicht anmelden
+Korrektur: Fehlendes persist/flush in resetPassword() hinzugefügt
+
+Geänderte Dateien:
+- src/Application/Service/PasswordResetService.php
+- tests/Unit/PasswordResetTest.php
+
+Bitte prüfen:
+1. Korrektur ist richtig und vollständig
+2. Keine Nebenwirkungen
+3. Testabdeckung ausreichend
 ```
+
+### Validierungs-Checkliste
+
+- [ ] Regressionstest besteht
+- [ ] Alle vorhandenen Tests bestehen
+- [ ] Statische Analyse besteht
+- [ ] Manuelles Testen bestätigt die Korrektur
+- [ ] Code-Review abgeschlossen
 
 ---
 
 ## Phase 6: Dokumentieren
 
-```bash
-git commit -m "fix(auth): Login-Fehler nach Passwort-Reset behoben
+Die Korrektur für künftige Referenz dokumentieren.
 
-Bug: Benutzer konnten sich nach Passwort-Reset nicht anmelden
-Ursache: Passwort-Hash wurde nicht in der Datenbank persistiert
-Korrektur: persist() und flush() in PasswordResetService hinzugefügt
+### Format der Commit-Nachricht
 
-Closes #123"
 ```
+fix(auth): Login-Fehler nach Passwort-Reset beheben
+
+Bug: Benutzer konnten sich nach dem Zurücksetzen ihres Passworts nicht anmelden
+Grundursache: Passwort-Hash-Änderung wurde nicht in der Datenbank persistiert
+Korrektur: persist()- und flush()-Aufrufe in PasswordResetService hinzugefügt
+
+Closes #123
+
+Test: test_user_can_login_after_password_reset
+```
+
+### Issue-Tracker aktualisieren
+
+```markdown
+## Lösung
+
+**Grundursache:**
+Die Methode `resetPassword()` in `PasswordResetService` hat den Passwort-Hash des Benutzers
+im Speicher aktualisiert, aber die Änderung nicht in der Datenbank persistiert.
+
+**Korrektur:**
+`persist()`- und `flush()`-Aufrufe nach dem Setzen des neuen Passwort-Hashs hinzugefügt.
+
+**Tests:**
+- Regressionstest `test_user_can_login_after_password_reset` hinzugefügt
+- Grenzfalltest `test_old_password_fails_after_reset` hinzugefügt
+
+**Prävention:**
+Erwägen, einen Punkt zur Code-Review-Checkliste für Persistenzoperationen hinzuzufügen.
+```
+
+### Wissensdatenbank-Eintrag (bei wiederkehrendem Muster)
+
+```markdown
+# Häufiger Fehler: Entity-Änderungen werden nicht persistiert
+
+## Symptome
+- Datenänderungen scheinen zu funktionieren (keine Fehler)
+- Änderungen erscheinen nicht in der Datenbank
+- Änderungen gehen nach Seitenaktualisierung verloren
+
+## Grundursache
+Fehlende `persist()`- und/oder `flush()`-Aufrufe in Doctrine.
+
+## Korrektionsmuster
+```php
+$entity->setSomething($value);
+$this->entityManager->persist($entity); // Nicht vergessen!
+$this->entityManager->flush();
+```
+
+## Prävention
+- Persistenzprüfung zur Code-Review-Checkliste hinzufügen
+- Auto-Flush in Service-Basisklasse in Betracht ziehen
+```
+
+### Dokumentations-Checkliste
+
+- [ ] Commit-Nachricht beschreibt Fehler und Korrektur
+- [ ] Issue-Tracker mit Lösung aktualisiert
+- [ ] Verwandte Dokumentation aktualisiert
+- [ ] Wissensdatenbank-Eintrag bei wiederkehrendem Muster
 
 ---
 
 ## Hotfix-Verfahren
 
+Für kritische Fehler in der Produktion.
+
+### Hotfix-Workflow
+
+```
+1. Hotfix-Branch von Produktion erstellen
+2. Minimale Korrektur anwenden
+3. Gründlich testen
+4. In Produktion deployen
+5. Zurück in main mergen
+```
+
+### Schritt für Schritt
+
 ```bash
 # 1. Hotfix-Branch erstellen
 git checkout production
-git checkout -b hotfix/issue-123
+git checkout -b hotfix/issue-123-login-failure
 
-# 2. Korrektur und Test anwenden
+# 2. Korrektur anwenden
+# ... Änderungen vornehmen ...
 
-# 3. Verifizieren
+# 3. Regressionstest schreiben
+# ... Test hinzufügen ...
+
+# 4. Verifizieren
 make test
 /symfony:check-compliance
 
-# 4. PR erstellen
-gh pr create --base production --title "HOTFIX: Login-Fehler"
+# 5. Mit klarer Nachricht committen
+git commit -m "fix(auth): Kritischen Login-Fehler nach Passwort-Reset beheben
 
-# 5. Nach Merge in main mergen
+HOTFIX für Produktionsproblem.
+Grundursache: Passwort-Hash nach Reset nicht persistiert.
+
+Closes #123"
+
+# 6. PR zur Review erstellen
+gh pr create --base production --title "HOTFIX: Login-Fehler nach Passwort-Reset"
+
+# 7. Nach Merge deployen
+# ... Deployment-Prozess ...
+
+# 8. Zurück in main mergen
 git checkout main
-git merge hotfix/issue-123
+git merge hotfix/issue-123-login-failure
+git push origin main
+```
+
+### Hotfix-Checkliste
+
+- [ ] Hotfix-Branch von Produktion erstellt
+- [ ] Nur minimale, fokussierte Korrektur
+- [ ] Regressionstest hinzugefügt
+- [ ] Alle Tests bestehen
+- [ ] PR wurde überprüft und genehmigt
+- [ ] In Produktion deployt
+- [ ] In Produktion verifiziert
+- [ ] Zurück in main gemergt
+
+---
+
+## Vollständiges Beispiel
+
+Lassen Sie uns durch die Behebung eines echten Fehlers gehen.
+
+### Fehlerbericht
+
+```
+Issue #456: Bestellsumme wird falsch berechnet
+
+Reproduktionsschritte:
+1. Artikel mit Preis $10.00, Menge 3 hinzufügen
+2. Artikel mit Preis $5.50, Menge 2 hinzufügen
+3. Warenkorb anzeigen
+
+Erwartet: Gesamt = $41.00 (30 + 11)
+Tatsächlich: Gesamt = $36.00
+
+Umgebung: Produktion v2.3.1
+Gemeldet von: Kundendienst
+Priorität: Hoch
+```
+
+### Schritt 1: Reproduzieren
+
+```php
+// Schneller lokaler Test
+$order = new Order();
+$order->addItem(new Item('A', 10.00), 3);  // $30
+$order->addItem(new Item('B', 5.50), 2);   // $11
+echo $order->getTotal(); // Zeigt 36.00 – bestätigt!
+```
+
+### Schritt 2: Diagnostizieren
+
+```markdown
+@tdd-coach Hilf mir, den Fehler in der Bestellsummen-Berechnung zu finden
+
+Die Summe sollte 41.00 sein, zeigt aber 36.00
+Differenz ist 5.00, was genau dem Preis eines Artikels B entspricht
+
+Hypothese: Menge für zweiten Artikel wird nicht berücksichtigt?
+```
+
+Untersuchung ergibt:
+
+```php
+// Fehler in Order::calculateTotal() gefunden
+public function calculateTotal(): Money
+{
+    $total = Money::zero();
+    foreach ($this->items as $item) {
+        // BUG: Verwendet 1 statt der tatsächlichen Artikelmenge!
+        $total = $total->add($item->getPrice()->multiply(1));
+    }
+    return $total;
+}
+```
+
+### Schritt 3: Regressionstest schreiben
+
+```php
+/**
+ * @test
+ * @see https://github.com/company/shop/issues/456
+ *
+ * Bug: Bestellsumme hat Artikelmengen ignoriert
+ */
+public function test_order_total_includes_all_quantities(): void
+{
+    $order = new Order();
+    $order->addItem($this->createItem(10.00), 3);  // $30
+    $order->addItem($this->createItem(5.50), 2);   // $11
+
+    $total = $order->calculateTotal();
+
+    $this->assertEquals(41.00, $total->getAmount());
+}
+
+/**
+ * @test
+ * Grenzfall: Einzelner Artikel mit Menge > 1
+ */
+public function test_single_item_quantity_multiplied(): void
+{
+    $order = new Order();
+    $order->addItem($this->createItem(10.00), 5);
+
+    $this->assertEquals(50.00, $order->calculateTotal()->getAmount());
+}
+```
+
+Test ausführen – bestätigt, dass er fehlschlägt.
+
+### Schritt 4: Beheben
+
+```php
+public function calculateTotal(): Money
+{
+    $total = Money::zero();
+    foreach ($this->items as $item) {
+        // Korrigiert: Tatsächliche Menge aus dem Bestellartikel verwenden
+        $total = $total->add(
+            $item->getPrice()->multiply($item->getQuantity())
+        );
+    }
+    return $total;
+}
+```
+
+### Schritt 5: Validieren
+
+```bash
+# Regressionstest besteht
+./vendor/bin/phpunit --filter test_order_total
+
+# Alle Tests bestehen
+make test
+
+# Qualitätsprüfung
+/symfony:check-compliance
+# Score: 94/100 ✓
+```
+
+### Schritt 6: Dokumentieren
+
+```bash
+git commit -m "fix(order): Gesamtberechnung korrigieren, um Mengen zu berücksichtigen
+
+Bug: Bestellsumme hat Artikelmengen ignoriert und immer 1 verwendet
+Grundursache: Hartcodiertes multiply(1) statt multiply(quantity)
+Korrektur: getQuantity() aus dem Bestellartikel in der Berechnung verwenden
+
+Closes #456
+
+Regressionstests hinzugefügt:
+- test_order_total_includes_all_quantities
+- test_single_item_quantity_multiplied"
 ```
 
 ---
 
-## Korrektur-Checkliste
+## Tipps zur Fehlerprävention
 
-- [ ] Fehler lokal reproduziert
-- [ ] Regressionstest geschrieben (schlägt fehl)
-- [ ] Code korrigiert
-- [ ] Test besteht
-- [ ] Keine Regressionen
-- [ ] Commit mit Issue-Referenz
+1. **Zuerst Tests schreiben**: TDD verhindert viele Fehler
+2. **Code-Review**: Frische Augen erkennen Probleme
+3. **Statische Analyse**: Werkzeuge finden häufige Fehler
+4. **Integrationstests**: Interaktionsfehler erkennen
+5. **Produktion überwachen**: Probleme frühzeitig erkennen
+6. **`/loop` verwenden**: Wiederkehrende Qualitätsprüfungen einrichten (z. B. `/loop 5m /common:pre-commit-check`)
+7. **Erkenntnisse speichern**: `/memory` verwenden, um Fehlermuster über Sitzungen hinweg zu persistieren
 
 ---
 
-[&larr; Feature-Entwicklung](03-feature-development.md) | [Werkzeuge-Referenz &rarr;](05-tools-reference.md)
+[&larr; Feature-Entwicklung](03-feature-development.md) | [Werkzeug-Referenz &rarr;](05-tools-reference.md)

--- a/docs/guides/de/05-tools-reference.md
+++ b/docs/guides/de/05-tools-reference.md
@@ -1,103 +1,717 @@
-# Werkzeuge-Referenz
+# Werkzeug-Referenzhandbuch
 
-Anleitung zu den mit Claude-Craft enthaltenen Hilfswerkzeugen.
+Dieser Leitfaden behandelt die Hilfswerkzeuge von Claude-Craft zur Verwaltung von Profilen, Statusanzeigen, Projektkonfigurationen sowie Befehle und Funktionen von Claude Code (v8.7).
+
+---
+
+## Inhaltsverzeichnis
+
+1. [Claude Code-Befehle](#claude-code-befehle)
+2. [Hook-Ereignisse](#hook-ereignisse)
+3. [Agent-Frontmatter](#agent-frontmatter)
+4. [MCP Tool Search](#mcp-tool-search)
+5. [Auto-Modus](#auto-modus)
+6. [Hook-Vorlagen](#hook-vorlagen)
+7. [Verwaltete Einstellungen](#verwaltete-einstellungen)
+8. [MultiAccount-Manager](#multiaccount-manager)
+9. [StatusLine](#statusline)
+10. [ProjectConfig-Manager](#projectconfig-manager)
+11. [Installation](#installation)
+
+---
+
+## Claude Code-Befehle
+
+Claude Code stellt eingebaute Befehle für die Kontext- und Sitzungsverwaltung bereit. Diese sind in jeder Claude Code-Sitzung verfügbar (v2.1.47+).
+
+### Befehle zur Kontextverwaltung
+
+| Befehl | Version | Beschreibung |
+|--------|---------|--------------|
+| `/clear` | Alle | Kontext zwischen nicht zusammenhängenden Aufgaben löschen |
+| `/compact` | Alle | Kontext proaktiv komprimieren (bei ca. 70 % Auslastung ausführen) |
+| `/context` | v2.1.74+ | Umsetzbare Vorschläge zur Kontextoptimierung erhalten |
+| `/effort low\|medium\|high` | v2.1.72+ | Reasoning-Aufwand des Modells je nach Aufgabenkomplexität anpassen |
+| `/memory` | v2.1.59+ | Dauerhaftes Speichern von Erkenntnissen über Sitzungen und Komprimierungen hinweg |
+| `/model haiku\|sonnet\|opus` | v2.1.72+ | Modell während einer Sitzung je nach Aufgabenkomplexität wechseln |
+
+### Sitzungsbefehle
+
+| Befehl | Version | Beschreibung |
+|--------|---------|--------------|
+| `/loop [interval] [befehl]` | v2.1.71+ | Wiederkehrende Aufgaben ausführen (z. B. `/loop 5m /common:pre-commit-check`) |
+| `/proactive` | v2.1.105+ | Alias für `/loop` |
+| `/color` | v2.1.94+ | Farbschema des Terminals ändern |
+| `/rename` | v2.1.94+ | Aktuelle Sitzung umbenennen |
+| `/powerup` | v2.1.94+ | Power-up-Funktionen aktivieren |
+
+### Verwendungsbeispiele
+
+```bash
+# Aufwand für eine einfache Suche anpassen
+/effort low
+
+# Zu einem günstigeren Modell für die Erkundung wechseln
+/model sonnet
+
+# Wiederkehrendes CI-Monitoring einrichten
+/loop 5m "Check if CI pipeline passed"
+
+# Wichtigen Kontext vor der Komprimierung speichern
+/memory "Authentication uses JWT with RS256, refresh tokens in HttpOnly cookies"
+```
+
+---
+
+## Hook-Ereignisse
+
+Claude Code unterstützt 24 Hook-Ereignisse (8 davon wurden in neueren Claude Code-Versionen hinzugefügt), um Workflows zu automatisieren:
+
+### Alle Hook-Ereignisse
+
+| Ereignis | Zeitpunkt | Anwendungsfall |
+|----------|-----------|----------------|
+| **PreToolUse** | Vor der Werkzeugausführung | Gefährliche Befehle blockieren, mit RTK umschreiben |
+| **PostToolUse** | Nach der Werkzeugausführung | Ausführliche Ausgabe filtern, Ergebnisse zusammenfassen |
+| **PreCompact** | Vor der Kontextkomprimierung | Kritischen Kontext speichern; Exit-Code 2 blockiert Komprimierung (v2.1.105+) |
+| **PostCompact** | Nach der Kontextkomprimierung | Wesentlichen Kontext erneut einschleusen |
+| **SessionStart** | Beim Sitzungsstart | Wesentliche Kontextdaten laden, Umgebung einrichten |
+| **StopFailure** | Bei unerwartetem Stopp | Zustand speichern, bei Fehlern warnen |
+| **Notification** | Bei Benachrichtigungsereignissen | Benutzerdefinierte Benachrichtigungen |
+| **TaskCreated** | Wenn eine Unteragenten-Aufgabe erstellt wird | Unteragenten-Arbeit verfolgen |
+| **CwdChanged** | Änderung des Arbeitsverzeichnisses | Umgebung je nach Verzeichnis aktualisieren |
+| **FileChanged** | Dateiänderung erkannt | Neuerstellungen und Linting auslösen |
+| **PermissionDenied** | Berechtigungsprüfung schlägt fehl | Sicherheitsereignisse protokollieren |
+| **Elicitation** | Vor der Benutzeraufforderung | Elicitation-Ablauf anpassen |
+| **ElicitationResult** | Nach der Benutzerantwort | Elicitation-Ergebnisse verarbeiten |
+| **Stop** | Bei Sitzungsende | Aufräumen |
+
+### Hook-Erweiterungen (v8.7)
+
+| Funktion | Beschreibung |
+|----------|--------------|
+| **Bedingtes `if`** | Hooks nur ausführen, wenn die Bedingung zutrifft |
+| **`defer`** | Ausführung des Hooks verschieben, um Blockierungen zu vermeiden |
+| **PreCompact-Blockierung** | Exit-Code 2 im PreCompact-Hook blockiert die Komprimierung (v2.1.105+) |
+
+### Beispiel: PostToolUse-Ausgabefilter
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "echo '$TOOL_OUTPUT' | head -100"
+      }]
+    }]
+  }
+}
+```
+
+---
+
+## Agent-Frontmatter
+
+Benutzerdefinierte Agenten (v2.1.78+) unterstützen Frontmatter-Felder, um Verhalten und Kosten zu steuern:
+
+```yaml
+---
+effort: low          # Reasoning-Aufwand (low/medium/high)
+maxTurns: 10         # Maximale Anzahl von Gesprächsrunden
+disallowedTools:     # Werkzeuge, die der Agent nicht verwenden darf
+  - Edit
+  - Write
+---
+```
+
+| Feld | Typ | Beschreibung |
+|------|-----|--------------|
+| `effort` | string | `low`, `medium` oder `high` Reasoning-Aufwand |
+| `maxTurns` | number | Maximale Anzahl von Runden vor dem Stopp |
+| `disallowedTools` | list | Werkzeuge, die dem Agenten nicht erlaubt sind |
+
+Dies ist nützlich, um kostengünstige Erkundungsagenten zu erstellen, die Code lesen, aber nicht ändern können.
+
+---
+
+## MCP Tool Search
+
+MCP Tool Search (v2.1.80+) ermöglicht das verzögerte Laden von MCP-Werkzeugen und reduziert den Kontextverbrauch um 95 %:
+
+| Ansatz | Kontextkosten |
+|--------|--------------|
+| MCP klassisch (alle Werkzeuge geladen) | ~500–2000 Token/Werkzeug/Runde |
+| MCP mit Tool Search (lazy) | ~50 Token insgesamt |
+
+### Verwendung
+
+```bash
+# Ein bestimmtes Werkzeug bei Bedarf laden
+ToolSearch with query: "select:tool_name"
+
+# Nach Schlüsselwort suchen
+ToolSearch with query: "slack send"
+```
+
+Anstatt alle MCP-Server-Werkzeuge beim Start zu laden, lädt Tool Search sie nur bei Bedarf.
+
+---
+
+## Auto-Modus
+
+Der Auto-Modus (v2.1.94+) ist ein KI-gestützter Berechtigungsklassifikator, der `--dangerously-skip-permissions` sicherer ersetzt:
+
+| Modus | Schutz | Geschwindigkeit | Anwendungsfall |
+|-------|--------|-----------------|----------------|
+| Manuell | Maximum | Langsam | Geprüfte Workflows, hohe Sicherheit |
+| Auto-Modus | Hoch | Schnell | Vertrauenswürdige Entwicklungs-Workflows |
+| Berechtigungen überspringen | Minimal | Maximum | Nur lokale/persönliche Projekte |
+
+**Sicherheitsfunktionen:**
+- Ein Sicherheitsmodell im Hintergrund bewertet jeden Werkzeugaufruf
+- Sichere Operationen (Lesen, Tests) werden automatisch genehmigt
+- Riskante Aktionen (Massenlöschung, Exfiltration) werden blockiert
+- 3 aufeinanderfolgende Blockierungen setzen den Modus auf manuell zurück
+- Mehr als 20 Blockierungen in einer Sitzung setzen auf den vollständigen manuellen Modus zurück
+
+Verfügbar für Team-Pläne mit Administratorgenehmigung.
+
+---
+
+## Hook-Vorlagen
+
+Claude-Craft stellt fertig verwendbare Hook-Vorlagen in `.claude/templates/hooks/` bereit:
+
+| Vorlage | Zweck |
+|---------|-------|
+| `output-filter.json` | PostToolUse-Filter für große CLI-Ausgaben |
+| `pre-compact.json` | PreCompact-Hook zum Bewahren von kritischem Kontext |
+| `context-reinject.json` | SessionStart-Hook zur erneuten Kontexteinschleusung nach der Komprimierung |
+
+### Installation
+
+Vorlagen in die `.claude/settings.json` des Projekts kopieren oder in die Hook-Konfiguration einbinden:
+
+```bash
+# Verfügbare Vorlagen anzeigen
+ls .claude/templates/hooks/
+
+# Auf das Projekt anwenden (manuell in settings.json einbinden)
+cat .claude/templates/hooks/output-filter.json
+```
+
+---
+
+## Verwaltete Einstellungen
+
+Das Verzeichnis `managed-settings.d/` (v2.1.83+) ermöglicht eine modulare Konfiguration durch alphabetisches Zusammenführen:
+
+```
+.claude/
+  managed-settings.d/
+    00-base.json          # Grundkonfiguration
+    10-security.json      # Sicherheitsregeln
+    20-team.json          # Team-Einstellungen
+```
+
+Dateien werden in alphabetischer Reihenfolge zusammengeführt, sodass Teams Konfigurationen schichten können, ohne Konflikte zu erzeugen.
 
 ---
 
 ## MultiAccount-Manager
 
-Verwaltet mehrere Claude Code-Profile.
+Mehrere Claude Code-Profile für verschiedene Konten oder Kontexte verwalten.
+
+### Zweck
+
+- Zwischen Claude-Konten wechseln (persönlich, Arbeit, Kunde)
+- Ratenbegrenzungen durch Profilwechsel steuern
+- Projektkontexte isoliert halten
+- Konfigurationen teilen oder isolieren
 
 ### Installation
+
 ```bash
+# Über Makefile
 make install-multiaccount
+
+# Oder manuell
+cp Tools/MultiAccount/claude-accounts.sh ~/.local/bin/
+chmod +x ~/.local/bin/claude-accounts.sh
 ```
 
-### Interaktive Nutzung
+### Verwendung
+
+#### Interaktiver Modus
+
 ```bash
+# Interaktives Menü starten
 ./claude-accounts.sh
+# Oder wenn global installiert
+claude-accounts.sh
 ```
 
-### CLI-Modus
-```bash
-./claude-accounts.sh list              # Profile auflisten
-./claude-accounts.sh add <name>        # Profil hinzufügen
-./claude-accounts.sh remove <name>     # Profil entfernen
-./claude-accounts.sh auth <name>       # Profil authentifizieren
-./claude-accounts.sh launch <name>     # Claude mit Profil starten
+Menüoptionen:
+```
+1. Profile auflisten
+2. Profil hinzufügen
+3. Profil löschen
+4. Profil authentifizieren
+5. Claude Code starten
+6. ccsp()-Funktion installieren
+7. Veraltetes Profil migrieren
+8. Hilfe
+9. Beenden
 ```
 
-### Profil-Modi
-- **shared**: Teilt Konfiguration mit `~/.claude`
-- **isolated**: Unabhängige Konfiguration
+#### CLI-Modus
 
-### ccsp()-Funktion
 ```bash
-ccsp           # Profile auflisten
-ccsp arbeit    # Zu Profil "arbeit" wechseln
-claude         # Mit aktuellem Profil starten
+# Alle Profile auflisten
+./claude-accounts.sh list
+
+# Neues Profil hinzufügen
+./claude-accounts.sh add <profilname>
+
+# Profil entfernen
+./claude-accounts.sh remove <profilname>
+
+# Profil authentifizieren
+./claude-accounts.sh auth <profilname>
+
+# Claude Code mit Profil starten
+./claude-accounts.sh launch <profilname>
+
+# Hilfe anzeigen
+./claude-accounts.sh --help
+```
+
+### Profilmodi
+
+#### Gemeinsamer Modus (Standard)
+
+Das Profil teilt die Konfiguration mit dem Hauptverzeichnis `~/.claude`:
+
+```bash
+./claude-accounts.sh add work --mode=shared
+```
+
+- Einstellungen per Symlink mit `~/.claude` verknüpft
+- Geeignet für: Kontowechsel bei beibehaltenen Einstellungen
+- Anwendungsfall: Ratenbegrenzungsverwaltung
+
+#### Isolierter Modus
+
+Das Profil hat eine vollständig unabhängige Konfiguration:
+
+```bash
+./claude-accounts.sh add client-a --mode=isolated
+```
+
+- Unabhängige Kopie der Einstellungen
+- Geeignet für: Kundenarbeit mit separaten Regeln
+- Anwendungsfall: Unterschiedliche Projektkonfigurationen
+
+### Schneller Profilwechsel
+
+Die Shell-Funktion `ccsp()` installieren:
+
+```bash
+# Über Menüoption 6 zum Profil hinzufügen
+# Oder manuell in ~/.bashrc oder ~/.zshrc eintragen:
+
+ccsp() {
+    if [ -z "$1" ]; then
+        claude-accounts.sh list
+    else
+        export CLAUDE_CONFIG_DIR="$HOME/.claude-profiles/$1"
+        echo "Switched to profile: $1"
+    fi
+}
+```
+
+Verwendung:
+```bash
+# Profile auflisten
+ccsp
+
+# Zu einem Profil wechseln
+ccsp work
+
+# Claude Code starten (verwendet aktuelles Profil)
+claude
+```
+
+### Profilstruktur
+
+```
+~/.claude-profiles/
+├── work/
+│   ├── .mode              # "shared" oder "isolated"
+│   ├── config/            # Claude-Konfiguration
+│   └── settings.json      # Profileinstellungen
+├── client-a/
+│   └── ...
+└── personal/
+    └── ...
+```
+
+### Sprachunterstützung
+
+```bash
+# In einer bestimmten Sprache verwenden
+./claude-accounts.sh --lang=fr list
+./claude-accounts.sh --lang=es add trabajo
+./claude-accounts.sh --lang=de --help
 ```
 
 ---
 
 ## StatusLine
 
-Zeigt kontextuelle Informationen in der Claude Code-Statusleiste.
+Kontextbezogene Informationen in der Statusleiste von Claude Code anzeigen.
+
+### Zweck
+
+- Aktuelles Profil anzeigen
+- Verwendetes Modell anzeigen
+- Git-Branch und -Status anzeigen
+- Kontextauslastung in Prozent verfolgen
+- Sitzungs- und Wochenkosten überwachen
+- Nutzungslimits anzeigen
 
 ### Installation
+
 ```bash
+# Über Makefile
 make install-statusline
+
+# Oder manuell
+cp Tools/StatusLine/statusline.sh ~/.claude/statusline.sh
+cp Tools/StatusLine/statusline.conf.example ~/.claude/statusline.conf
+chmod +x ~/.claude/statusline.sh
 ```
 
-### Format
-```
-🔑 pro | 🧠 Opus | 🌿 main +2~1 | 📁 projekt | 📊 45% | ⏱️ 5h: 23% | 📅 Woche: 45% | 💰 $0.42 | 🕐 14:32
+### Claude Code konfigurieren
+
+In `~/.claude/settings.json` einfügen:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  }
+}
 ```
 
-### Konfiguration (`~/.claude/statusline.conf`)
+### Format der Statusleiste
+
+```
+🔑 pro | 🧠 Opus | 🌿 main +2~1 | 📁 my-project | 📊 45% | ⏱️ 5h: 23% | 📅 Sem: 45% | 💰 $0.42 | 🕐 14:32
+```
+
+| Element | Beschreibung |
+|---------|--------------|
+| 🔑 pro | Name des aktiven Profils |
+| 🧠 Opus | Aktuelles Modell (🧠 Opus, 🎵 Sonnet, 🍃 Haiku) |
+| 🌿 main +2~1 | Git-Branch + Status (+bereitgestellt ~geändert ?unverfolgt) |
+| 📁 my-project | Name des Projektverzeichnisses |
+| 📊 45% | Auslastung des Kontextfensters |
+| ⏱️ 5h: 23% | Auslastungsprozentsatz der Sitzung (5h) |
+| 📅 Sem: 45% | Wöchentlicher Auslastungsprozentsatz |
+| 💰 $0.42 | Sitzungskosten |
+| 🕐 14:32 | Aktuelle Uhrzeit |
+
+### Farbkodierung
+
+Auslastungsanzeigen wechseln die Farbe je nach Schwellenwert:
+
+| Farbe | Bedeutung | Schwellenwert |
+|-------|-----------|---------------|
+| Grün | Geringe Auslastung | < 60 % |
+| Gelb | Mittlere Auslastung | 60–80 % |
+| Rot | Hohe Auslastung | > 80 % |
+
+### Konfiguration
+
+`~/.claude/statusline.conf` bearbeiten:
+
 ```bash
-SESSION_COST_LIMIT=500.00    # Sitzungslimit (Max 20x)
-WEEKLY_COST_LIMIT=3000.00    # Wochenlimit
-USAGE_WARN_THRESHOLD=60      # Gelb bei 60%
-USAGE_CRIT_THRESHOLD=80      # Rot bei 80%
+# =============================================================================
+# NUTZUNGSLIMITS
+# =============================================================================
+# Empfohlene Werte nach Plan:
+#   - Pro ($20/Monat)     : SESSION=25,   WEEKLY=150
+#   - Max 5x ($100/Monat) : SESSION=125,  WEEKLY=750
+#   - Max 20x ($200/Monat): SESSION=500,  WEEKLY=3000
+
+SESSION_COST_LIMIT=500.00
+WEEKLY_COST_LIMIT=3000.00
+
+# =============================================================================
+# WARNSCHWELLEN (Prozentsatz)
+# =============================================================================
+USAGE_WARN_THRESHOLD=60    # Gelb bei 60 %
+USAGE_CRIT_THRESHOLD=80    # Rot bei 80 %
+
+# =============================================================================
+# CACHE (Leistung)
+# =============================================================================
+SESSION_CACHE_TTL=60       # Sitzung alle 60 s aktualisieren
+WEEKLY_CACHE_TTL=300       # Wöchentlich alle 5 min aktualisieren
+
+# =============================================================================
+# ANZEIGEOPTIONEN
+# =============================================================================
+SHOW_SESSION_LIMIT=true
+SHOW_WEEKLY_LIMIT=true
+
+# Benutzerdefinierte Bezeichnungen
+SESSION_LABEL="⏱️ 5h"
+WEEKLY_LABEL="📅 Sem"
 ```
 
 ### Abhängigkeiten
+
 ```bash
-brew install jq   # Erforderlich
-npm install -g ccusage  # Optional
+# Erforderlich: jq (JSON-Prozessor)
+# macOS
+brew install jq
+
+# Linux
+sudo apt install jq
+
+# Optional: ccusage (Kostenverfolgung)
+npm install -g ccusage
+```
+
+### Fehlerbehebung
+
+**Statusleiste wird nicht angezeigt:**
+```bash
+# Prüfen, ob das Skript ausführbar ist
+ls -la ~/.claude/statusline.sh
+
+# Manuell testen
+echo '{"model":{"display_name":"Test"}}' | ~/.claude/statusline.sh
+```
+
+**Kosten zeigen $0.00:**
+```bash
+# Prüfen, ob ccusage funktioniert
+npx ccusage daily --json
+```
+
+**Auslastungsprozentsätze werden nicht angezeigt:**
+```bash
+# Cache-Dateien prüfen
+ls -la /tmp/.ccusage_*
+
+# Cache leeren, um zu aktualisieren
+rm /tmp/.ccusage_*
 ```
 
 ---
 
 ## ProjectConfig-Manager
 
-Verwaltet Claude-Craft-Projektkonfigurationen via YAML.
+Claude-Craft-Projektkonfigurationen über YAML verwalten.
+
+### Zweck
+
+- Projekteinstellungen in YAML definieren
+- Mehrere Projekte verwalten
+- Monorepo-Konfigurationen verwalten
+- Konfigurationen validieren
+- Regeln aus der Konfiguration installieren
 
 ### Installation
-```bash
-make install-projectconfig
-```
 
-### CLI-Modus
 ```bash
-./claude-projects.sh list                  # Projekte auflisten
-./claude-projects.sh validate              # Konfiguration validieren
-./claude-projects.sh install <name>        # Projekt installieren
-./claude-projects.sh install-all           # Alle installieren
+# Über Makefile
+make install-projectconfig
+
+# Oder manuell
+cp Tools/ProjectConfig/claude-projects.sh ~/.local/bin/
+chmod +x ~/.local/bin/claude-projects.sh
 ```
 
 ### Abhängigkeiten
+
 ```bash
-brew install yq  # Erforderlich
+# Erforderlich: yq (YAML-Prozessor)
+# macOS
+brew install yq
+
+# Linux (snap)
+sudo snap install yq
+
+# Linux (Binärdatei)
+wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+chmod +x /usr/local/bin/yq
+```
+
+### Verwendung
+
+#### Interaktiver Modus
+
+```bash
+./claude-projects.sh
+```
+
+Menüoptionen:
+```
+1. Projekte auflisten
+2. Projekt hinzufügen
+3. Projekt bearbeiten
+4. Modul hinzufügen
+5. Projekt löschen
+6. Konfiguration validieren
+7. Projekt installieren
+8. Hilfe
+9. Beenden
+```
+
+#### CLI-Modus
+
+```bash
+# Konfigurierte Projekte auflisten
+./claude-projects.sh list
+
+# Konfigurationsdatei validieren
+./claude-projects.sh validate [konfigurationsdatei]
+
+# Bestimmtes Projekt installieren
+./claude-projects.sh install <projektname>
+
+# Alle Projekte installieren
+./claude-projects.sh install-all
+
+# Projektdetails anzeigen
+./claude-projects.sh show <projektname>
+
+# Neues Projekt hinzufügen
+./claude-projects.sh add <projektname> <pfad>
+
+# Projekt entfernen
+./claude-projects.sh remove <projektname>
+```
+
+### Konfigurationsdatei
+
+Standardspeicherort: `./claude-projects.yaml`
+
+```yaml
+settings:
+  default_lang: "fr"
+
+projects:
+  - name: "my-saas"
+    description: "SaaS platform"
+    path: "~/Projects/my-saas"
+    modules:
+      - name: "api"
+        path: "backend"
+        technologies: ["symfony"]
+      - name: "web"
+        path: "frontend"
+        technologies: ["react"]
+      - name: "mobile"
+        path: "app"
+        technologies: ["flutter"]
+
+  - name: "internal-tool"
+    path: "~/Projects/internal"
+    technologies: ["python"]
+    lang: "en"
+```
+
+### Validierung
+
+```bash
+# Konfiguration validieren
+./claude-projects.sh validate
+
+# Oder über Makefile
+make config-validate CONFIG=claude-projects.yaml
+```
+
+Validierungsprüfungen:
+- YAML-Syntax gültig
+- Pflichtfelder vorhanden
+- Pfade vorhanden
+- Technologien gültig
+- Sprachen gültig
+
+### Installation aus der Konfiguration
+
+```bash
+# Einzelnes Projekt installieren
+./claude-projects.sh install my-saas
+
+# Oder über Makefile
+make config-install CONFIG=claude-projects.yaml PROJECT=my-saas
+
+# Alle Projekte installieren
+make config-install-all CONFIG=claude-projects.yaml
+
+# Probelauf (Dry run)
+make config-install CONFIG=claude-projects.yaml PROJECT=my-saas OPTIONS="--dry-run"
+```
+
+### Sprachunterstützung
+
+```bash
+# In einer bestimmten Sprache verwenden
+./claude-projects.sh --lang=fr list
+./claude-projects.sh --lang=de validate
 ```
 
 ---
 
-## Alle Werkzeuge installieren
+## Installation
+
+### Alle Werkzeuge installieren
 
 ```bash
 make install-tools
+```
+
+Dies installiert:
+- MultiAccount-Manager
+- StatusLine
+- ProjectConfig-Manager
+
+### Einzelne Werkzeuge installieren
+
+```bash
+# Nur MultiAccount
+make install-multiaccount
+
+# Nur StatusLine
+make install-statusline
+
+# Nur ProjectConfig
+make install-projectconfig
+```
+
+### Installation überprüfen
+
+```bash
+# MultiAccount prüfen
+which claude-accounts.sh
+claude-accounts.sh --version
+
+# StatusLine prüfen
+ls ~/.claude/statusline.sh
+cat ~/.claude/settings.json | jq '.statusLine'
+
+# ProjectConfig prüfen
+which claude-projects.sh
+claude-projects.sh --version
 ```
 
 ---
@@ -105,25 +719,44 @@ make install-tools
 ## Kurzreferenz
 
 ### MultiAccount-Befehle
+
 | Befehl | Beschreibung |
 |--------|--------------|
-| `list` | Profile anzeigen |
-| `add <name>` | Profil erstellen |
+| `list` | Alle Profile anzeigen |
+| `add <name>` | Neues Profil erstellen |
 | `remove <name>` | Profil löschen |
-| `launch <name>` | Claude starten |
+| `auth <name>` | Profil authentifizieren |
+| `launch <name>` | Claude mit Profil starten |
+| `migrate` | Veraltetes Profil konvertieren |
 
 ### StatusLine-Elemente
+
 | Emoji | Bedeutung |
 |-------|-----------|
 | 🔑 | Profil |
-| 🧠/🎵/🍃 | Modell (Opus/Sonnet/Haiku) |
+| 🧠 | Opus-Modell |
+| 🎵 | Sonnet-Modell |
+| 🍃 | Haiku-Modell |
 | 🌿 | Git-Branch |
 | 📁 | Projekt |
 | 📊 | Kontext % |
-| ⏱️ | Sitzungsnutzung |
-| 📅 | Wochennutzung |
+| ⏱️ | Sitzungsauslastung |
+| 📅 | Wöchentliche Auslastung |
 | 💰 | Kosten |
+| 🕐 | Uhrzeit |
+
+### ProjectConfig-Befehle
+
+| Befehl | Beschreibung |
+|--------|--------------|
+| `list` | Alle Projekte anzeigen |
+| `validate` | Konfigurationsgültigkeit prüfen |
+| `install <name>` | Projektregeln installieren |
+| `install-all` | Alle Projekte installieren |
+| `show <name>` | Projektdetails anzeigen |
+| `add <name> <pfad>` | Neues Projekt hinzufügen |
+| `remove <name>` | Projekt löschen |
 
 ---
 
-[&larr; Fehlerbehebung](04-bug-fixing.md) | [Problemlösung &rarr;](06-troubleshooting.md)
+[&larr; Fehlerbehebung bei Bugs](04-bug-fixing.md) | [Problemlösung &rarr;](06-troubleshooting.md)

--- a/docs/guides/de/06-troubleshooting.md
+++ b/docs/guides/de/06-troubleshooting.md
@@ -1,139 +1,696 @@
-# Anleitung zur Problemlösung
+# Leitfaden zur Problemlösung
 
-Häufige Probleme und ihre Lösungen bei der Verwendung von Claude-Craft.
+Dieser Leitfaden behandelt häufige Probleme und ihre Lösungen bei der Verwendung von Claude-Craft.
+
+---
+
+## Inhaltsverzeichnis
+
+1. [Installationsprobleme](#installationsprobleme)
+2. [Agenten-Probleme](#agenten-probleme)
+3. [Befehlsprobleme](#befehlsprobleme)
+4. [Konfigurationsprobleme](#konfigurationsprobleme)
+5. [Werkzeugprobleme](#werkzeugprobleme)
+6. [Leistungsprobleme](#leistungsprobleme)
+7. [Hilfe erhalten](#hilfe-erhalten)
 
 ---
 
 ## Installationsprobleme
 
-### Befehle nicht erkannt
-**Lösungen:**
-1. Claude Code neu starten (`exit` + `claude`)
-2. Installation überprüfen: `ls -la .claude/commands/`
-3. Dateiformat der Befehle überprüfen
+### Befehle werden nach der Installation nicht erkannt
 
-### Dateien nicht gefunden
-**Lösungen:**
-1. Claude-Craft-Pfad überprüfen: `pwd && ls Dev/scripts/`
-2. Sprachdateien überprüfen: `ls Dev/i18n/de/`
-3. Absoluten TARGET-Pfad verwenden
+**Symptome:**
+- Slash-Befehle wie `/symfony:check-compliance` funktionieren nicht
+- Claude erkennt installierte Befehle nicht
 
-### Berechtigungsfehler
-```bash
-chmod +x Dev/scripts/*.sh
-chmod +x Tools/*/*.sh
-```
+**Lösungen:**
+
+1. **Claude Code neu starten**
+   ```bash
+   # Claude Code vollständig beenden
+   exit
+
+   # Neu starten
+   claude
+   ```
+
+2. **Installation überprüfen**
+   ```bash
+   ls -la .claude/commands/
+   # Sollte Befehlsverzeichnisse anzeigen
+   ```
+
+3. **Dateiformat des Befehls prüfen**
+   ```bash
+   head -5 .claude/commands/symfony/check-compliance.md
+   # Sollte mit einem korrekten Markdown-Header beginnen
+   ```
+
+### Dateien werden bei der Installation nicht gefunden
+
+**Symptome:**
+- Fehler „Quelldatei nicht gefunden"
+- Fehlende Regeln oder Vorlagen
+
+**Lösungen:**
+
+1. **Claude-Craft-Pfad überprüfen**
+   ```bash
+   # Prüfen, ob man sich im claude-craft-Verzeichnis befindet
+   pwd
+   ls -la Dev/scripts/
+   ```
+
+2. **Vorhandensein der Sprachdateien prüfen**
+   ```bash
+   ls -la Dev/i18n/en/Symfony/rules/
+   ```
+
+3. **Absoluten TARGET-Pfad verwenden**
+   ```bash
+   # Statt
+   make install-symfony TARGET=./backend
+
+   # Verwenden
+   make install-symfony TARGET=/vollständiger/pfad/zum/backend
+   ```
+
+### Fehler „Zugriff verweigert"
+
+**Symptome:**
+- Installationsskripte können nicht ausgeführt werden
+- Schreibzugriff auf Zielverzeichnis nicht möglich
+
+**Lösungen:**
+
+1. **Skripte ausführbar machen**
+   ```bash
+   chmod +x Dev/scripts/*.sh
+   chmod +x Project/*.sh
+   chmod +x Infra/*.sh
+   chmod +x Tools/*/*.sh
+   ```
+
+2. **Berechtigungen des Zielverzeichnisses prüfen**
+   ```bash
+   ls -la ~/my-project/
+   # Sicherstellen, dass Schreibzugriff vorhanden ist
+   ```
+
+3. **Mit entsprechendem Benutzer ausführen**
+   ```bash
+   # sudo nur bei Notwendigkeit verwenden
+   # Verzeichnisbesitz prüfen
+   ls -la ~/my-project
+   ```
+
+### Installation erstellt leeres Verzeichnis
+
+**Symptome:**
+- `.claude/`-Verzeichnis erstellt, aber leer oder fehlende Dateien
+
+**Lösungen:**
+
+1. **Fehler in der Ausgabe prüfen**
+   ```bash
+   # Mit ausführlicher Ausgabe ausführen
+   make install-symfony TARGET=./backend 2>&1 | tee install.log
+   ```
+
+2. **Quelle überprüfen**
+   ```bash
+   ls -la Dev/i18n/en/Symfony/
+   ```
+
+3. **Direktes Skript ausführen**
+   ```bash
+   ./Dev/scripts/install-symfony-rules.sh --lang=en ./backend
+   ```
 
 ---
 
 ## Agenten-Probleme
 
 ### Agent nicht verfügbar
-1. Dateien überprüfen: `ls .claude/agents/`
-2. Frontmatter-Format überprüfen
-3. Neu installieren: `make install-common TARGET=. OPTIONS="--force"`
 
-### Irrelevante Antworten
-1. Mehr Kontext in der Anfrage bereitstellen
-2. Spezifischer in der Anfrage sein
-3. `00-project-context.md` überprüfen
+**Symptome:**
+- `@api-designer` oder andere Agenten antworten nicht
+- Fehler des Typs „Unbekannter Agent"
+
+**Lösungen:**
+
+1. **Vorhandensein der Agent-Dateien prüfen**
+   ```bash
+   ls -la .claude/agents/
+   # Sollte Agent-.md-Dateien auflisten
+   ```
+
+2. **Dateiformat des Agenten prüfen**
+   ```bash
+   head -20 .claude/agents/api-designer.md
+   # Sollte korrekte Frontmatter mit Name und Beschreibung haben
+   ```
+
+3. **Agenten neu installieren**
+   ```bash
+   make install-common TARGET=. OPTIONS="--force"
+   ```
+
+### Agent gibt irrelevante Antworten
+
+**Symptome:**
+- Agent befolgt seine spezialisierten Anweisungen nicht
+- Generische Antworten statt Expertenrat
+
+**Lösungen:**
+
+1. **Mehr Kontext bereitstellen**
+   ```markdown
+   @symfony-reviewer Überprüfe meine UserService-Implementierung
+
+   Kontext:
+   - Symfony 7 mit API Platform
+   - Clean Architecture
+   - DDD-Ansatz
+
+   Zu überprüfender Code:
+   [Code hier einfügen]
+   ```
+
+2. **In der Anfrage spezifisch sein**
+   ```markdown
+   # Statt
+   @database-architect Hilf mir mit meiner Datenbank
+
+   # Verwenden
+   @database-architect Entwirf das Schema für den User-Aggregat mit:
+   - User-Entity (id, email, password_hash)
+   - Role-Entity (Many-to-Many mit User)
+   - Permission-Entity (Many-to-Many mit Role)
+   - Audit-Trail für Benutzeränderungen
+   ```
+
+3. **Projektkontextdatei prüfen**
+   ```bash
+   cat .claude/rules/00-project-context.md
+   # Sicherstellen, dass das Projekt korrekt beschrieben wird
+   ```
+
+### Agent widerspricht Projektregeln
+
+**Symptome:**
+- Agent-Vorschläge widersprechen Projektkonventionen
+- Inkonsistenter Rat
+
+**Lösungen:**
+
+1. **Projektkontext aktualisieren**
+   - Spezifische Konventionen zu `00-project-context.md` hinzufügen
+   - Team-Präferenzen und -Einschränkungen einschließen
+
+2. **In Anfragen explizit sein**
+   ```markdown
+   @api-designer Endpunkt gemäß unseren RESTful-Konventionen entwerfen
+   (Siehe 00-project-context.md für unsere API-Standards)
+   ```
 
 ---
 
 ## Befehlsprobleme
 
 ### Befehl nicht gefunden
-1. Verzeichnis überprüfen: `ls .claude/commands/symfony/`
-2. Korrekten Namespace überprüfen
-3. Befehle auflisten: `/help`
 
-### Ausführungsfehler
-1. Voraussetzungen überprüfen
-2. Befehlsdatei überprüfen
-3. Erforderliche Parameter bereitstellen
+**Symptome:**
+- `/symfony:generate-crud` gibt „Unbekannter Befehl" zurück
+- Befehlsvorschläge erscheinen nicht
+
+**Lösungen:**
+
+1. **Befehlsverzeichnis prüfen**
+   ```bash
+   ls .claude/commands/symfony/
+   # Sollte generate-crud.md enthalten
+   ```
+
+2. **Namespace überprüfen**
+   ```bash
+   # Befehle haben das Format: /{namespace}:{befehl}
+   # Verfügbare Namespaces:
+   ls .claude/commands/
+   # common/, symfony/, flutter/, python/, react/, reactnative/, docker/
+   ```
+
+3. **Verfügbare Befehle auflisten**
+   ```bash
+   # In Claude Code eingeben:
+   /help
+   ```
+
+### Ausführungsfehler bei Befehlen
+
+**Symptome:**
+- Befehl startet, schlägt aber fehl
+- Unerwartete Ausgabe oder Fehler
+
+**Lösungen:**
+
+1. **Voraussetzungen prüfen**
+   - Manche Befehle benötigen bestimmte Werkzeuge
+   - Erforderliche Abhängigkeiten auf Vorhandensein prüfen
+
+2. **Befehlsdatei überprüfen**
+   ```bash
+   cat .claude/commands/symfony/generate-crud.md
+   # Verstehen, was der Befehl erwartet
+   ```
+
+3. **Erforderliche Parameter bereitstellen**
+   ```bash
+   # Statt
+   /symfony:generate-crud
+
+   # Verwenden
+   /symfony:generate-crud User --with-api --with-tests
+   ```
+
+### Befehlsausgabe ist falsch
+
+**Symptome:**
+- Generierter Code entspricht nicht dem Projektstil
+- Falsche Technologiemuster verwendet
+
+**Lösungen:**
+
+1. **Projektkontext aktualisieren**
+   ```bash
+   # .claude/rules/00-project-context.md bearbeiten
+   # Spezifische Muster und Konventionen hinzufügen
+   ```
+
+2. **Vorlagen anpassen**
+   ```bash
+   # Vorlagen in .claude/templates/ bearbeiten
+   # An den Projektstil anpassen
+   ```
 
 ---
 
 ## Konfigurationsprobleme
 
-### Ungültiges YAML
-```bash
-yq e '.' claude-projects.yaml  # Syntax validieren
-make config-validate CONFIG=claude-projects.yaml
-```
+### YAML-Konfiguration ungültig
 
-### Projekt nicht gefunden
-1. Namensschreibung überprüfen (Groß-/Kleinschreibung)
-2. Pfad zur Konfigurationsdatei überprüfen
+**Symptome:**
+- `make config-validate` schlägt fehl
+- Syntaxfehler in der Konfiguration
+
+**Lösungen:**
+
+1. **YAML-Syntax prüfen**
+   ```bash
+   # YAML validieren
+   yq e '.' claude-projects.yaml
+   ```
+
+2. **Häufige YAML-Fehler:**
+   ```yaml
+   # Falsch: inkonsistente Einrückung
+   projects:
+     - name: "project"
+       path: "/path"  # 2 Leerzeichen
+        technologies: ["symfony"]  # 3 Leerzeichen – FEHLER!
+
+   # Korrekt: konsistente Einrückung
+   projects:
+     - name: "project"
+       path: "/path"
+       technologies: ["symfony"]
+   ```
+
+3. **Mit Werkzeug validieren**
+   ```bash
+   make config-validate CONFIG=claude-projects.yaml
+   ```
+
+### Projekt in Konfiguration nicht gefunden
+
+**Symptome:**
+- „Projekt nicht gefunden" bei der Installation
+- Projekt wird nicht aufgelistet
+
+**Lösungen:**
+
+1. **Schreibweise des Projektnamens prüfen**
+   ```bash
+   # Projekte auflisten
+   make config-list CONFIG=claude-projects.yaml
+
+   # Namen beachten Groß-/Kleinschreibung
+   ```
+
+2. **Pfad zur Konfigurationsdatei überprüfen**
+   ```bash
+   # Standard sucht nach claude-projects.yaml im aktuellen Verzeichnis
+   # Explizit angeben:
+   make config-install CONFIG=/pfad/zur/config.yaml PROJECT=meinprojekt
+   ```
+
+### Konfiguration wird nicht angewendet
+
+**Symptome:**
+- Änderungen an der Konfiguration wirken sich nicht aus
+- Alte Einstellungen bleiben erhalten
+
+**Lösungen:**
+
+1. **Mit force neu installieren**
+   ```bash
+   make config-install CONFIG=claude-projects.yaml PROJECT=meinprojekt OPTIONS="--force"
+   ```
+
+2. **Konflikte prüfen**
+   ```bash
+   # Vorhandene Installation entfernen
+   rm -rf /pfad/zum/projekt/.claude
+
+   # Neu installieren
+   make config-install CONFIG=claude-projects.yaml PROJECT=meinprojekt
+   ```
 
 ---
 
 ## Werkzeugprobleme
 
 ### StatusLine wird nicht angezeigt
-```bash
-ls -la ~/.claude/statusline.sh  # Installation überprüfen
-echo '{"model":{"display_name":"Test"}}' | ~/.claude/statusline.sh  # Test
-```
+
+**Symptome:**
+- Statusleiste leer oder standardmäßig
+- Benutzerdefinierte Statusleiste wird nicht angezeigt
+
+**Lösungen:**
+
+1. **Überprüfen, ob Skript installiert ist**
+   ```bash
+   ls -la ~/.claude/statusline.sh
+   # Sollte vorhanden und ausführbar sein
+   ```
+
+2. **settings.json prüfen**
+   ```bash
+   cat ~/.claude/settings.json | jq '.statusLine'
+   # Sollte anzeigen:
+   # {
+   #   "type": "command",
+   #   "command": "~/.claude/statusline.sh"
+   # }
+   ```
+
+3. **Skript manuell testen**
+   ```bash
+   echo '{"model":{"display_name":"Test","id":"claude-opus"}}' | ~/.claude/statusline.sh
+   # Sollte formatierte Statusleiste ausgeben
+   ```
+
+4. **Auf jq prüfen**
+   ```bash
+   which jq
+   # Bei fehlendem jq installieren: brew install jq / apt install jq
+   ```
 
 ### MultiAccount-Profilprobleme
+
+**Symptome:**
+- Profilwechsel nicht möglich
+- Profil wird nicht erkannt
+
+**Lösungen:**
+
+1. **Profile auflisten**
+   ```bash
+   ./claude-accounts.sh list
+   ```
+
+2. **Profilverzeichnis prüfen**
+   ```bash
+   ls -la ~/.claude-profiles/
+   # Sollte Profilverzeichnisse enthalten
+   ```
+
+3. **Profil-Modus-Datei überprüfen**
+   ```bash
+   cat ~/.claude-profiles/meinprofil/.mode
+   # Sollte "shared" oder "isolated" enthalten
+   ```
+
+4. **Problematisches Profil neu erstellen**
+   ```bash
+   ./claude-accounts.sh remove meinprofil
+   ./claude-accounts.sh add meinprofil --mode=shared
+   ```
+
+### ProjectConfig-yq-Fehler
+
+**Symptome:**
+- „yq: Befehl nicht gefunden"
+- YAML-Parsing-Fehler
+
+**Lösungen:**
+
+1. **yq installieren**
+   ```bash
+   # macOS
+   brew install yq
+
+   # Linux
+   sudo snap install yq
+   # oder
+   sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+   sudo chmod +x /usr/local/bin/yq
+   ```
+
+2. **yq-Version überprüfen**
+   ```bash
+   yq --version
+   # Sollte v4.x sein (mikefarah/yq, nicht kislyuk/yq)
+   ```
+
+---
+
+## Hook-Probleme
+
+### Hook wird nicht ausgelöst
+
+**Symptome:**
+- PreToolUse/PostToolUse-Hooks werden nicht ausgeführt
+- Keine Ausgabe von Hook-Befehlen
+
+**Lösungen:**
+
+1. **Hook-Konfiguration in settings.json überprüfen**
+   ```bash
+   cat .claude/settings.json | jq '.hooks'
+   ```
+
+2. **Matcher-Syntax prüfen**
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [{
+         "matcher": "Bash",
+         "hooks": [{"type": "command", "command": "echo test"}]
+       }]
+     }
+   }
+   ```
+   Der `matcher` muss exakt mit dem Werkzeugnamen übereinstimmen (z. B. `Bash`, `Edit`, `Write`).
+
+3. **Hook-Befehl unabhängig testen**
+   ```bash
+   # Den Hook-Befehl manuell ausführen, um zu prüfen, ob er funktioniert
+   bash -c 'echo test'
+   ```
+
+### PreCompact-Hook blockiert
+
+**Symptome:**
+- Kontextkomprimierung findet nicht wie erwartet statt
+- Komprimierung scheint blockiert
+
+**Lösung:** PreCompact-Hooks (v2.1.105+) können die Komprimierung mit Exit-Code 2 blockieren. Die eigenen Hooks prüfen:
 ```bash
-./claude-accounts.sh list
-ls -la ~/.claude-profiles/
+cat .claude/settings.json | jq '.hooks.PreCompact'
+# Sicherstellen, dass Hook-Skripte nicht versehentlich Exit-Code 2 zurückgeben
 ```
 
-### yq-Fehler
-```bash
-# yq v4.x installieren (mikefarah/yq)
-brew install yq  # macOS
-sudo snap install yq  # Linux
-yq --version  # Version überprüfen
-```
+### Sandbox-Fehler
+
+**Symptome:**
+- Fehler „Sandbox nicht verfügbar"
+- Berechtigungsprobleme bei Unterprozessen
+
+**Lösungen:**
+
+1. **Claude Code-Version prüfen** (Sandboxing erfordert v2.1.98+)
+   ```bash
+   claude --version
+   ```
+
+2. **Unter Linux PID-Namespace-Unterstützung prüfen**
+   ```bash
+   # Prüfen, ob unshare verfügbar ist
+   which unshare
+   ```
+
+3. **Strenge Sandbox bei Bedarf deaktivieren** (aus Sicherheitsgründen nicht empfohlen)
+   - `sandbox.failIfUnavailable` aus den Einstellungen entfernen, falls es hinzugefügt wurde
+
+### Sicherheitsbezogene Hook-Fehler
+
+Bei Verwendung von MCP-Servern mit Hooks sicherstellen, dass Claude Code v2.1.97+ verwendet wird, um bekannte CVEs zu vermeiden:
+- CVE-2025-59536: Command-Injection über MCP-Eingaben in der Hook-Pipeline
+- CVE-2026-35020: Bypass durch zusammengesetzte Befehle
+- CVE-2026-35022: Umgebungsvariablen-Präfix-Injektion
 
 ---
 
 ## Leistungsprobleme
 
-### Langsame Ausführung
-1. Cache-TTL in `statusline.conf` anpassen
-2. Caches leeren: `rm /tmp/.ccusage_*`
-3. Netzwerkverbindung überprüfen
+### Langsame Befehlsausführung
 
-### Hohe Kontextnutzung
-1. `/compact` verwenden, um den Kontext proaktiv zu komprimieren
-2. `/clear` zwischen nicht zusammenhängenden Aufgaben verwenden
-3. `/effort low` für einfache Aufgaben verwenden (reduziert Token-Verbrauch)
-4. `/context` für Optimierungsvorschläge verwenden
-5. RTK für 60-90% Token-Einsparung konfigurieren (`/common:setup-rtk`)
-6. Untersuchungen an Sub-Agenten delegieren
+**Symptome:**
+- Befehle brauchen lange zum Antworten
+- StatusLine wird langsam aktualisiert
+
+**Lösungen:**
+
+1. **Cache-Einstellungen prüfen**
+   ```bash
+   # In ~/.claude/statusline.conf
+   SESSION_CACHE_TTL=60   # Reduzieren, wenn zu langsam
+   WEEKLY_CACHE_TTL=300   # Reduzieren, wenn zu langsam
+   ```
+
+2. **Caches leeren**
+   ```bash
+   rm /tmp/.ccusage_*
+   ```
+
+3. **Netzwerk prüfen**
+   - Manche Funktionen benötigen Netzwerkzugang (ccusage)
+   - Langsames Netzwerk = langsame Aktualisierungen
+
+### Hohe Kontextfensterauslastung
+
+**Symptome:**
+- Kontextanzeige zeigt schnell hohen Prozentsatz
+- Warnungen „Kontextlimit erreicht"
+
+**Lösungen:**
+
+1. **`/context` für Optimierungsvorschläge verwenden** (v2.1.74+)
+   ```bash
+   /context
+   ```
+
+2. **Aufwandsniveau für einfache Aufgaben anpassen** (v2.1.72+)
+   ```bash
+   /effort low    # Einfache Suchen
+   /effort medium # Standardarbeit
+   ```
+
+3. **Proaktiv bei ca. 70 % Auslastung komprimieren**
+   ```bash
+   /compact
+   ```
+
+4. **`/clear` zwischen nicht zusammenhängenden Aufgaben verwenden**
+
+5. **Wichtige Erkenntnisse vor der Komprimierung speichern**
+   ```bash
+   /memory "Wichtig: Auth verwendet JWT RS256 mit 15 Min. Ablaufzeit"
+   ```
+
+6. **RTK für 55–65 % Token-Einsparung einrichten**
+   ```bash
+   /common:setup-rtk
+   ```
+
+7. **Agenten für komplexe Aufgaben verwenden**
+   ```markdown
+   # Statt die gesamte Codebasis einzufügen
+   @research-assistant Alle authentifizierungsbezogenen Dateien in src/ finden
+   ```
 
 ---
 
 ## Hilfe erhalten
 
-### Dokumentation
-- `docs/AGENTS.md` - Agenten-Referenz
-- `docs/COMMANDS.md` - Befehls-Referenz
-- `docs/TECHNOLOGIES.md` - Technologie-Leitfaden
+### Dokumentation prüfen
 
-### Versionen
+1. **Haupt-Docs**: Verzeichnis `docs/`
+2. **Agenten-Referenz**: `docs/AGENTS.md`
+3. **Befehls-Referenz**: `docs/COMMANDS.md`
+4. **Technologie-Leitfaden**: `docs/TECHNOLOGIES.md`
+
+### Versionsinformationen abrufen
+
 ```bash
+# Installationsskripte
 ./Dev/scripts/install-symfony-rules.sh --version
+
+# Werkzeuge
 ./Tools/MultiAccount/claude-accounts.sh --version
+./Tools/ProjectConfig/claude-projects.sh --version
+```
+
+### Fehler melden
+
+Bei Auftreten von Bugs:
+
+1. Informationen sammeln:
+   - Claude-Craft-Version
+   - Betriebssystem
+   - Reproduktionsschritte
+   - Fehlermeldungen
+
+2. Vorhandene Issues auf GitHub prüfen
+
+3. Neues Issue mit Details erstellen
+
+### Um Hilfe bitten
+
+```markdown
+@research-assistant Ich habe Probleme mit [Problem beschreiben]
+
+Umgebung:
+- Betriebssystem: [Ihr OS]
+- Claude-Craft-Version: [Version]
+- Technologie: [symfony/flutter/etc.]
+
+Was ich versucht habe:
+1. [Schritt 1]
+2. [Schritt 2]
+
+Fehlermeldung:
+[Fehler einfügen]
 ```
 
 ---
 
 ## Schnellkorrekturen-Checkliste
 
+Wenn etwas nicht funktioniert:
+
 - [ ] Claude Code neu starten
 - [ ] Installation überprüfen (`ls .claude/`)
-- [ ] Dateiberechtigungen überprüfen
+- [ ] Dateiberechtigungen prüfen
 - [ ] Konfiguration validieren
 - [ ] Caches leeren
-- [ ] Abhängigkeiten überprüfen (jq, yq)
+- [ ] Abhängigkeiten prüfen (jq, yq)
 - [ ] Neuinstallation mit `--force` versuchen
+- [ ] Dokumentation prüfen
+- [ ] Um Hilfe bitten
 
 ---
 
-[&larr; Werkzeuge-Referenz](05-tools-reference.md) | [Backlog-Management &rarr;](07-backlog-management.md)
+[&larr; Werkzeug-Referenz](05-tools-reference.md) | [Backlog-Management &rarr;](07-backlog-management.md)

--- a/docs/guides/de/07-backlog-management.md
+++ b/docs/guides/de/07-backlog-management.md
@@ -1,24 +1,35 @@
-# Backlog-Management Leitfaden
+# Backlog-Management-Leitfaden
 
-Vollstandiger Workflow zur Erstellung und Verwaltung eines SCRUM-Backlogs mit Claude-Craft.
+Vollständiger Workflow zur Erstellung und Verwaltung eines SCRUM-Backlogs mit Claude-Craft.
 
 ---
 
-## Ubersicht
+## Überblick
 
-Claude-Craft bietet einen umfassenden Satz von Befehlen zur Verwaltung Ihres Product Backlogs nach SCRUM-Methodik:
+Claude-Craft bietet einen umfassenden Satz von Befehlen zur Verwaltung Ihres Product Backlogs nach der SCRUM-Methodik:
 
-- **15 Slash-Befehle** fur Backlog-Operationen
-- **5 Vorlagen** fur konsistente Struktur
-- **Vertical Slicing** uber alle Schichten erforderlich
-- **INVEST-Validierung** fur User Stories
+- **15 Slash-Befehle** für Backlog-Operationen
+- **5 Vorlagen** für eine konsistente Struktur
+- **Vertical Slicing** über alle Technologieschichten hinweg
+- **INVEST-Modell**-Validierung für User Stories
+
+### Philosophie
+
+Basiert auf:
+- den Prinzipien des Agile Manifesto
+- den 12 Agilen Prinzipien
+- den Grundlagen von SCRUM
+- Vertical Slicing (jede US berührt alle Schichten)
 
 ---
 
 ## Initiale Backlog-Generierung
 
+### Aus Spezifikationen
+
+Legen Sie Ihre Projektspezifikationen in `./docs/` ab und führen Sie dann aus:
+
 ```bash
-# Aus Spezifikationen in ./docs/
 /project:generate-backlog symfony+flutter
 ```
 
@@ -26,67 +37,121 @@ Claude-Craft bietet einen umfassenden Satz von Befehlen zur Verwaltung Ihres Pro
 
 ```
 project-management/
-├── README.md                    # Projektuberblick
-├── personas.md                  # Personas (min. 3)
+├── README.md                    # Projektübersicht
+├── personas.md                  # Benutzer-Personas (min. 3)
 ├── definition-of-done.md        # Progressive DoD-Stufen
+├── dependencies-matrix.md       # Epic- und US-Abhängigkeiten
 ├── backlog/
-│   ├── epics/                   # EPIC-XXX-name.md
-│   └── user-stories/            # US-XXX-name.md
+│   ├── epics/                   # EPIC-XXX-name.md Dateien
+│   └── user-stories/            # US-XXX-name.md Dateien
 └── sprints/
-    └── sprint-XXX-ziel/
+    └── sprint-XXX-goal/         # Sprint-Pläne
 ```
 
 ---
 
 ## SCRUM-Struktur
 
-### Personas (mindestens 3)
-- Identitat, Ziele, Frustrationen
-- Format: P-001, P-002...
+### Personas
+
+Mindestens 3 Personas erforderlich, jede mit:
+- **Identität**: Name, Rolle, demografische Daten
+- **Ziele**: Was sie erreichen möchten
+- **Frustrationen**: Schmerzpunkte, die gelöst werden sollen
+
+Format: `P-001`, `P-002`, `P-003`…
 
 ### EPICs
-- Eindeutige ID (EPIC-XXX)
-- MMF (Minimum Marketable Feature)
-- Geschaftsziele und Erfolgskriterien
 
-### User Stories (INVEST-Modell)
+Große Features, die mehrere User Stories enthalten:
 
-| Buchstabe | Bedeutung |
-|-----------|-----------|
-| **I** | Independent - Keine Abhangigkeiten |
-| **N** | Negotiable - Details verhandelbar |
-| **V** | Valuable - Nutzerwert |
-| **E** | Estimable - Schatzbar |
-| **S** | Sized - Max 8 Punkte |
-| **T** | Testable - Klare Kriterien |
+| Feld | Beschreibung |
+|------|--------------|
+| ID | Eindeutiger Bezeichner (EPIC-001, EPIC-002…) |
+| MMF | Minimum Marketable Feature |
+| Status | Entwurf, Bereit, In Bearbeitung, Erledigt |
+| Geschäftsziele | Warum dieses EPIC wichtig ist |
+| Erfolgskriterien | Wie der Erfolg gemessen wird |
+
+### User Stories
+
+Dem **INVEST**-Modell folgen:
+
+| Buchstabe | Bedeutung | Validierung |
+|-----------|-----------|-------------|
+| **I** | Independent (Unabhängig) | Keine Abhängigkeiten von anderen US |
+| **N** | Negotiable (Verhandelbar) | Details können besprochen werden |
+| **V** | Valuable (Wertvoll) | Liefert Nutzwert für den Benutzer |
+| **E** | Estimable (Schätzbar) | Kann in Story-Punkten bewertet werden |
+| **S** | Sized (Bemessen) | Max. 8 Story-Punkte |
+| **T** | Testable (Testbar) | Hat klare Akzeptanzkriterien |
+
+#### Die 3 Cs
+
+1. **Card**: Kurze Beschreibung
+2. **Conversation**: Diskussionsdetails
+3. **Confirmation**: Akzeptanzkriterien
 
 #### Akzeptanzkriterien (Gherkin)
-- 1 Nominal-Szenario
-- 2 Alternative Szenarien
+
+Jede US erfordert:
+- 1 Nominalszenario (Happy Path)
+- 2 alternative Szenarien
 - 2 Fehlerszenarien
+
+```gherkin
+Scenario: User logs in successfully
+  Given a registered user with valid credentials
+  When they submit the login form
+  Then they should see their dashboard
+  And a session should be created
+```
 
 ### Tasks (Aufgaben)
 
-| Typ | Beschreibung |
-|-----|--------------|
-| `[DB]` | Datenbank |
-| `[BE]` | Backend |
-| `[FE-WEB]` | Frontend Web |
-| `[FE-MOB]` | Frontend Mobile |
-| `[TEST]` | Testing |
-| `[DOC]` | Dokumentation |
-| `[OPS]` | DevOps |
-| `[REV]` | Code Review |
+Technische Arbeitselemente innerhalb einer User Story:
+
+| Typ | Beschreibung | Typische Dauer |
+|-----|-------------|----------------|
+| `[DB]` | Datenbank (Entitäten, Migrationen) | 1–3 h |
+| `[BE]` | Backend (Services, APIs) | 2–4 h |
+| `[FE-WEB]` | Frontend Web (Controller, Templates) | 2–4 h |
+| `[FE-MOB]` | Frontend Mobile (Screens, Blocs) | 3–5 h |
+| `[TEST]` | Testing (Unit, Integration, E2E) | 2–4 h |
+| `[DOC]` | Dokumentation | 0,5–1 h |
+| `[OPS]` | DevOps (CI/CD, Deployment) | 1–2 h |
+| `[REV]` | Code Review | 1–2 h |
+
+**Schätzregeln:**
+- Aufgabendauer: 0,5 h – 8 h max.
+- Story-Punkte (Fibonacci): 1, 2, 3, 5, 8, 13, 21
+- Max. US-Größe: 8 Punkte (bei größeren aufteilen)
 
 ---
 
 ## Workflow
 
+### Status-Ablauf
+
 ```
-To Do ──→ In Progress ──→ Done
-   │            │
-   └────→ Blocked ←────┘
+┌─────────┐     ┌─────────────┐     ┌──────┐
+│  To Do  │ ──→ │ In Progress │ ──→ │ Done │
+└─────────┘     └─────────────┘     └──────┘
+     │                │
+     │                ↓
+     └────────→ ┌─────────┐
+                │ Blocked │
+                └─────────┘
+                     │
+                     ↓
+              ┌─────────────┐
+              │ In Progress │
+              └─────────────┘
 ```
+
+**Verbotene Übergänge:**
+- To Do → Done (muss durch In Progress laufen)
+- Beliebig → To Do (außer manuellem Wiedereröffnen)
 
 ---
 
@@ -96,105 +161,175 @@ To Do ──→ In Progress ──→ Done
 
 | Befehl | Beschreibung |
 |--------|--------------|
-| `/project:generate-backlog [stack]` | Backlog aus Specs generieren |
+| `/project:generate-backlog [stack]` | Vollständiges Backlog aus Specs generieren |
 | `/project:add-epic` | Neues EPIC erstellen |
-| `/project:add-story` | User Story hinzufugen |
-| `/project:add-task` | Technische Aufgabe erstellen |
+| `/project:add-story` | User Story zu einem EPIC hinzufügen |
+| `/project:add-task` | Technische Aufgabe für eine US erstellen |
 
-### Anzeige-Befehle
+### Anzeigebefehle
 
 | Befehl | Beschreibung |
 |--------|--------------|
-| `/project:list-epics` | EPICs auflisten |
-| `/project:list-stories` | User Stories auflisten |
-| `/project:list-tasks` | Aufgaben auflisten |
-| `/project:board` | Kanban-Board |
-| `/sprint:status` | Sprint-Status |
+| `/project:list-epics` | Alle EPICs mit Status anzeigen |
+| `/project:list-stories [filter]` | User Stories auflisten (nach EPIC, Sprint, Status) |
+| `/project:list-tasks [filter]` | Aufgaben auflisten (nach US, Sprint, Typ, Status) |
+| `/project:board [sprint]` | Kanban-Board anzeigen |
+| `/sprint:status [sprint]` | Detaillierter Sprint-Fortschrittsbericht |
 
 ### Aktualisierungsbefehle
 
 | Befehl | Beschreibung |
 |--------|--------------|
-| `/sprint:transition` | US-Status/Sprint andern |
-| `/project:move-task` | Aufgabenstatus andern |
-| `/project:update-epic` | EPIC bearbeiten |
-| `/project:update-story` | User Story bearbeiten |
+| `/sprint:transition [id] [status/sprint]` | US-Status ändern oder Sprint zuweisen |
+| `/project:move-task [id] [status]` | Aufgabenstatus ändern |
+| `/project:update-epic [id]` | Bestehendes EPIC bearbeiten |
+| `/project:update-story [id]` | Bestehende User Story bearbeiten |
 
 ### Erweiterte Befehle
 
 | Befehl | Beschreibung |
 |--------|--------------|
-| `/project:decompose-tasks` | US in Aufgaben zerlegen |
-| `/gate:validate-backlog` | SCRUM-Qualitat prufen |
+| `/project:decompose-tasks [sprint]` | Sprint-US in Aufgaben zerlegen |
+| `/gate:validate-backlog` | Backlog-Qualität prüfen (SCRUM-Konformität) |
 
 ---
 
-## Vollstandiges Beispiel
+## Vollständiges Beispiel: Neues Projekt
 
-```markdown
-## Schritt 1: Initiales Backlog generieren
+### Schritt 1: Initiales Backlog generieren
+
+```bash
+# Sicherstellen, dass Specs in ./docs/ vorhanden sind
 /project:generate-backlog symfony+flutter
-
-## Schritt 2: Qualitat validieren
-/gate:validate-backlog
-
-## Schritt 3: Sprint 1 anzeigen
-/project:board 1
-
-## Schritt 4: In Aufgaben zerlegen
-/project:decompose-tasks 1
-
-## Schritt 5: Arbeit beginnen
-/project:move-task TASK-001 in-progress
 ```
 
+### Schritt 2: Qualität validieren
+
+```bash
+/gate:validate-backlog
+```
+
+Dies generiert `scrum-validation-report.md` mit:
+- INVEST-Konformitätspunktzahl
+- Prüfung der 3 Cs
+- SMART-Kriterienanalyse
+- Konsistenz der Schätzungen
+
+### Schritt 3: Sprint 1 überprüfen
+
+```bash
+/project:board 1
+```
+
+Zeigt Kanban-Board mit Spalten:
+- To Do | In Progress | In Review | Done | Blocked
+
+### Schritt 4: In Aufgaben zerlegen
+
+```bash
+/project:decompose-tasks 1
+```
+
+Erstellt detaillierte Aufgabenaufschlüsselung:
+- Aufgaben gruppiert nach US
+- Abhängigkeitsgraph (Mermaid)
+- Zeitschätzungen pro Schicht
+
+### Schritt 5: Mit der Arbeit beginnen
+
+```bash
+# Erste Aufgabe in Bearbeitung setzen
+/project:move-task TASK-001 in-progress
+
+# Später als erledigt markieren
+/project:move-task TASK-001 done
+
+# Bei Blockierung
+/project:move-task TASK-002 blocked "Waiting for API specs"
+```
+
+### Schritt 6: Fortschritt verfolgen
+
+```bash
+/sprint:status 1
+```
+
+### Schritt 7: Wiederkehrendes Monitoring einrichten (Optional)
+
+Mit `/loop` (v2.1.71+) den Sprint-Fortschritt automatisch überwachen:
+
+```bash
+# Sprint-Status alle 30 Minuten prüfen
+/loop 30m /sprint:status 1
+
+# Pre-Commit-Checks alle 5 Minuten während der Entwicklung
+/loop 5m /common:pre-commit-check
+```
+
+Alias: `/proactive` (v2.1.105+).
+
+Zeigt:
+- Gesamtfortschritt und Burndown
+- Metriken nach User Story
+- Blocker und Risiken
+- Empfohlene Maßnahmen
+
 ---
 
-## Verfugbare Vorlagen
+## Vorlagen
+
+Claude-Craft bietet 5 Vorlagen für eine konsistente Backlog-Struktur:
 
 | Vorlage | Zweck |
 |---------|-------|
-| `epic.md` | EPIC-Struktur |
-| `user-story.md` | User Story-Struktur |
-| `task.md` | Aufgabenstruktur |
-| `board.md` | Kanban-Board |
-| `index.md` | Backlog-Index |
+| `epic.md` | EPIC-Dateistruktur mit Metadaten, Zielen, US-Liste |
+| `user-story.md` | US-Struktur mit Gherkin-Kriterien, Aufgabentabelle |
+| `task.md` | Aufgabenstruktur mit DoD-Checkliste |
+| `board.md` | Kanban-Board mit Metrikberechnung |
+| `index.md` | Backlog-Index mit globalem Überblick |
 
 ---
 
-## SCRUM-Regeln
+## Durchgesetzte SCRUM-Regeln
 
 | Regel | Wert |
 |-------|------|
-| Sprint-Dauer | 2 Wochen |
-| Velocity | 20-40 Punkte/Sprint |
-| Max US | 8 Punkte |
-| Schatzung | Fibonacci (1,2,3,5,8,13,21) |
-| Aufgabendauer | 0.5h - 8h max |
+| Sprint-Dauer | 2 Wochen (fest) |
+| Velocity | 20–40 Punkte/Sprint |
+| Max. US-Größe | 8 Punkte (bei größeren aufteilen) |
+| Schätzskala | Fibonacci (1, 2, 3, 5, 8, 13, 21) |
+| Aufgabendauer | 0,5 h – 8 h max. |
 
-### Sprint 1 = Walking Skeleton
-- Vollstandige Infrastruktur
-- 1 End-to-End Feature
-- Testbar auf Web und Mobile
+### Sprint 1: Walking Skeleton
+
+Der erste Sprint muss enthalten:
+- Vollständige Infrastruktureinrichtung
+- 1 End-to-End-Feature (nicht nur Setup)
+- Testbar sowohl auf Web als auch auf Mobile
 
 ### Vertical Slicing
-Jede US muss alle Schichten durchlaufen:
+
+**Jede User Story MUSS alle Schichten durchlaufen:**
+
 ```
-UI → API → Geschaftslogik → Datenbank
+UI (Web/Mobile) → API → Business Logic → Database
 ```
+
+User Stories, die nur Backend, nur Frontend oder nur Mobile abdecken, sind nicht erlaubt.
 
 ---
 
-## Checkliste
+## Checkliste: Backlog bereit
 
 - [ ] Mindestens 3 Personas definiert
-- [ ] EPICs mit MMF und Erfolgskriterien
-- [ ] User Stories folgen INVEST
-- [ ] Kriterien im Gherkin-Format
-- [ ] Fibonacci-Schatzung
+- [ ] EPICs haben MMF und Erfolgskriterien
+- [ ] User Stories folgen dem INVEST-Modell
+- [ ] Akzeptanzkriterien im Gherkin-Format
+- [ ] Stories in Fibonacci-Punkten geschätzt
 - [ ] Sprint 1 = Walking Skeleton
-- [ ] Backlog validiert
+- [ ] Definition of Done dokumentiert
+- [ ] Backlog validiert (`/gate:validate-backlog`)
 
 ---
 
-[&larr; Fehlerbehebung](06-troubleshooting.md) | [Nachste: Neues Projekt Einrichten &rarr;](08-setup-new-project.md)
+[&larr; Fehlerbehebung](06-troubleshooting.md) | [Weiter: Neues Projekt einrichten &rarr;](08-setup-new-project.md)

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -17,7 +17,7 @@ Dieser Leitfaden führt Sie durch den vollständigen Entwicklungslebenszyklus:
 7. **Deployment** – In die Produktion deployen
 
 **Voraussetzungen:**
-- Claude Craft v8.8.1 in Ihrem Projekt installiert
+- Claude Craft v8.8.2 in Ihrem Projekt installiert
 - Claude Code v2.1.159 (empfohlen) oder v2.1.97+ (Minimum, CVE-2025-59536 gepatcht)
 - Grundlegendes Verständnis Ihres gewählten Technologie-Stacks
 

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -1,24 +1,41 @@
-# Vollständiger Workflow-Leitfaden: Von der Idee zur Produktion
+# Vollständiger Workflow-Leitfaden: Von der Idee bis zur Produktion
 
-Umfassende Schritt-für-Schritt-Anleitung zum Aufbau einer kompletten Anwendung mit Claude Craft, von der ersten Idee bis zum Produktions-Deployment.
+Ein umfassender Schritt-für-Schritt-Leitfaden zur Entwicklung einer vollständigen Anwendung mit Claude Craft, von der ersten Idee bis zum Produktions-Deployment.
 
 ---
 
 ## Überblick
 
-Dieser Leitfaden führt Sie durch den kompletten Entwicklungszyklus:
+Dieser Leitfaden führt Sie durch den vollständigen Entwicklungslebenszyklus:
 
-1. **Ideation** - Definieren Sie Ihre Produktvision
-2. **Anforderungen** - Dokumentieren Sie, was Sie bauen
-3. **Architektur** - Entwerfen Sie die technische Lösung
-4. **Planung** - Erstellen Sie umsetzbare Sprints
-5. **Entwicklung** - Implementieren Sie mit TDD
-6. **Qualität** - Validieren und testen
-7. **Deployment** - In Produktion liefern
+1. **Ideenfindung** – Produktvision definieren
+2. **Anforderungen** – Dokumentieren, was gebaut werden soll
+3. **Architektur** – Technische Lösung entwerfen
+4. **Planung** – Umsetzbare Sprints erstellen
+5. **Entwicklung** – Mit TDD implementieren
+6. **Qualität** – Validieren und testen
+7. **Deployment** – In die Produktion deployen
+
+**Voraussetzungen:**
+- Claude Craft v8.8.1 in Ihrem Projekt installiert
+- Claude Code v2.1.159 (empfohlen) oder v2.1.97+ (Minimum, CVE-2025-59536 gepatcht)
+- Grundlegendes Verständnis Ihres gewählten Technologie-Stacks
 
 ---
 
-## Phase 1: Ideation (5-10 Minuten)
+## Phase 1: Ideenfindung (5–10 Minuten)
+
+### Session einrichten
+
+Konfigurieren Sie vor dem Einstieg Ihre Session für optimale Performance:
+
+```bash
+# Denkanstrengung für die Planung anpassen (hoch für komplexe Aufgaben)
+/effort high
+
+# Optional: Token-Optimierung einrichten
+/common:setup-rtk
+```
 
 ### Mit BMAD starten
 
@@ -30,122 +47,465 @@ Dieser Leitfaden führt Sie durch den kompletten Entwicklungszyklus:
 /workflow:init
 ```
 
-### Vision definieren
+### Die Vision definieren
+
+Mit dem Product-Manager-Agenten arbeiten:
 
 ```
-@pm Ich möchte eine E-Commerce-Plattform für handwerkliche Produkte aufbauen.
-Hauptfunktionen:
-- Produktkatalog mit Kategorien
-- Warenkorb und Checkout
-- Benutzerauthentifizierung
-- Bestellverwaltung
+@pm I want to build an e-commerce platform for selling artisanal products.
+Key features:
+- Product catalog with categories
+- Shopping cart and checkout
+- User authentication
+- Order management
 ```
+
+Der PM hilft Ihnen dabei:
+- Das zu lösende Problem zu klären
+- Zielnutzer zu identifizieren
+- Erfolgskennzahlen zu definieren
+
+### Erstes Visionsdokument erstellen
+
+```
+@pm Create a vision document for this project
+```
+
+Ausgabe: `docs/vision.md`
 
 ---
 
-## Phase 2: Anforderungen (15-30 Minuten)
+## Phase 2: Anforderungen (15–30 Minuten)
+
+### Anforderungen analysieren
+
+Mit dem Business Analyst arbeiten:
+
+```
+@ba Analyze requirements for the e-commerce platform based on the vision
+```
+
+Der BA wird:
+- Features in User Stories aufschlüsseln
+- Abhängigkeiten identifizieren
+- Eine User-Story-Map erstellen
 
 ### PRD erstellen
 
 ```
-@pm Erstelle ein Product Requirements Document
+@pm Create a Product Requirements Document
+```
+
+### PRD validieren
+
+```
 /gate:validate-prd docs/prd.md
 ```
 
+Stellen Sie sicher, dass Sie das PRD-Gate (≥80 %) bestehen:
+- [ ] Problem-Statement definiert
+- [ ] Zielnutzer identifiziert
+- [ ] Ziele klar formuliert
+- [ ] Erfolgskennzahlen definiert
+- [ ] Scope-Grenzen festgelegt
+
 ---
 
-## Phase 3: Architektur (20-45 Minuten)
+## Phase 3: Architektur (20–45 Minuten)
 
 ### Architektur entwerfen
 
+Mit dem Architekten arbeiten:
+
 ```
-@architect Entwerfe die Systemarchitektur für die E-Commerce-Plattform
+@architect Design the system architecture for the e-commerce platform
+Consider:
+- Symfony backend with API Platform
+- PostgreSQL database
+- Redis caching
+- Docker deployment
 ```
 
-### Technische Spezifikation validieren
+Der Architekt wird erstellen:
+- Systemarchitekturdiagramm
+- Komponentendesign
+- Datenmodell
+- API-Verträge
+
+### Technische Spezifikation erstellen
+
+```
+@architect Create technical specification from the PRD
+```
+
+Ausgabe: `docs/tech-spec.md`
+
+### Entscheidungen dokumentieren
+
+Für wichtige Entscheidungen:
+
+```
+@architect Create an ADR for choosing JWT over session-based auth
+```
+
+Ausgabe: `docs/adr/001-jwt-authentication.md`
+
+### Tech-Spec validieren
 
 ```
 /gate:validate-techspec docs/tech-spec.md
 ```
 
+Stellen Sie sicher, dass Sie das Tech-Spec-Gate (≥90 %) bestehen:
+- [ ] Architektur dokumentiert
+- [ ] API-Verträge definiert
+- [ ] Sicherheit berücksichtigt
+- [ ] Performance-Anforderungen festgelegt
+- [ ] Teststrategie definiert
+- [ ] Deployment-Plan erstellt
+
 ---
 
-## Phase 4: Planung (15-30 Minuten)
+## Phase 4: Planung (15–30 Minuten)
 
 ### Backlog erstellen
 
+Mit dem Product Owner arbeiten:
+
 ```
-@po Erstelle User Stories aus der technischen Spezifikation
-@sm Plane Sprint 1
+@po Create user stories from the technical specification
+Prioritize using MoSCoW method
+```
+
+Der PO erstellt Stories wie:
+```
+EPIC-001: User Authentication
+├── US-001: User registration
+├── US-002: User login
+├── US-003: Password reset
+└── US-004: Social login
+
+EPIC-002: Product Catalog
+├── US-005: Browse products
+├── US-006: Product search
+├── US-007: Category filtering
+└── US-008: Product details
+```
+
+### Backlog validieren
+
+```
+/gate:validate-backlog
+```
+
+Jede Story muss INVEST bestehen:
+- **I**ndependent (Unabhängig)
+- **N**egotiable (Verhandelbar)
+- **V**aluable (Wertvoll)
+- **E**stimable (Schätzbar)
+- **S**mall (Klein)
+- **T**estable (Testbar)
+
+### Ersten Sprint planen
+
+Mit dem Scrum Master arbeiten:
+
+```
+@sm Plan sprint 1 with the highest priority stories
+Include:
+- US-001: User registration
+- US-002: User login
+- US-005: Browse products
+```
+
+### Sprint validieren
+
+```
 /gate:validate-sprint
 ```
 
 ---
 
-## Phase 5: Entwicklung
+## Phase 5: Entwicklung (variabel)
 
-### TDD-Zyklus
+### Sprint-Entwicklung starten
 
-```bash
-# Nächste Story holen
+```
+/sprint:dev 1
+```
+
+Oder Story für Story vorgehen:
+
+### 5.1 Nächste Story holen
+
+```
 /sprint:next-story --claim
+```
 
-# Mit TDD implementieren
-@dev Implementiere US-001 mit TDD
+Beispiel: US-001 (Benutzerregistrierung)
 
-# 🔴 Rot - Fehlschlagenden Test schreiben
-# 🟢 Grün - Implementieren
-# 🔵 Refactoring
+### 5.2 In Bearbeitung übertragen
 
-# Validieren
+```
+/sprint:transition US-001 in-progress
+```
+
+### 5.3 TDD Red-Phase (fehlschlagende Tests schreiben)
+
+Mit dem Developer-Agenten arbeiten:
+
+```
+@dev Start TDD for US-001 (User Registration)
+Begin with 🔴 Red phase - write failing tests
+```
+
+Zuerst Tests erstellen:
+```php
+// tests/Feature/UserRegistrationTest.php
+class UserRegistrationTest extends TestCase
+{
+    public function test_user_can_register_with_valid_data(): void
+    {
+        $response = $this->post('/api/register', [
+            'email' => 'test@example.com',
+            'password' => 'SecurePass123!',
+            'name' => 'Test User'
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
+    }
+}
+```
+
+### 5.4 TDD Green-Phase (Implementieren)
+
+```
+@dev Now implement 🟢 Green phase - make tests pass
+```
+
+Code generieren:
+```
+/symfony:generate-crud User
+```
+
+### 5.5 TDD Refactor-Phase
+
+```
+@dev 🔵 Refactor - clean up the implementation
+```
+
+### 5.6 Code Review
+
+```
+@symfony-reviewer Review the user registration implementation
+```
+
+### 5.7 Story-DoD validieren
+
+```
 /gate:validate-story US-001
+```
+
+### 5.8 Zum Review übertragen
+
+```
+/sprint:transition US-001 review
+```
+
+### 5.9 QA-Validierung
+
+```
+@qa Validate acceptance criteria for US-001
+```
+
+### 5.10 Story abschließen
+
+```
 /sprint:transition US-001 done
 ```
 
+### 5.11 Wiederholen
+
+Mit der nächsten Story fortfahren, bis der Sprint abgeschlossen ist.
+
 ---
 
-## Phase 6: Qualität
+## Phase 6: Qualität (fortlaufend)
+
+### Kontextverwaltung
+
+Verwalten Sie während der Entwicklung Ihr Kontextfenster effizient:
 
 ```bash
+# Optimierungsvorschläge für den Kontext prüfen
+/context
+
+# Für einfache Aufgaben auf niedrigeren Aufwand wechseln
+/effort low
+
+# Kontext zwischen nicht zusammenhängenden Aufgaben löschen
+/clear
+
+# Wichtige Erkenntnisse sitzungsübergreifend speichern
+/memory "Key architectural decision: using CQRS for order module"
+```
+
+### Kontinuierliche Qualitätsprüfungen
+
+Regelmäßig während der Entwicklung ausführen:
+
+```bash
+# Wiederkehrende Qualitätsüberwachung einrichten
+/loop 5m /common:pre-commit-check
+
+# Architekturprüfung
 /symfony:check-architecture
+
+# Codequalität
+/symfony:check-code-quality
+
+# Sicherheits-Audit
+/symfony:check-security
+
+# Testabdeckung
+/symfony:check-testing
+```
+
+### Vollständiges Audit vor dem Release
+
+```
 /team:audit --sequential
+```
+
+### Pre-Commit-Validierung
+
+Immer vor dem Commit:
+
+```
 /common:pre-commit-check
 ```
 
+### Sprint-Review
+
+Am Ende des Sprints:
+
+```
+@sm Run sprint review for sprint 1
+```
+
+### Retrospektive
+
+```
+@sm Run sprint retrospective
+```
+
 ---
 
-## Phase 7: Deployment
+## Phase 7: Deployment (30–60 Minuten)
 
-```bash
+### Docker-Konfiguration vorbereiten
+
+```
+@docker-architect Design Docker architecture for production
+```
+
+### Docker-Dateien erstellen
+
+```
 /docker:compose-setup symfony postgresql redis
+```
+
+### CI/CD-Pipeline erstellen
+
+```
 /docker:cicd-pipeline github-actions
+```
+
+### Sicherheitsprüfung
+
+```
+/docker:security-scan
+```
+
+### Pre-Release-Checkliste
+
+```
 /common:release-checklist
 ```
 
----
-
-## Ralph für Automatisierung nutzen
+### Deployen
 
 ```bash
-/common:ralph-run "Implementiere Benutzerauthentifizierung mit TDD"
+# Bauen und testen
+docker compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml up -d
+
+# Migrationen ausführen
+docker compose exec app php bin/console doctrine:migrations:migrate
+
+# Gesundheit überprüfen
+curl https://your-app.com/health
 ```
+
+---
+
+## Ralph für die Automatisierung verwenden
+
+Für automatisierte Entwicklungszyklen Ralph Wiggum verwenden:
+
+```bash
+# Ein Feature automatisch implementieren
+/common:ralph-run "Implement user registration with TDD"
+
+# Mit vollständigen DoD-Prüfungen
+/common:ralph-run --full "Add password reset feature"
+```
+
+Ralph iteriert, bis:
+- Alle Tests bestehen
+- Lint besteht
+- DoD-Validatoren bestehen
 
 ---
 
 ## Vollständige Befehlssequenz
 
+Hier ist eine komprimierte Sequenz für ein typisches Feature:
+
 ```bash
+# 0. Session einrichten
+/effort high                    # Komplexe Planung
+/common:setup-rtk               # Token-Optimierung (nur beim ersten Mal)
+
+# 1. Initialisieren
 /bmad:init
-@pm Erstelle das PRD
+
+# 2. Definieren (PM)
+@pm Create PRD for the feature
 /gate:validate-prd docs/prd.md
-@architect Erstelle die technische Spezifikation
+
+# 3. Entwerfen (Architekt)
+@architect Create technical specification
 /gate:validate-techspec docs/tech-spec.md
-@po Erstelle die User Stories
-@sm Plane Sprint 1
+
+# 4. Planen (PO + SM)
+@po Create user stories
+@sm Plan sprint 1
+/gate:validate-sprint
+
+# 5. Entwickeln (Dev)
 /sprint:next-story --claim
-@dev Implementiere mit TDD
+@dev Implement with TDD
 /gate:validate-story US-001
+/sprint:transition US-001 done
+
+# 6. Überprüfen (QA)
+@qa Validate acceptance criteria
 /team:audit --sequential
+
+# 7. Deployen
+/docker:cicd-pipeline github-actions
 /common:release-checklist
 ```
 
@@ -153,22 +513,78 @@ Hauptfunktionen:
 
 ## Tipps für den Erfolg
 
-1. **Quality Gates nicht überspringen**
-2. **Agenten kollaborativ nutzen** - Claude-Craft enthält **70 Agenten** spezialisiert
-3. **TDD ist nicht verhandelbar**: 🔴 → 🟢 → 🔵
-4. **Entscheidungen dokumentieren** mit ADRs
-5. **Regelmäßige Reviews**: `/common:daily-standup`, `@{tech}-reviewer`
-6. **Kontext verwalten**:
-   - `/effort high` für komplexe Aufgaben, `/effort low` für Lookups
-   - `/context` für Vorschläge zur Kontextoptimierung
-   - `/compact` proaktiv wenn der Kontext 70% überschreitet
-   - `/clear` zwischen nicht zusammenhängenden Aufgaben
-   - `/loop` für wiederkehrende Aufgaben (z.B. `/loop 5m /common:pre-commit-check`)
+### 0. Ihr Kontextfenster verwalten
+
+Das Kontextfenster ist Ihre wichtigste Ressource:
+- `/effort low` für einfache Aufgaben, `/effort high` für komplexe
+- `/context` regelmäßig verwenden, um Optimierungsvorschläge zu prüfen
+- `/clear` zwischen nicht zusammenhängenden Aufgaben ausführen
+- `/memory` verwenden, um wichtige Entscheidungen sitzungsübergreifend zu speichern
+- `/loop` für wiederkehrende Prüfungen statt manueller Ausführungen einrichten
+
+### 1. Quality-Gates nicht überspringen
+
+Jedes Gate deckt andere Probleme auf:
+- PRD-Gate → Verhindert das Bauen der falschen Sache
+- Tech-Spec-Gate → Verhindert Architekturprobleme
+- Backlog-Gate → Stellt sicher, dass Stories implementierbar sind
+- Story-DoD → Sichert Codequalität
+
+### 2. Agenten kollaborativ nutzen
+
+Agenten sich gegenseitig übergeben lassen:
+```
+@bmad-master Route this to the appropriate agent
+```
+
+### 3. TDD ist nicht verhandelbar
+
+Immer dem Schema folgen: 🔴 Red → 🟢 Green → 🔵 Refactor.
+
+### 4. Entscheidungen dokumentieren
+
+ADRs für wichtige Entscheidungen verwenden:
+```
+@architect Create ADR for choosing X over Y
+```
+
+### 5. Regelmäßige Reviews
+
+- Täglich: `/common:daily-standup`
+- Sprint-Ende: `@sm Run sprint review`
+- Kontinuierlich: `@{tech}-reviewer Review this code`
 
 ---
 
-## Siehe auch
+## Fehlerbehebung
 
-- [BMAD Praktischer Leitfaden](../BMAD-PRACTICAL-GUIDE.md)
-- [Ralph Wiggum Leitfaden](../RALPH-GUIDE.md)
-- [Befehlsreferenz](../COMMANDS.md)
+### Quality-Gate schlägt fehl
+
+```
+/gate:report
+```
+
+Prüfen, welche Kriterien fehlen.
+
+### Story blockiert
+
+```
+/sprint:transition US-001 blocked --reason="Waiting for API"
+```
+
+### Rollback erforderlich
+
+Bei Verwendung von Ralph mit Git-Checkpointing:
+```bash
+git log --oneline --grep="[ralph]"
+git reset --hard HEAD~3
+```
+
+---
+
+## Nächste Schritte
+
+- [BMAD-Praxisleitfaden](../BMAD-PRACTICAL-GUIDE.md) – Tiefes Eintauchen in BMAD
+- [Ralph-Wiggum-Leitfaden](../RALPH-GUIDE.md) – Automatisierte Entwicklung
+- [Befehls-Referenz](../COMMANDS.md) – Alle verfügbaren Befehle
+- [Agenten-Referenz](../AGENTS.md) – Alle verfügbaren Agenten

--- a/docs/guides/en/10-complete-workflow.md
+++ b/docs/guides/en/10-complete-workflow.md
@@ -17,7 +17,7 @@ This guide walks you through the complete development lifecycle:
 7. **Deployment** - Ship to production
 
 **Prerequisites:**
-- Claude Craft v8.8.1 installed in your project
+- Claude Craft v8.8.2 installed in your project
 - Claude Code v2.1.159 (recommended) or v2.1.97+ (minimum, CVE-2025-59536 patched)
 - Basic understanding of your chosen technology stack
 

--- a/docs/guides/es/01-getting-started.md
+++ b/docs/guides/es/01-getting-started.md
@@ -1,65 +1,84 @@
 # Primeros Pasos con Claude-Craft
 
-Bienvenido a Claude-Craft. Esta guía te ayudará a entender qué es Claude-Craft y a poner en marcha tu primer proyecto en solo 5 minutos.
+¡Bienvenido a Claude-Craft! Esta guía te ayudará a entender qué es Claude-Craft y a poner en marcha tu primer proyecto en tan solo 5 minutos.
 
 ---
 
 ## ¿Qué es Claude-Craft?
 
-Claude-Craft es un framework completo para desarrollo asistido por IA con Claude Code. Proporciona:
+Claude-Craft es un framework completo para el desarrollo asistido por IA con Claude Code. Proporciona:
 
-- **125 Comandos Slash** - Acciones rápidas en 15 namespaces para generación, análisis y calidad de código
-- **70 Agentes IA (31 especializados + 39 infra a demanda)** - Asistentes especializados para diferentes tareas (diseño de API, arquitectura, revisión de código, DevOps, etc.)
+- **125 Comandos Slash** - Acciones rápidas en 15 espacios de nombres para generación de código, análisis y controles de calidad
+- **70 Agentes IA (31 especializados + 39 de infra a demanda)** - Asistentes especializados con niveles de esfuerzo optimizados y memoria persistente
 - **11 Stacks Tecnológicos** - De .NET/C# a Vue.js, con reglas y agentes dedicados
-- **48 Skills** - Mejores prácticas para arquitectura, pruebas, seguridad y calidad de código
-- **21 Plantillas** - Patrones de código listos para usar
-- **10 Checklists** - Puertas de calidad para funcionalidades y releases
+- **48 Skills** - Mejores prácticas de arquitectura, testing y seguridad
+- **21 Plantillas** - Patrones de código listos para usar para componentes comunes
+- **10 Checklists** - Puertas de calidad para funcionalidades, releases y auditorías de seguridad
+- **Suite de 937 Tests** - Validación completa (vitest + bats)
 
 ### Tecnologías Soportadas
 
 | Tecnología | Enfoque | Casos de Uso |
 |------------|---------|--------------|
-| **Symfony / PHP** | Clean Architecture + DDD | APIs, Apps web, Servicios backend |
-| **React** | Hooks + State Management | SPAs web, Dashboards |
-| **Flutter / Dart** | Patrón BLoC | Apps móviles (iOS/Android) |
-| **Python** | FastAPI + async/await | APIs, Servicios de datos, ML |
-| **Angular** | Signals + Standalone | SPAs enterprise |
-| **Vue.js** | Composition API + Pinia | SPAs web, Dashboards |
-| **React Native** | New Architecture | Apps móviles multiplataforma |
-| **C# / .NET** | Clean Architecture + CQRS | APIs enterprise, Microservicios |
-| **Laravel** | Actions Pattern | APIs, CMS, E-commerce |
-| **PHP** | PSR-12 + PHPStan | Librerías, APIs |
-| **Docker** | Contenedorización | Dev local, CI/CD |
-| **Coolify** | PaaS auto-hospedado | Despliegues simples |
-| **Kubernetes** | Orquestación | Microservicios, Scale |
-| **OpenTofu** | IaC | Multi-cloud |
-| **Ansible** | Automatización | Gestión de configuración |
-| **Hcloud** | Hetzner Cloud | Hosting europeo |
-| **PgBouncer** | Connection pooling | PostgreSQL alta carga |
-| **FrankenPHP** | Servidor PHP/Go | Rendimiento PHP |
+| **.NET / C#** | Clean Architecture + CQRS | APIs, aplicaciones enterprise |
+| **Symfony** | Clean Architecture + DDD | APIs, aplicaciones web, servicios backend |
+| **Flutter** | Patrón BLoC | Aplicaciones móviles (iOS/Android) |
+| **Python** | FastAPI + async/await | APIs, servicios de datos, backends de ML |
+| **React** | Hooks + State Management | SPAs web, dashboards |
+| **React Native** | New Architecture multiplataforma | Aplicaciones móviles con JS |
+| **Angular** | Signals + Standalone | Aplicaciones web enterprise |
+| **Vue.js** | Composition API + Pinia | SPAs web, aplicaciones progresivas |
+| **Laravel** | Clean Architecture + Actions | APIs, aplicaciones web |
+| **PHP** | PSR-12 + PHPStan | Librerías, servicios backend |
+| **Docker** | Infraestructura | Contenedorización, CI/CD |
 
 ### Idiomas Soportados
 
-Todo el contenido está disponible en 5 idiomas: Inglés (en), Francés (fr), Español (es), Alemán (de), Portugués (pt)
+Todo el contenido está disponible en 5 idiomas:
+- Inglés (en)
+- Francés (fr)
+- Español (es)
+- Alemán (de)
+- Portugués (pt)
 
 ---
 
 ## Prerrequisitos
 
 ### Obligatorios
-- **Bash** - Shell para ejecutar scripts de instalación
+
+- **Bash** - Shell para ejecutar los scripts de instalación
 - **Claude Code** - El asistente de codificación IA de Anthropic
 
-### Opcionales (Recomendados)
-```bash
-# yq - Procesador YAML
-brew install yq  # macOS
-sudo apt install yq  # Linux
+### Compatibilidad con Claude Code
 
-# jq - Procesador JSON (para StatusLine)
-brew install jq  # macOS
-sudo apt install jq  # Linux
-```
+| Versión | Estado |
+|---------|--------|
+| **2.1.159** | Recomendada (soporte completo de funcionalidades) |
+| **2.1.97+** | Mínima soportada (CVE-2025-59536 parcheado) |
+
+### Opcionales (Recomendados)
+
+- **yq** - Procesador YAML para archivos de configuración
+  ```bash
+  # macOS
+  brew install yq
+
+  # Linux (Debian/Ubuntu)
+  sudo apt install yq
+
+  # Linux (snap)
+  sudo snap install yq
+  ```
+
+- **jq** - Procesador JSON (para la herramienta StatusLine)
+  ```bash
+  # macOS
+  brew install jq
+
+  # Linux
+  sudo apt install jq
+  ```
 
 ---
 
@@ -68,24 +87,37 @@ sudo apt install jq  # Linux
 ### Método 1: Makefile (Recomendado)
 
 ```bash
+# Clonar Claude-Craft
 git clone https://github.com/thebeardedcto/claude-craft.git
 cd claude-craft
 
-# Instalar para proyecto Symfony (en español)
-make install-symfony TARGET=~/mi-proyecto LANG=es
+# Instalar para un proyecto Symfony (en francés)
+make install-symfony TARGET=~/mi-proyecto LANG=fr
+
+# O para un proyecto Flutter (en inglés)
+make install-flutter TARGET=~/mi-app LANG=en
 ```
 
 ### Método 2: Script Directo
 
 ```bash
-./Dev/scripts/install-symfony-rules.sh --lang=es ~/mi-proyecto
+# Navegar a Claude-Craft
+cd claude-craft
+
+# Ejecutar el script de instalación
+./Dev/scripts/install-symfony-rules.sh --lang=fr ~/mi-proyecto
 ```
 
 ### Método 3: Configuración YAML (para Monorepos)
 
 ```bash
+# Crear el archivo de configuración
 cp claude-projects.yaml.example claude-projects.yaml
+
+# Editar con tus proyectos
 nano claude-projects.yaml
+
+# Instalar desde la configuración
 make config-install CONFIG=claude-projects.yaml PROJECT=mi-proyecto
 ```
 
@@ -93,65 +125,162 @@ make config-install CONFIG=claude-projects.yaml PROJECT=mi-proyecto
 
 ## Tu Primer Proyecto en 5 Minutos
 
+Vamos a crear un nuevo proyecto de API Symfony con reglas en francés.
+
+### Paso 1: Crear el Directorio del Proyecto
+
 ```bash
-# Paso 1: Crear directorio del proyecto
-mkdir ~/mi-api && cd ~/mi-api && git init
-
-# Paso 2: Instalar reglas Claude-Craft
-make install-symfony TARGET=~/mi-api LANG=es
-
-# Paso 3: Verificar instalación
-ls -la ~/mi-api/.claude/
-
-# Paso 4: Configurar contexto del proyecto (elige una opción)
-# Opción A: Interactiva (recomendada)
-cd ~/mi-api && claude
-# Luego ejecuta: /common:setup-project-context
-
-# Opción B: Manual
-nano ~/mi-api/.claude/rules/00-project-context.md
-
-# Paso 5: Iniciar Claude Code
-cd ~/mi-api && claude
+mkdir ~/mi-api
+cd ~/mi-api
+git init
 ```
+
+### Paso 2: Instalar las Reglas de Claude-Craft
+
+```bash
+# Desde el directorio claude-craft
+make install-symfony TARGET=~/mi-api LANG=fr
+```
+
+### Paso 3: Verificar la Instalación
+
+```bash
+ls -la ~/mi-api/.claude/
+```
+
+Deberías ver:
+```
+.claude/
+├── CLAUDE.md           # Configuración principal
+├── .claudeignore       # Patrones de ignorado para reducir el contexto
+├── settings.json       # Valores predeterminados optimizados con hook PostCompact
+├── settings.local.json # Permisos locales (patrones con comodín)
+├── rules/              # 21 archivos de reglas
+├── agents/             # Agentes IA con optimización de esfuerzo/memoria
+├── commands/           # Comandos slash
+│   ├── common/         # Comandos transversales
+│   └── symfony/        # Comandos específicos de Symfony
+├── templates/          # Plantillas de código
+└── checklists/         # Puertas de calidad
+```
+
+### Paso 4: Configurar el Contexto de tu Proyecto
+
+Puedes configurar el contexto del proyecto de forma interactiva o manual:
+
+**Opción A: Interactiva (Recomendada)**
+```bash
+cd ~/mi-api && claude
+# Luego ejecuta:
+/common:setup-project-context
+```
+
+**Opción B: Manual**
+```bash
+nano ~/mi-api/.claude/rules/00-project-context.md
+```
+
+Actualiza estas secciones:
+- Nombre y descripción del proyecto
+- Detalles del stack técnico
+- Convenciones del equipo
+- Restricciones específicas
+
+### Paso 5: Iniciar Claude Code
+
+```bash
+cd ~/mi-api
+claude
+```
+
+¡Ahora puedes usar todos los comandos y agentes instalados!
 
 ---
 
 ## Entendiendo la Estructura
 
 ### Reglas (`rules/`)
-Directrices que Claude sigue al trabajar en tu proyecto, numeradas por prioridad (00-12+).
+
+Las reglas son directrices que Claude sigue al trabajar en tu proyecto. Están numeradas por prioridad:
+
+| Número | Tema |
+|--------|------|
+| 00 | Contexto del proyecto (¡personaliza esto!) |
+| 01 | Flujo de trabajo y análisis |
+| 02 | Arquitectura |
+| 03 | Estándares de código |
+| 04 | Principios SOLID |
+| 05 | KISS, DRY, YAGNI |
+| 06 | Docker y herramientas |
+| 07 | Testing |
+| 08 | Herramientas de calidad |
+| 09 | Flujo de trabajo Git |
+| 10 | Documentación |
+| 11 | Seguridad |
+| 12+ | Temas avanzados (DDD, CQRS, etc.) |
 
 ### Agentes (`agents/`)
+
+Los agentes son personas especializadas de IA que puedes invocar para tareas específicas:
+
 ```markdown
-@api-designer Diseña la API REST para gestión de usuarios
+@api-designer Diseña la API REST para la gestión de usuarios
 @database-architect Crea el esquema para el agregado Pedido
 @symfony-reviewer Revisa mi implementación de UserService
+@tdd-coach Ayúdame a escribir tests para el flujo de autenticación
 ```
 
 ### Comandos (`commands/`)
+
+Los comandos slash son acciones rápidas:
+
 ```bash
+# Generar código
 /symfony:generate-crud User
+
+# Verificar calidad
 /symfony:check-compliance
+
+# Analizar arquitectura
 /common:architecture-decision
 ```
 
 ### Plantillas (`templates/`)
-service.md, value-object.md, aggregate-root.md, test-unit.md
+
+Las plantillas proporcionan patrones de código:
+- `service.md` - Plantilla de clase de servicio
+- `value-object.md` - Plantilla de Value Object
+- `aggregate-root.md` - Plantilla de Aggregate Root DDD
+- `test-unit.md` - Plantilla de test unitario
 
 ### Checklists (`checklists/`)
-feature-checklist.md, pre-commit.md, release.md, security-audit.md
+
+Puertas de calidad para diferentes escenarios:
+- `feature-checklist.md` - Antes de completar una funcionalidad
+- `pre-commit.md` - Antes de hacer commit del código
+- `release.md` - Antes de publicar una release
+- `security-audit.md` - Revisión de seguridad
 
 ---
 
 ## Conceptos Clave
 
 ### 1. Flujo de Trabajo TDD
+
+Claude-Craft aplica el Desarrollo Guiado por Tests:
+
 ```
-1. Analizar → 2. Tests → 3. Implementar → 4. Refactorizar → 5. Revisar
+1. Analizar requisitos
+2. Escribir tests que fallen
+3. Implementar el código
+4. Refactorizar
+5. Revisar
 ```
 
 ### 2. Clean Architecture
+
+Todos los stacks tecnológicos siguen los principios de Clean Architecture:
+
 ```
 ┌─────────────────────────────────────┐
 │           Presentación              │
@@ -165,19 +294,82 @@ feature-checklist.md, pre-commit.md, release.md, security-audit.md
 ```
 
 ### 3. Calidad Primero
-- 80%+ cobertura de tests
-- Análisis estático aprobado
-- Auditoría de seguridad clara
+
+Cada funcionalidad debe superar las puertas de calidad:
+- 80%+ de cobertura de tests
+- Análisis estático superado
+- Auditoría de seguridad sin hallazgos
 - Documentación actualizada
+
+---
+
+## Optimizaciones Automáticas (v8.7)
+
+Claude-Craft ahora incluye valores predeterminados optimizados de fábrica:
+
+**Instalados automáticamente:**
+- ✓ `.claudeignore` para reducir el ruido en el contexto
+- ✓ `settings.json` con hook PostCompact para reinyección del contexto
+- ✓ `settings.local.json` con permisos con comodín
+- ✓ `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` aplicado para reducir costes
+- ✓ RTK `--ultra-compact` parcheado automáticamente durante la instalación
+
+**Opcional: Integración RTK**
+
+Para la máxima reducción de salida CLI (ahorro del 60-90%):
+
+```bash
+# En Claude Code, ejecuta el comando de configuración
+/common:setup-rtk
+```
+
+**Ahorros esperados:** Reducción global de tokens del 55-65% con RTK completo + optimizaciones. Consulta la [Guía de Configuración](08-setup-new-project.md) para más detalles.
 
 ---
 
 ## Próximos Pasos
 
-1. **[Guía de Creación de Proyecto](02-project-creation.md)**
-2. **[Guía de Desarrollo de Funcionalidades](03-feature-development.md)**
-3. **[Guía de Corrección de Bugs](04-bug-fixing.md)**
+Ahora que entiendes los conceptos básicos, continúa con:
+
+1. **[Guía de Creación de Proyecto](02-project-creation.md)** - Configuración detallada para diferentes escenarios
+2. **[Guía de Desarrollo de Funcionalidades](03-feature-development.md)** - Flujo de trabajo TDD con agentes y comandos
+3. **[Guía de Corrección de Bugs](04-bug-fixing.md)** - Flujo de trabajo de diagnóstico y testing de regresión
 
 ---
 
-[Siguiente: Creación de Proyecto &rarr;](02-project-creation.md)
+## Referencia Rápida
+
+### Comandos Comunes
+
+```bash
+# Instalación
+make install-{tech} TARGET=ruta LANG=xx
+
+# Listar opciones disponibles
+make help
+
+# Validar configuración YAML
+make config-validate CONFIG=archivo.yaml
+```
+
+### Agentes Útiles
+
+| Agente | Propósito |
+|--------|-----------|
+| `@api-designer` | Diseño y documentación de API |
+| `@database-architect` | Diseño de esquema de base de datos |
+| `@tdd-coach` | Ayuda para escribir tests |
+| `@{tech}-reviewer` | Revisión de código para tecnología específica |
+
+### Comandos Esenciales
+
+| Comando | Propósito |
+|---------|-----------|
+| `/common:analyze-feature` | Analizar requisitos |
+| `/{tech}:generate-crud` | Generar código CRUD |
+| `/{tech}:check-compliance` | Auditoría completa de calidad |
+| `/common:security-audit` | Revisión de seguridad |
+
+---
+
+[Siguiente: Guía de Creación de Proyecto &rarr;](02-project-creation.md)

--- a/docs/guides/es/02-project-creation.md
+++ b/docs/guides/es/02-project-creation.md
@@ -1,130 +1,421 @@
-# Guía de Creación de Proyecto
+# Guía de Creación de Proyectos
 
-Esta guía te acompaña en la configuración de un nuevo proyecto con Claude-Craft.
+Esta guía te lleva paso a paso por la configuración de un nuevo proyecto con Claude-Craft, desde la elección de tu stack tecnológico hasta la configuración de tu entorno de desarrollo.
 
 ---
 
-## Elegir Tu Tecnología
+## Tabla de Contenidos
 
-Claude-Craft soporta **11 stacks de aplicación** (+ 8 de infraestructura):
+1. [Elegir tu Tecnología](#elegir-tu-tecnología)
+2. [Métodos de Instalación](#métodos-de-instalación)
+3. [Proyectos de Tecnología Única](#proyectos-de-tecnología-única)
+4. [Proyectos Monorepo](#proyectos-monorepo)
+5. [Configuración Post-Instalación](#configuración-post-instalación)
+6. [Lista de Verificación de Inicio de Proyecto](#lista-de-verificación-de-inicio-de-proyecto)
 
-### Stacks de Desarrollo
+---
+
+## Elegir tu Tecnología
+
+### Comparación de Tecnologías
 
 | Tecnología | Ideal Para | Arquitectura | Características Clave |
-|------------|------------|--------------|----------------------|
-| **C# / .NET** | APIs backend, Enterprise | Clean Architecture | CQRS, MediatR, EF Core |
-| **Symfony / PHP** | APIs backend, Apps web | Clean Architecture + DDD | Doctrine, Messenger, API Platform |
-| **Laravel / PHP** | Apps web, APIs rápidas | Clean Architecture | Actions, Pest PHP, Sanctum |
-| **PHP** | Clean Architecture genérica | Clean Architecture | PSR-12, PHPStan, Pest PHP |
-| **Flutter / Dart** | Apps móviles | Feature-based + BLoC | Material/Cupertino, Gestión de estado |
-| **Python** | APIs, Servicios de datos | Clean Architecture | FastAPI, async/await, Pydantic |
-| **React** | SPAs web | Feature-based + Hooks | Zustand, React Query, accesibilidad |
-| **React Native** | Móvil multiplataforma | Feature-based | Navigation 7, Reanimated 4 |
-| **Angular** | Apps empresariales | Domain-driven | Signals, Standalone, RxJS |
+|------------|-----------|--------------|----------------------|
+| **.NET / C#** | APIs empresariales | Clean Architecture + CQRS | MediatR, EF Core, C# 14 |
+| **Symfony** | APIs backend, aplicaciones web | Clean Architecture + DDD | Doctrine, Messenger, API Platform |
+| **Flutter** | Aplicaciones móviles | Feature-based + BLoC | Material/Cupertino, gestión de estado |
+| **Python** | APIs, servicios de datos | Clean Architecture | FastAPI, async/await, Pydantic |
+| **React** | SPAs web | Feature-based + Hooks | Gestión de estado, accesibilidad |
+| **React Native** | Móvil multiplataforma | Basado en navegación | Módulos nativos, código específico de plataforma |
+| **Angular** | Aplicaciones web empresariales | Domain-driven | Signals, Standalone, RxJS |
 | **Vue.js** | SPAs web | Composition API | Pinia, Vitest, TypeScript |
+| **Laravel** | APIs PHP, aplicaciones web | Clean Architecture | Actions, Pest PHP, Sanctum |
+| **PHP** | Librerías, backend | Clean Architecture | PSR-12, PHPStan, Pest PHP |
 
-### Stacks de Infraestructura
-
-Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hetzner Cloud, PgBouncer, FrankenPHP
-
-### Elección según Tipo de Proyecto
+### Elegir Según el Tipo de Proyecto
 
 | Tipo de Proyecto | Stack Recomendado |
-|------------------|-------------------|
-| API REST | Symfony, Laravel o Python |
-| App móvil (nativa) | Flutter |
-| App móvil (equipo JS) | React Native |
-| SPA Web | React, Vue.js o Angular |
+|-----------------|-------------------|
+| API REST | Symfony o Python |
+| Aplicación móvil (sensación nativa) | Flutter |
+| Aplicación móvil (equipo JS) | React Native |
+| SPA web | React |
 | Full-stack web | Symfony + React |
 | Full-stack móvil | Symfony + Flutter |
 | Microservicios | Python (FastAPI) |
-| Enterprise | C# / .NET o Angular |
+
+### Combinaciones Comunes
+
+```
+Aplicación Web:      Symfony (backend) + React (frontend)
+Aplicación Móvil:    Symfony (API) + Flutter (móvil)
+Plataforma Completa: Symfony (API) + React (web) + Flutter (móvil)
+Plataforma de Datos: Python (API) + React (dashboard)
+```
 
 ---
 
 ## Métodos de Instalación
 
+Claude-Craft ofrece múltiples métodos de instalación para adaptarse a diferentes flujos de trabajo.
+
 ### Método 1: Makefile (Recomendado)
 
+El enfoque más sencillo y flexible.
+
 ```bash
-make install-{tecnología} TARGET=ruta LANG=idioma
+# Sintaxis básica
+make install-{technology} TARGET=ruta LANG=idioma
 
 # Ejemplos
-make install-symfony TARGET=./backend LANG=es
-make install-flutter TARGET=./mobile LANG=es
+make install-symfony TARGET=./backend LANG=en
+make install-flutter TARGET=./mobile LANG=fr
+make install-python TARGET=./api LANG=es
+make install-react TARGET=./frontend LANG=de
+make install-reactnative TARGET=./app LANG=pt
 ```
 
-#### Opciones
+#### Opciones Disponibles
+
+| Opción | Descripción | Ejemplo |
+|--------|-------------|---------|
+| `TARGET` | Ruta de instalación | `TARGET=~/projects/myapp` |
+| `LANG` | Código de idioma | `LANG=fr` |
+| `OPTIONS` | Indicadores adicionales | `OPTIONS="--force --backup"` |
+
+#### Indicadores de Opción
+
 ```bash
-OPTIONS="--dry-run"      # Vista previa sin cambios
-OPTIONS="--force"        # Sobrescribir archivos
-OPTIONS="--backup"       # Crear respaldo
-OPTIONS="--interactive"  # Modo interactivo
-OPTIONS="--update"       # Solo actualizar
+# Previsualizar cambios sin aplicar
+make install-symfony TARGET=./backend OPTIONS="--dry-run"
+
+# Forzar sobrescritura de archivos existentes (crea copia de seguridad)
+make install-symfony TARGET=./backend OPTIONS="--force"
+
+# Crear copia de seguridad antes de la instalación
+make install-symfony TARGET=./backend OPTIONS="--backup"
+
+# Modo interactivo (solicita información del proyecto)
+make install-symfony TARGET=./backend OPTIONS="--interactive"
+
+# Solo actualizar (preservar archivos específicos del proyecto)
+make install-symfony TARGET=./backend OPTIONS="--update"
 ```
 
-### Método 2: Script Directo
+### Método 2: Ejecución Directa del Script
+
+Ejecutar los scripts de instalación directamente para mayor control.
 
 ```bash
-./Dev/scripts/install-symfony-rules.sh --lang=es ~/mi-proyecto
+# Sintaxis
+./Dev/scripts/install-{technology}-rules.sh [OPTIONS] [TARGET]
+
+# Ejemplos
+./Dev/scripts/install-symfony-rules.sh --lang=fr ~/mi-proyecto
+./Dev/scripts/install-flutter-rules.sh --lang=en --dry-run .
+./Dev/scripts/install-python-rules.sh --force --backup ~/api
+```
+
+#### Opciones del Script
+
+```bash
+--lang=XX       # Idioma (en, fr, es, de, pt)
+--install       # Modo de instalación completa
+--update        # Actualizar solo las reglas comunes
+--force         # Sobrescribir todos los archivos
+--dry-run       # Previsualizar sin cambios
+--backup        # Crear copia de seguridad primero
+--interactive   # Solicitar información del proyecto
+--help          # Mostrar ayuda
+--version       # Mostrar versión
 ```
 
 ### Método 3: Configuración YAML
 
-```yaml
-# claude-projects.yaml
-settings:
-  default_lang: "es"
-
-projects:
-  - name: "mi-plataforma"
-    path: "~/Proyectos/mi-plataforma"
-    modules:
-      - name: "api"
-        path: "backend"
-        technologies: ["symfony"]
-      - name: "mobile"
-        path: "app"
-        technologies: ["flutter"]
-```
+Ideal para monorepos y configuraciones multi-proyecto.
 
 ```bash
-make config-install CONFIG=claude-projects.yaml PROJECT=mi-plataforma
+# Crear configuración
+cp claude-projects.yaml.example claude-projects.yaml
+
+# Editar configuración
+nano claude-projects.yaml
+
+# Validar configuración
+make config-validate CONFIG=claude-projects.yaml
+
+# Instalar proyecto específico
+make config-install CONFIG=claude-projects.yaml PROJECT=mi-proyecto
+
+# Instalar todos los proyectos
+make config-install-all CONFIG=claude-projects.yaml
 ```
 
 ---
 
-## Proyectos Mono-Tecnología
+## Proyectos de Tecnología Única
 
 ### Proyecto Symfony
+
 ```bash
-mkdir ~/mi-api && cd ~/mi-api && git init
-make install-symfony TARGET=. LANG=es
+# Crear directorio del proyecto
+mkdir ~/mi-api-symfony
+cd ~/mi-api-symfony
+composer create-project symfony/skeleton .
+git init
+
+# Instalar las reglas de Claude-Craft
+make install-symfony TARGET=. LANG=fr
+
+# Verificar instalación
+ls -la .claude/
 ```
+
+**Contenido instalado:**
+- 21 reglas específicas de Symfony (Clean Architecture, DDD, CQRS, etc.)
+- 10+ comandos Symfony (`/symfony:generate-crud`, `/symfony:check-compliance`, etc.)
+- Agente revisor de Symfony
+- Plantillas de código (Service, ValueObject, Aggregate, etc.)
+- Listas de verificación de calidad
 
 ### Proyecto Flutter
+
 ```bash
-flutter create mi_app && cd mi_app && git init
-make install-flutter TARGET=. LANG=es
+# Crear proyecto
+flutter create my_flutter_app
+cd my_flutter_app
+git init
+
+# Instalar las reglas de Claude-Craft
+make install-flutter TARGET=. LANG=en
+
+# Verificar
+ls -la .claude/
 ```
 
+**Contenido instalado:**
+- 13 reglas específicas de Flutter (BLoC, gestión de estado, testing)
+- 10 comandos Flutter
+- Agente revisor de Flutter
+- Plantillas de Widget y BLoC
+- Listas de verificación de calidad
+
 ### Proyecto Python
+
 ```bash
-mkdir ~/mi-api-python && cd ~/mi-api-python && git init
-make install-python TARGET=. LANG=es
+# Crear proyecto
+mkdir ~/mi-api-python
+cd ~/mi-api-python
+python -m venv venv
+git init
+
+# Instalar las reglas de Claude-Craft
+make install-python TARGET=. LANG=en
+
+# Verificar
+ls -la .claude/
+```
+
+**Contenido instalado:**
+- 12 reglas específicas de Python (FastAPI, async, tipado)
+- 10 comandos Python
+- Agente revisor de Python
+- Plantillas de servicio y API
+- Listas de verificación de calidad
+
+### Proyecto React
+
+```bash
+# Crear proyecto
+npx create-react-app my-react-app
+cd my-react-app
+
+# Instalar las reglas de Claude-Craft
+make install-react TARGET=. LANG=en
+
+# Verificar
+ls -la .claude/
+```
+
+### Proyecto React Native
+
+```bash
+# Crear proyecto
+npx react-native init MyApp
+cd MyApp
+
+# Instalar las reglas de Claude-Craft
+make install-reactnative TARGET=. LANG=en
+
+# Verificar
+ls -la .claude/
+```
+
+---
+
+## Proyectos Monorepo
+
+### Entendiendo la Estructura del Monorepo
+
+Un monorepo típico podría verse así:
+
+```
+mi-plataforma/
+├── backend/          # API Symfony
+├── web/              # Frontend React
+├── mobile/           # Aplicación Flutter
+├── shared/           # Tipos/contratos compartidos
+└── claude-projects.yaml
+```
+
+### Estructura de Configuración YAML
+
+```yaml
+# claude-projects.yaml
+
+settings:
+  default_lang: "fr"              # Idioma predeterminado para todos los proyectos
+  claude_craft_path: "~/claude-craft"  # Ruta a claude-craft (opcional)
+
+projects:
+  - name: "mi-plataforma"
+    description: "Plataforma SaaS full-stack"
+    path: "~/Projects/mi-plataforma"
+    modules:
+      - name: "api"
+        path: "backend"
+        technologies: ["symfony"]
+        lang: "en"                # Sobrescribir idioma predeterminado
+
+      - name: "web"
+        path: "web"
+        technologies: ["react"]
+
+      - name: "mobile"
+        path: "mobile"
+        technologies: ["flutter"]
+```
+
+### Campos de Configuración
+
+#### Nivel de Proyecto
+
+| Campo | Requerido | Descripción |
+|-------|----------|-------------|
+| `name` | Sí | Identificador del proyecto |
+| `description` | No | Descripción del proyecto |
+| `path` | Sí | Ruta absoluta a la raíz del proyecto |
+| `lang` | No | Sobrescritura de idioma |
+| `modules` | No | Lista de módulos (para monorepos) |
+| `technologies` | No | Tecnologías si no hay módulos |
+
+#### Nivel de Módulo
+
+| Campo | Requerido | Descripción |
+|-------|----------|-------------|
+| `name` | Sí | Identificador del módulo |
+| `path` | Sí | Ruta relativa desde la raíz del proyecto |
+| `technologies` | Sí | Lista de tecnologías |
+| `lang` | No | Sobrescritura de idioma |
+| `skip_common` | No | Omitir reglas comunes (predeterminado: false) |
+
+### Comandos de Instalación
+
+```bash
+# Validar configuración
+make config-validate CONFIG=claude-projects.yaml
+
+# Listar proyectos configurados
+make config-list CONFIG=claude-projects.yaml
+
+# Instalar proyecto específico
+make config-install CONFIG=claude-projects.yaml PROJECT=mi-plataforma
+
+# Instalar módulo específico
+make config-install CONFIG=claude-projects.yaml PROJECT=mi-plataforma MODULE=api
+
+# Dry-run para previsualizar
+make config-install CONFIG=claude-projects.yaml PROJECT=mi-plataforma OPTIONS="--dry-run"
+
+# Instalar todos los proyectos
+make config-install-all CONFIG=claude-projects.yaml
+```
+
+### Ejemplos del Mundo Real
+
+#### Ejemplo 1: Plataforma SaaS
+
+```yaml
+projects:
+  - name: "saas-platform"
+    path: "~/Projects/saas"
+    modules:
+      - name: "api"
+        path: "services/api"
+        technologies: ["symfony"]
+      - name: "admin"
+        path: "apps/admin"
+        technologies: ["react"]
+      - name: "mobile"
+        path: "apps/mobile"
+        technologies: ["flutter"]
+```
+
+#### Ejemplo 2: Microservicios
+
+```yaml
+projects:
+  - name: "microservices"
+    path: "~/Projects/micro"
+    modules:
+      - name: "gateway"
+        path: "gateway"
+        technologies: ["python"]
+      - name: "users"
+        path: "services/users"
+        technologies: ["symfony"]
+      - name: "orders"
+        path: "services/orders"
+        technologies: ["symfony"]
+      - name: "analytics"
+        path: "services/analytics"
+        technologies: ["python"]
+```
+
+#### Ejemplo 3: Múltiples Proyectos Independientes
+
+```yaml
+settings:
+  default_lang: "fr"
+
+projects:
+  - name: "client-a"
+    path: "~/Clients/client-a"
+    technologies: ["symfony", "react"]
+
+  - name: "client-b"
+    path: "~/Clients/client-b"
+    technologies: ["flutter"]
+    lang: "en"
+
+  - name: "internal-tool"
+    path: "~/Internal/tool"
+    technologies: ["python"]
 ```
 
 ---
 
 ## Configuración Post-Instalación
 
+Después de la instalación, configura estos archivos para tu proyecto específico.
+
 ### 1. Contexto del Proyecto (`rules/00-project-context.md`)
 
-Este es el archivo más importante a personalizar.
+Este es el archivo más importante a personalizar. Le indica a Claude los detalles de tu proyecto específico.
 
 **Opción A: Configuración Interactiva (Recomendada)**
 
-Ejecuta este comando en Claude Code para detectar tu stack y responder preguntas específicas:
+Ejecuta este comando en Claude Code para autodetectar tu stack y responder preguntas específicas:
 ```bash
 /common:setup-project-context
 ```
@@ -136,48 +427,178 @@ Edita el archivo directamente con los detalles de tu proyecto:
 ```markdown
 # Contexto del Proyecto
 
-## Información
-- **Nombre**: Mi API E-commerce
-- **Tipo**: API REST para plataforma e-commerce
+## Información del Proyecto
+- **Nombre**: Mi Awesome API
+- **Tipo**: API REST para plataforma de e-commerce
+- **Tamaño del Equipo**: 3 desarrolladores
 
 ## Stack Técnico
 - PHP 8.3 con Symfony 7.0
 - PostgreSQL 16
 - Redis para caché
+- RabbitMQ para mensajería
 
 ## Convenciones
-- Código en inglés, documentación en español
+- Estándar de código PSR-12
+- Tipado estricto habilitado
+- Código en inglés, documentación en francés
+
+## Restricciones
+- Cumplimiento RGPD obligatorio
+- Debe soportar arquitectura multi-tenant
+- Tiempo máximo de respuesta: 200ms
+
+## Dependencias Externas
+- Stripe para pagos
+- SendGrid para correos electrónicos
+- S3 para almacenamiento de archivos
 ```
 
 ### 2. Configuración Principal (`CLAUDE.md`)
 
-Revisar y ajustar:
-- Configuración de idioma
-- Requisitos de arquitectura
-- Requisitos de calidad
-- Requisitos Docker
+El archivo CLAUDE.md en el directorio `.claude/` contiene la configuración principal. Secciones clave a revisar:
+
+```markdown
+# Configuración del Proyecto
+
+## Configuración de Idioma
+- Código: Inglés
+- Documentación: Francés
+- Comentarios: Inglés
+
+## Arquitectura
+Clean Architecture + DDD + Hexagonal
+
+## Requisitos de Calidad
+- Cobertura de tests: 80%+
+- Nivel PHPStan: 9
+- Sin problemas críticos de seguridad
+
+## Requisitos Docker
+Todos los comandos deben usar Docker a través de targets de make.
+```
+
+### 3. Configuración de Agentes
+
+Revisa los agentes instalados en `.claude/agents/` y personaliza si es necesario:
+
+```bash
+ls .claude/agents/
+# api-designer.md
+# database-architect.md
+# symfony-reviewer.md
+# tdd-coach.md
+# ...
+```
 
 ---
 
-## Checklist de Inicio
+## Lista de Verificación de Inicio de Proyecto
+
+Usa esta lista al configurar un nuevo proyecto:
 
 ### Pre-Instalación
+
 - [ ] Directorio del proyecto creado
 - [ ] Repositorio Git inicializado
 - [ ] Stack tecnológico decidido
+- [ ] Preferencia de idioma elegida
 
 ### Instalación
-- [ ] Reglas Claude-Craft instaladas
+
+- [ ] Reglas de Claude-Craft instaladas
 - [ ] Instalación verificada (`ls .claude/`)
+- [ ] Sin errores en la salida de instalación
 
 ### Configuración
-- [ ] `00-project-context.md` personalizado
-- [ ] `CLAUDE.md` revisado
+
+- [ ] `00-project-context.md` personalizado con detalles del proyecto
+- [ ] `CLAUDE.md` revisado y ajustado
+- [ ] Convenciones del equipo documentadas
+- [ ] Restricciones y requisitos listados
 
 ### Verificación
-- [ ] Claude Code iniciado en el directorio
-- [ ] Comandos disponibles
-- [ ] Agentes respondiendo
+
+- [ ] Claude Code iniciado en el directorio del proyecto
+- [ ] Comandos disponibles (prueba `/symfony:check-compliance`)
+- [ ] Agentes respondiendo (prueba `@symfony-reviewer hello`)
+
+### Configuración del Equipo
+
+- [ ] Directorio `.claude/` confirmado en git
+- [ ] Miembros del equipo informados sobre los comandos disponibles
+- [ ] README actualizado con información de uso de Claude-Craft
+
+---
+
+## Patrones Comunes
+
+### Instalar Solo Reglas Comunes
+
+Para librerías compartidas o paquetes que no encajan en una tecnología específica:
+
+```bash
+make install-common TARGET=./shared-lib LANG=en
+```
+
+### Instalar Herramientas de Gestión de Proyectos
+
+Para seguimiento de sprints y gestión de backlog:
+
+```bash
+make install-project TARGET=. LANG=fr
+```
+
+### Instalar Herramientas de Infraestructura
+
+Para soporte de Docker y CI/CD:
+
+```bash
+make install-infra TARGET=. LANG=en
+```
+
+### Instalación Completa (Todas las Tecnologías)
+
+```bash
+make install-all TARGET=. LANG=fr
+```
+
+---
+
+### Configuración de Optimización de Tokens
+
+Después de instalar las reglas, opcionalmente configura RTK para ahorrar tokens:
+
+```bash
+# En sesión de Claude Code
+/common:setup-rtk
+```
+
+Esto configura el proxy RTK, la optimización del modelo de sub-agente y plantillas de hooks para una reducción total de tokens del 55-65%.
+
+---
+
+## Actualizar Reglas
+
+Cuando Claude-Craft publica nuevas versiones:
+
+```bash
+# Actualizar a la última versión (preserva archivos específicos del proyecto)
+make install-symfony TARGET=./backend OPTIONS="--update"
+
+# Forzar reinstalación completa (copia de seguridad creada automáticamente)
+make install-symfony TARGET=./backend OPTIONS="--force"
+```
+
+---
+
+## Próximos Pasos
+
+¡Tu proyecto ya está configurado! Continúa con:
+
+1. **[Guía de Desarrollo de Funcionalidades](03-feature-development.md)** - Aprende el flujo de trabajo TDD
+2. **[Guía de Corrección de Errores](04-bug-fixing.md)** - Maneja los errores de forma efectiva
+3. **[Referencia de Herramientas](05-tools-reference.md)** - Explora herramientas adicionales
 
 ---
 

--- a/docs/guides/es/03-feature-development.md
+++ b/docs/guides/es/03-feature-development.md
@@ -1,175 +1,656 @@
 # Guía de Desarrollo de Funcionalidades
 
-Flujo de trabajo completo para desarrollar nuevas funcionalidades con Claude-Craft.
+Esta guía cubre el flujo de trabajo completo para desarrollar nuevas funcionalidades con Claude-Craft, desde el análisis inicial hasta la revisión final.
 
 ---
 
-## Flujo de Trabajo TDD
+## Tabla de Contenidos
+
+1. [Visión General del Flujo TDD](#visión-general-del-flujo-tdd)
+2. [Fase 1: Análisis](#fase-1-análisis)
+3. [Fase 2: Diseño](#fase-2-diseño)
+4. [Fase 3: Escritura de Tests](#fase-3-escritura-de-tests)
+5. [Fase 4: Implementación](#fase-4-implementación)
+6. [Fase 5: Refactorización](#fase-5-refactorización)
+7. [Fase 6: Revisión](#fase-6-revisión)
+8. [Ejemplo Completo](#ejemplo-completo)
+9. [Recursos Disponibles](#recursos-disponibles)
+
+---
+
+## Visión General del Flujo TDD
+
+Claude-Craft impone un flujo de trabajo de Desarrollo Guiado por Tests (TDD):
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ 1. Analizar │ --> │ 2. Diseñar  │ --> │  3. Tests   │
+│  1. Analizar│ --> │  2. Diseñar │ --> │  3. Tests   │
 └─────────────┘     └─────────────┘     └─────────────┘
                                               │
                                               v
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│  6. Revisar │ <-- │5. Refactorizar│ <--│4. Implementar│
+│  6. Revisar │ <-- │5. Refactori.│ <-- │4. Implementar│
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
+
+### ¿Por qué TDD?
+
+- **Confianza**: Los tests demuestran que tu código funciona
+- **Documentación**: Los tests describen el comportamiento esperado
+- **Diseño**: Escribir los tests primero conduce a mejores APIs
+- **Regresión**: Los tests detectan bugs futuros
 
 ---
 
 ## Fase 1: Análisis
 
+Antes de escribir cualquier código, comprende qué necesita construirse.
+
+### Establecer el Nivel de Esfuerzo
+
+Para las fases de análisis que requieren razonamiento profundo, establece un esfuerzo alto:
+
 ```bash
-/common:analyze-feature "Autenticación de usuarios con tokens JWT"
+/effort high
 ```
+
+Usa `/effort low` para búsquedas simples y `/effort medium` para trabajo de implementación estándar.
+
+### Usar el Comando de Análisis
+
+```bash
+/common:analyze-feature "Autenticación de usuario con tokens JWT y acceso basado en roles"
+```
+
+Este comando hará lo siguiente:
+1. Desglosar la funcionalidad en componentes
+2. Identificar los requisitos técnicos
+3. Listar posibles casos límite
+4. Sugerir el enfoque de implementación
+
+### Usar el Agente de Investigación
 
 ```markdown
 @research-assistant Investiga las mejores prácticas para autenticación JWT en Symfony 7
 ```
 
+El agente de investigación hará lo siguiente:
+- Buscar documentación y mejores prácticas
+- Resumir los hallazgos
+- Proporcionar ejemplos de código
+- Destacar consideraciones de seguridad
+
+### Lista de Verificación del Análisis
+
+- [ ] Historia de usuario claramente definida
+- [ ] Criterios de aceptación documentados
+- [ ] Casos límite identificados
+- [ ] Enfoque técnico elegido
+- [ ] Dependencias identificadas
+- [ ] Implicaciones de seguridad revisadas
+
 ---
 
 ## Fase 2: Diseño
 
-### Base de Datos
+Diseña la arquitectura antes de la implementación.
+
+### Diseño de Base de Datos
+
 ```markdown
 @database-architect Diseña el esquema para la entidad User con roles y permisos
+
+Requisitos:
+- El usuario puede tener múltiples roles
+- Los roles tienen permisos
+- Soporte para borrado lógico (soft delete)
+- Historial de auditoría para los cambios
 ```
 
-### API
+El arquitecto de base de datos hará lo siguiente:
+- Diseñar el esquema normalizado
+- Sugerir índices
+- Considerar relaciones
+- Planificar migraciones
+
+### Diseño de API
+
 ```markdown
-@api-designer Diseña la API REST para gestión de usuarios
+@api-designer Diseña la API REST para la gestión de usuarios
+
+Endpoints necesarios:
+- Operaciones CRUD para usuarios
+- Asignación de roles
+- Autenticación (login/logout)
+- Flujo de restablecimiento de contraseña
 ```
 
-### Decisión Arquitectónica
+El diseñador de API hará lo siguiente:
+- Definir endpoints y métodos
+- Especificar formatos de solicitud/respuesta
+- Documentar los requisitos de autenticación
+- Planificar las respuestas de error
+
+### Decisión de Arquitectura
+
 ```bash
-/common:architecture-decision "Cómo implementar control de acceso basado en roles"
+/common:architecture-decision "Cómo implementar el control de acceso basado en roles"
 ```
+
+Usa este comando para decisiones arquitectónicas importantes. Crea un Registro de Decisión de Arquitectura (ADR) que documenta:
+- Contexto y problema
+- Opciones consideradas
+- Solución elegida
+- Consecuencias
+
+### Lista de Verificación del Diseño
+
+- [ ] Esquema de base de datos diseñado
+- [ ] Endpoints de la API definidos
+- [ ] Decisiones arquitectónicas documentadas
+- [ ] Modelo de seguridad definido
+- [ ] Estrategia de manejo de errores planificada
 
 ---
 
-## Fase 3: Escribir Tests
+## Fase 3: Escritura de Tests
+
+Escribe tests ANTES de la implementación. Esto es el "TDD" en TDD.
+
+### Usar el Entrenador TDD
 
 ```markdown
 @tdd-coach Ayúdame a escribir tests para el método de autenticación de UserService
+
+El método debe:
+- Aceptar email y contraseña
+- Devolver un token JWT en caso de éxito
+- Lanzar una excepción con credenciales inválidas
+- Bloquear la cuenta después de 5 intentos fallidos
 ```
 
-### Tipos de Tests
+El entrenador TDD hará lo siguiente:
+- Sugerir casos de prueba
+- Escribir ejemplos de código de prueba
+- Explicar las aserciones
+- Identificar casos límite
 
-**Tests Unitarios:**
+### Categorías de Tests
+
+#### Tests Unitarios
+
+Prueba componentes individuales de forma aislada:
+
 ```php
+// tests/Unit/Domain/User/UserTest.php
 public function test_user_can_change_password(): void
 {
-    $user = User::create('test@example.com', 'old-password');
+    $user = User::create(
+        email: 'test@example.com',
+        password: 'old-password'
+    );
+
     $user->changePassword('new-password');
+
     $this->assertTrue($user->verifyPassword('new-password'));
+    $this->assertFalse($user->verifyPassword('old-password'));
 }
 ```
 
-**Tests de Integración:**
+#### Tests de Integración
+
+Prueba las interacciones entre componentes:
+
 ```php
+// tests/Integration/UserServiceTest.php
 public function test_user_service_creates_user_in_database(): void
 {
     $service = $this->container->get(UserService::class);
-    $user = $service->createUser('test@example.com', 'password');
+
+    $user = $service->createUser(
+        email: 'test@example.com',
+        password: 'secure-password'
+    );
+
     $this->assertNotNull($user->getId());
+    $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
 }
 ```
+
+#### Tests BDD/Funcionales
+
+Prueba escenarios de negocio:
+
+```gherkin
+# features/authentication.feature
+Feature: User Authentication
+  As a user
+  I want to log in with my credentials
+  So that I can access protected resources
+
+  Scenario: Successful login
+    Given I have a registered user with email "user@example.com"
+    When I submit valid credentials
+    Then I should receive a JWT token
+    And the token should be valid for 1 hour
+```
+
+### Comandos de Tests Específicos por Tecnología
+
+```bash
+# Symfony
+/symfony:check-testing
+
+# Flutter
+/flutter:check-testing
+
+# Python
+/python:check-testing
+
+# React
+/react:check-testing
+```
+
+### Lista de Verificación de Escritura de Tests
+
+- [ ] Tests unitarios para la lógica del dominio
+- [ ] Tests de integración para los servicios
+- [ ] Tests de API para los endpoints
+- [ ] Casos límite cubiertos
+- [ ] Escenarios de error probados
+- [ ] Todos los tests fallando (aún no implementados)
 
 ---
 
 ## Fase 4: Implementación
 
-### Comandos de Generación
+Ahora implementa el código para que los tests pasen.
+
+### Comandos de Generación de Código
+
+#### Symfony
 
 ```bash
-# Symfony
+# Generar CRUD con tests
 /symfony:generate-crud User
+
+# Generar endpoint de API
 /symfony:api-endpoint POST /api/users CreateUserRequest
 
-# Flutter
-/flutter:generate-feature Authentication
-/flutter:generate-widget LoginScreen
+# Generar comando
+/symfony:generate-command SendWelcomeEmailCommand
+```
 
-# Python
+#### Flutter
+
+```bash
+# Generar BLoC
+/flutter:generate-bloc Authentication
+
+# Generar pantalla
+/flutter:generate-screen LoginScreen
+
+# Generar widget
+/flutter:generate-widget UserAvatar
+```
+
+#### Python
+
+```bash
+# Generar endpoint FastAPI
 /python:generate-endpoint POST /users CreateUser
-/python:generate-model User
 
-# React
+# Generar servicio
+/python:generate-service UserService
+
+# Generar modelo
+/python:generate-model User
+```
+
+#### React
+
+```bash
+# Generar componente
 /react:generate-component UserProfile
+
+# Generar hook
 /react:generate-hook useAuth
 
-# Angular
-/angular:generate-component UserProfile
-
-# Vue.js
-/vuejs:generate-component UserProfile
-
-# C# / .NET
-/csharp:generate-feature User
-
-# Laravel
-/laravel:generate-controller UserController
-
-# React Native
-/reactnative:generate-screen LoginScreen
+# Generar contexto
+/react:generate-context AuthContext
 ```
+
+### Usar Plantillas
+
+Las plantillas proporcionan patrones de código listos para usar. Accede a ellas con:
+
+```markdown
+Muéstrame la plantilla de servicio para Symfony
+```
+
+Plantillas disponibles por tecnología:
+
+| Symfony | Flutter | Python | React |
+|---------|---------|--------|-------|
+| service.md | bloc.md | service.md | component.md |
+| value-object.md | widget.md | repository.md | hook.md |
+| aggregate-root.md | screen.md | endpoint.md | context.md |
+| domain-event.md | state.md | model.md | reducer.md |
+| repository.md | cubit.md | schema.md | - |
+
+### Mejores Prácticas de Implementación
+
+1. **Un test a la vez**: Haz pasar un test antes de pasar al siguiente
+2. **Código mínimo**: Escribe solo el código necesario para pasar el test
+3. **Sin optimización prematura**: Concéntrate en la corrección primero
+4. **Seguir patrones existentes**: Usa plantillas y convenciones
+
+### Lista de Verificación de Implementación
+
+- [ ] Todos los tests unitarios pasando
+- [ ] Todos los tests de integración pasando
+- [ ] Todos los tests de API pasando
+- [ ] Sin valores codificados en duro
+- [ ] Manejo de errores implementado
+- [ ] Logging añadido
 
 ---
 
 ## Fase 5: Refactorización
 
+Con los tests pasando, mejora la calidad del código.
+
+### Comandos de Refactorización
+
 ```bash
+# Verificar calidad del código
 /symfony:check-code-quality
+/flutter:check-code-quality
+/python:check-code-quality
+/react:check-code-quality
+
+# Verificar cumplimiento de la arquitectura
 /symfony:check-architecture
+/flutter:check-architecture
 ```
 
+### Usar el Especialista en Refactorización
+
 ```markdown
-@refactoring-specialist Revisa esta clase de servicio para mejoras potenciales
+@refactoring-specialist Revisa esta clase de servicio para posibles mejoras
+
+[pega el código aquí]
 ```
+
+El especialista en refactorización hará lo siguiente:
+- Identificar malos olores de código (code smells)
+- Sugerir mejoras
+- Mostrar ejemplos refactorizados
+- Explicar las compensaciones (trade-offs)
+
+### Patrones Comunes de Refactorización
+
+1. **Extraer Método**: Dividir métodos largos en otros más pequeños
+2. **Extraer Clase**: Separar clases grandes
+3. **Introducir Value Object**: Reemplazar primitivos con tipos de dominio
+4. **Reemplazar Condicional con Polimorfismo**: Usar el patrón Strategy
+5. **Mover Método**: Colocar los métodos donde pertenecen
+
+### Lista de Verificación de Refactorización
+
+- [ ] Sin duplicación de código
+- [ ] Métodos de menos de 20 líneas
+- [ ] Clases de menos de 200 líneas
+- [ ] Nombres claros
+- [ ] Estilo consistente
+- [ ] Todos los tests siguen pasando
 
 ---
 
 ## Fase 6: Revisión
 
+Verificación de calidad final antes de la finalización.
+
+### Auditoría de Cumplimiento
+
 ```bash
-# Auditoría completa (puntuación /100)
+# Verificación de cumplimiento completa (devuelve puntuación /100)
 /symfony:check-compliance
+/flutter:check-compliance
+/python:check-compliance
+/react:check-compliance
 ```
 
+Esta auditoría completa verifica:
+- Cumplimiento de arquitectura
+- Calidad del código
+- Cobertura de tests
+- Problemas de seguridad
+- Documentación
+
+### Revisión de Código con Agentes
+
 ```markdown
-@symfony-reviewer Revisa mi implementación completa de autenticación de Usuario
+@symfony-reviewer Revisa mi implementación completa de autenticación de usuario
+
+Archivos modificados:
+- src/Domain/User/User.php
+- src/Application/Service/AuthenticationService.php
+- src/Infrastructure/Security/JwtTokenGenerator.php
+- tests/Unit/Domain/User/UserTest.php
+- tests/Integration/AuthenticationServiceTest.php
 ```
+
+El revisor hará lo siguiente:
+- Verificar el cumplimiento de la arquitectura
+- Identificar posibles problemas
+- Sugerir mejoras
+- Verificar las mejores prácticas
+
+### Auditoría de Seguridad
 
 ```bash
 /common:security-audit
 ```
 
----
+O usa el agente enfocado en seguridad:
 
-## Checklist de Funcionalidad
+```markdown
+@devops-engineer Revisa la seguridad del sistema de autenticación
 
-- [ ] User story definida
-- [ ] Tests escritos (TDD)
-- [ ] Código implementado
-- [ ] Tests pasan (80%+ cobertura)
-- [ ] Revisión efectuada
+Preocupaciones:
+- Seguridad del token JWT
+- Almacenamiento de contraseñas
+- Rate limiting
+- Configuración CORS
+```
+
+### Lista de Verificación de la Funcionalidad
+
+Usa la lista de verificación incorporada:
+
+```bash
+cat .claude/checklists/feature-checklist.md
+```
+
+Elementos clave:
+- [ ] Requisitos de la historia de usuario cumplidos
+- [ ] Todos los criterios de aceptación verificados
+- [ ] Tests escritos y pasando (cobertura ≥80%)
+- [ ] Código revisado
+- [ ] Auditoría de seguridad superada
 - [ ] Documentación actualizada
+- [ ] Sin problemas críticos en el análisis estático
+- [ ] Rendimiento aceptable
+- [ ] Listo para revisión de código
 
 ---
 
-## Resumen de Agentes
+## Ejemplo Completo
 
-| Agente | Uso |
-|--------|-----|
-| `@api-designer` | Diseño de endpoints API |
-| `@database-architect` | Diseño de esquemas BD |
+Veamos un ejemplo completo: Añadir registro de usuarios.
+
+### Paso 1: Analizar
+
+```markdown
+/common:analyze-feature "Registro de usuario con verificación de correo electrónico"
+
+Esperado:
+- El usuario envía email y contraseña
+- El sistema envía un correo de verificación
+- El usuario hace clic en el enlace para verificar
+- La cuenta se activa
+```
+
+### Paso 2: Diseñar la Base de Datos
+
+```markdown
+@database-architect Diseña el esquema para User con verificación de email
+
+Campos necesarios:
+- id, email, password_hash
+- email_verified_at (timestamp nullable)
+- verification_token
+- created_at, updated_at
+```
+
+### Paso 3: Diseñar la API
+
+```markdown
+@api-designer Diseña los endpoints de la API de registro
+
+POST /api/register - Crear cuenta
+POST /api/verify-email - Verificar email con token
+POST /api/resend-verification - Reenviar email de verificación
+```
+
+### Paso 4: Escribir los Tests
+
+```markdown
+@tdd-coach Ayúdame a escribir tests para UserRegistrationService
+
+Casos de prueba:
+1. El registro exitoso crea al usuario
+2. El email duplicado devuelve un error
+3. La contraseña débil devuelve un error
+4. Se envía el email de verificación
+5. El token de verificación activa la cuenta
+6. El token expirado devuelve un error
+```
+
+### Paso 5: Generar el Código
+
+```bash
+/symfony:generate-crud User --with-api
+/symfony:generate-command SendVerificationEmailCommand
+```
+
+### Paso 6: Implementar
+
+Haz pasar los tests uno a uno:
+
+```php
+// Hacer pasar el test 1
+public function register(string $email, string $password): User
+{
+    $user = User::create($email, $password);
+    $this->repository->save($user);
+    return $user;
+}
+
+// Hacer pasar el test 2
+public function register(string $email, string $password): User
+{
+    if ($this->repository->findByEmail($email)) {
+        throw new DuplicateEmailException($email);
+    }
+    // ...
+}
+
+// Continuar para cada test...
+```
+
+### Paso 7: Refactorizar
+
+```bash
+/symfony:check-code-quality
+```
+
+Corrige los problemas identificados.
+
+### Paso 8: Revisar
+
+```markdown
+@symfony-reviewer Revisa mi implementación de registro de usuarios
+
+Implementación completa que incluye:
+- Domain: entidad User, ValueObjects
+- Application: RegistrationService
+- Infrastructure: DoctrineUserRepository
+- API: RegisterController
+- Tests: Unitarios, Integración, API
+```
+
+### Paso 9: Verificación Final
+
+```bash
+/symfony:check-compliance
+```
+
+Objetivo: Puntuación ≥90/100
+
+---
+
+## Recursos Disponibles
+
+### Resumen de Agentes
+
+| Agente | Usar Para |
+|--------|----------|
+| `@api-designer` | Diseño de endpoints de API |
+| `@database-architect` | Diseño de esquema de base de datos |
 | `@tdd-coach` | Guía para escritura de tests |
 | `@refactoring-specialist` | Mejora de código |
 | `@{tech}-reviewer` | Revisión de código |
+| `@devops-engineer` | Revisión de infraestructura |
+| `@research-assistant` | Investigación de mejores prácticas |
+
+### Resumen de Comandos
+
+| Fase | Comandos |
+|------|----------|
+| Análisis | `/common:analyze-feature` |
+| Diseño | `/common:architecture-decision` |
+| Testing | `/{tech}:check-testing` |
+| Generación | `/{tech}:generate-*` |
+| Calidad | `/{tech}:check-code-quality` |
+| Revisión | `/{tech}:check-compliance` |
+| Seguridad | `/common:security-audit` |
+
+### Ubicación de Plantillas
+
+```bash
+ls .claude/templates/
+```
+
+### Ubicación de Listas de Verificación
+
+```bash
+ls .claude/checklists/
+```
 
 ---
 
-[&larr; Creación de Proyecto](02-project-creation.md) | [Corrección de Bugs &rarr;](04-bug-fixing.md)
+## Consejos para el Éxito
+
+1. **No omitas los tests**: Son tu red de seguridad
+2. **Usa los agentes**: Proporcionan orientación experta
+3. **Ejecuta verificaciones de cumplimiento frecuentemente**: Detecta problemas con anticipación
+4. **Sigue el flujo de trabajo**: Cada fase tiene un propósito
+5. **Documenta las decisiones**: Usa ADRs para elecciones importantes
+6. **Gestiona el contexto**: Usa `/context` para ver sugerencias de optimización, `/clear` entre fases
+7. **Ajusta el esfuerzo**: Usa `/effort high` para análisis/diseño, `/effort low` para generación de código
+
+---
+
+[&larr; Creación de Proyectos](02-project-creation.md) | [Corrección de Errores &rarr;](04-bug-fixing.md)

--- a/docs/guides/es/04-bug-fixing.md
+++ b/docs/guides/es/04-bug-fixing.md
@@ -1,14 +1,30 @@
 # Guía de Corrección de Bugs
 
-Enfoque sistemático para corregir bugs con Claude-Craft.
+Esta guía cubre el enfoque sistemático para corregir bugs usando Claude-Craft, desde el diagnóstico hasta la validación.
 
 ---
 
-## Flujo de Corrección
+## Tabla de Contenidos
+
+1. [Flujo de Trabajo para la Corrección de Bugs](#flujo-de-trabajo-para-la-corrección-de-bugs)
+2. [Fase 1: Reproducir](#fase-1-reproducir)
+3. [Fase 2: Diagnosticar](#fase-2-diagnosticar)
+4. [Fase 3: Escribir Test de Regresión](#fase-3-escribir-test-de-regresión)
+5. [Fase 4: Corregir](#fase-4-corregir)
+6. [Fase 5: Validar](#fase-5-validar)
+7. [Fase 6: Documentar](#fase-6-documentar)
+8. [Procedimientos de Hotfix](#procedimientos-de-hotfix)
+9. [Ejemplo Completo](#ejemplo-completo)
+
+---
+
+## Flujo de Trabajo para la Corrección de Bugs
+
+El enfoque sistemático para corregir bugs:
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ 1. Reproducir│ --> │2. Diagnosticar│ --> │  3. Test    │
+│ 1. Reproducir│ --> │2. Diagnosticar│ --> │  3. Test   │
 └─────────────┘     └─────────────┘     └─────────────┘
                                               │
                                               v
@@ -17,51 +33,232 @@ Enfoque sistemático para corregir bugs con Claude-Craft.
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
 
+### ¿Por Qué Este Enfoque?
+
+1. **Reproducir primero**: No se puede corregir lo que no se puede ver
+2. **Test antes de la corrección**: Prueba que el bug existe y que se ha corregido
+3. **Validar a fondo**: Garantiza que no hay regresión
+4. **Documentar**: Ayuda a prevenir bugs similares
+
 ---
 
 ## Fase 1: Reproducir
 
-- Recopilar información del reporte de bug
-- Crear entorno de reproducción
-- Verificar que el bug es consistente
+Antes de corregir, reproduce el bug de forma consistente.
+
+### Recopilar Información
+
+Recoge del informe de bug:
+- Pasos para reproducir
+- Comportamiento esperado
+- Comportamiento real
+- Entorno (versión, SO, etc.)
+- Mensajes de error/logs
+- Capturas de pantalla si aplica
+
+### Crear el Entorno de Reproducción
+
+```bash
+# Hacer checkout de la versión problemática
+git checkout <commit-o-tag>
+
+# Configurar un entorno idéntico
+make docker-up
+
+# Reproducir con los pasos exactos
+```
+
+### Verificar la Reproducción
+
+¿Puedes activar el bug de forma consistente?
+
+- [ ] El bug ocurre con los pasos reportados
+- [ ] El bug ocurre en el mismo entorno
+- [ ] El bug es determinístico (no aleatorio)
+
+### Si No Puedes Reproducirlo
+
+```markdown
+@research-assistant Ayúdame a entender por qué este bug podría ser específico del entorno
+
+Informe de bug:
+- El usuario ve el error X al hacer Y
+- No puedo reproducirlo localmente
+- El usuario está en el entorno Z
+
+¿Posibles causas?
+```
 
 ---
 
 ## Fase 2: Diagnosticar
 
+Encuentra la causa raíz del bug.
+
+### Usar el Comando de Análisis
+
 ```bash
-/common:analyze-bug "Los usuarios no pueden iniciar sesión después de restablecer contraseña"
+/common:analyze-bug "Los usuarios no pueden iniciar sesión con las credenciales correctas después de restablecer la contraseña"
 ```
+
+Este comando:
+1. Sugerirá áreas a investigar
+2. Identificará posibles causas
+3. Recomendará pasos de depuración
+4. Listará las áreas de código relacionadas
+
+### Usar el Entrenador TDD para el Diagnóstico
 
 ```markdown
 @tdd-coach Ayúdame a diagnosticar este bug de autenticación
+
+Síntomas:
+- El usuario restablece la contraseña con éxito
+- La nueva contraseña se guarda (confirmado en la BD)
+- El inicio de sesión falla con "credenciales inválidas"
+- La contraseña antigua tampoco funciona
+
+¿Qué debería investigar?
 ```
+
+### Técnicas de Depuración
+
+#### Añadir Logging
+
+```php
+// Logging de depuración temporal
+$this->logger->debug('Password verification', [
+    'user_id' => $user->getId(),
+    'stored_hash' => substr($user->getPasswordHash(), 0, 20) . '...',
+    'verification_result' => $result,
+]);
+```
+
+#### Inspeccionar el Estado de la Base de Datos
+
+```sql
+-- Comprobar el estado del usuario tras el restablecimiento de contraseña
+SELECT id, email, password_hash, updated_at
+FROM users
+WHERE email = 'user@example.com';
+```
+
+#### Rastrear la Ruta de Ejecución
+
+```php
+// Añadir traza de pila en puntos sospechosos
+debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+```
+
+### Identificar la Causa Raíz
+
+Categorías comunes:
+- **Error de lógica**: Condición o cálculo incorrecto
+- **Error de estado**: Estado de datos incorrecto
+- **Condición de carrera**: Comportamiento dependiente del tiempo
+- **Error de integración**: Problema con un servicio externo
+- **Error de configuración**: Configuración incorrecta
+
+### Lista de Verificación del Diagnóstico
+
+- [ ] Bug reproducido de forma consistente
+- [ ] Ubicación del error identificada
+- [ ] Causa raíz comprendida
+- [ ] Áreas de código relacionadas identificadas
+- [ ] Enfoque de corrección determinado
 
 ---
 
-## Fase 3: Test de Regresión
+## Fase 3: Escribir Test de Regresión
+
+Escribe un test que falle ANTES de la corrección y que pase DESPUÉS.
+
+### ¿Por Qué Hacer el Test Primero?
+
+1. **Prueba que el bug existe**: El test falla con el código actual
+2. **Prueba que la corrección funciona**: El test pasa después de la corrección
+3. **Previene regresiones**: El test detecta futuras roturas
+4. **Documenta el comportamiento**: El test describe el comportamiento esperado
+
+### Usar el Entrenador TDD
+
+```markdown
+@tdd-coach Ayúdame a escribir un test de regresión para este bug
+
+Bug: El restablecimiento de contraseña no actualiza el hash de contraseña correctamente
+
+Comportamiento esperado:
+- El usuario solicita el restablecimiento de contraseña
+- El usuario establece una nueva contraseña
+- El usuario puede iniciar sesión con la nueva contraseña
+
+Comportamiento real:
+- El inicio de sesión falla después del restablecimiento de contraseña
+```
+
+### Ejemplo de Test de Regresión
 
 ```php
 /**
  * @test
  * @see https://github.com/company/project/issues/123
  *
- * Bug: Los usuarios no podían iniciar sesión después de restablecer
+ * Bug: Los usuarios no podían iniciar sesión después del restablecimiento de contraseña
+ * Causa raíz: El hash de contraseña no se persistía correctamente
  */
 public function test_user_can_login_after_password_reset(): void
 {
+    // Arrange: Crear usuario con contraseña conocida
     $user = $this->createUser('user@example.com', 'old-password');
+
+    // Act: Restablecer contraseña
     $this->passwordResetService->resetPassword($user, 'new-password');
 
+    // Assert: Puede iniciar sesión con la nueva contraseña
     $result = $this->authService->authenticate('user@example.com', 'new-password');
 
     $this->assertTrue($result->isSuccess());
+    $this->assertNotNull($result->getToken());
+}
+
+/**
+ * @test
+ * Relacionado: Verificar que la contraseña antigua ya no funciona
+ */
+public function test_old_password_fails_after_reset(): void
+{
+    $user = $this->createUser('user@example.com', 'old-password');
+
+    $this->passwordResetService->resetPassword($user, 'new-password');
+
+    $result = $this->authService->authenticate('user@example.com', 'old-password');
+
+    $this->assertFalse($result->isSuccess());
 }
 ```
+
+### Lista de Verificación para Escribir el Test
+
+- [ ] El test reproduce el bug (falla antes de la corrección)
+- [ ] El test tiene un nombre descriptivo
+- [ ] El test hace referencia al número de incidencia
+- [ ] El test documenta la causa raíz en un comentario
+- [ ] Se testean los casos límite relacionados
 
 ---
 
 ## Fase 4: Corregir
+
+Implementa la corrección mínima para el bug.
+
+### Pautas para la Corrección
+
+1. **Cambio mínimo**: Corrige solo el bug, no refactorices
+2. **Intención clara**: El código debe mostrar qué era incorrecto
+3. **Sin efectos secundarios**: No cambies el comportamiento no relacionado
+4. **Mantener el estilo**: Seguir los patrones de código existentes
+
+### Ejemplo de Corrección
 
 ```php
 // ANTES (con bug)
@@ -82,66 +279,382 @@ public function resetPassword(User $user, string $newPassword): void
 }
 ```
 
+### Ejecutar el Test de Regresión
+
+```bash
+# El test debería pasar ahora
+make test-unit TEST=tests/Unit/PasswordResetTest.php
+
+# O ejecutar un test específico
+./vendor/bin/phpunit --filter test_user_can_login_after_password_reset
+```
+
+### Lista de Verificación de la Corrección
+
+- [ ] El test de regresión ahora pasa
+- [ ] La corrección es mínima y enfocada
+- [ ] No se incluyen cambios no relacionados
+- [ ] Se mantiene el estilo del código
+
 ---
 
 ## Fase 5: Validar
 
+Asegúrate de que la corrección no rompe nada más.
+
+### Ejecutar la Suite de Tests Completa
+
 ```bash
+# Todos los tests unitarios
+make test-unit
+
+# Todos los tests de integración
+make test-integration
+
+# Suite de tests completa
 make test
+```
+
+### Comprobaciones de Calidad
+
+```bash
+# Calidad del código (según tecnología)
+/symfony:check-code-quality
+/flutter:check-code-quality
+/python:check-code-quality
+
+# Seguridad (si la corrección toca código sensible)
+/common:security-audit
+
+# Cumplimiento completo
 /symfony:check-compliance
 ```
 
+### Pruebas Manuales
+
+Incluso con tests automatizados, verifica manualmente:
+
+1. Sigue los pasos originales de reproducción del bug
+2. Verifica que el bug ya no ocurre
+3. Prueba la funcionalidad relacionada
+4. Comprueba los casos límite
+
+### Usar el Agente Revisor
+
 ```markdown
-@symfony-reviewer Revisa mi corrección para el issue #123
+@symfony-reviewer Revisa mi corrección del bug del issue #123
+
+Bug: Los usuarios no podían iniciar sesión después del restablecimiento de contraseña
+Corrección: Añadidos los persist/flush faltantes en resetPassword()
+
+Archivos modificados:
+- src/Application/Service/PasswordResetService.php
+- tests/Unit/PasswordResetTest.php
+
+Por favor comprueba:
+1. La corrección es correcta y completa
+2. Sin efectos secundarios
+3. Cobertura de tests adecuada
 ```
+
+### Lista de Verificación de Validación
+
+- [ ] El test de regresión pasa
+- [ ] Todos los tests existentes pasan
+- [ ] El análisis estático pasa
+- [ ] Las pruebas manuales confirman la corrección
+- [ ] La revisión de código se ha completado
 
 ---
 
 ## Fase 6: Documentar
 
-```bash
-git commit -m "fix(auth): resolver fallo de inicio de sesión después de restablecimiento
+Documenta la corrección para referencia futura.
 
-Bug: Los usuarios no podían iniciar sesión después de restablecer
-Causa raíz: El hash no se persistía en la base de datos
-Corrección: Añadidos persist() y flush() en PasswordResetService
+### Formato del Mensaje de Commit
 
-Closes #123"
 ```
+fix(auth): resolver fallo de inicio de sesión tras restablecimiento de contraseña
+
+Bug: Los usuarios no podían iniciar sesión después de restablecer su contraseña
+Causa raíz: El cambio del hash de contraseña no se persistía en la base de datos
+Corrección: Añadidas las llamadas a persist() y flush() en PasswordResetService
+
+Closes #123
+
+Test: test_user_can_login_after_password_reset
+```
+
+### Actualizar el Rastreador de Incidencias
+
+```markdown
+## Resolución
+
+**Causa Raíz:**
+El método `resetPassword()` en `PasswordResetService` actualizaba el hash de
+contraseña del usuario en memoria pero no persistía el cambio en la base de datos.
+
+**Corrección:**
+Añadidas las llamadas a `persist()` y `flush()` después de establecer el nuevo
+hash de contraseña.
+
+**Testing:**
+- Añadido el test de regresión `test_user_can_login_after_password_reset`
+- Añadido el test de caso límite `test_old_password_fails_after_reset`
+
+**Prevención:**
+Considerar añadir un elemento de lista de verificación de revisión de código
+para las operaciones de persistencia.
+```
+
+### Entrada en la Base de Conocimiento (si es un patrón recurrente)
+
+```markdown
+# Bug Común: Cambios en Entidades No Persistidos
+
+## Síntomas
+- Los cambios de datos parecen funcionar (sin errores)
+- Los cambios no aparecen en la base de datos
+- Los cambios se pierden tras la actualización
+
+## Causa Raíz
+Faltan las llamadas a `persist()` y/o `flush()` en Doctrine.
+
+## Patrón de Corrección
+```php
+$entity->setSomething($value);
+$this->entityManager->persist($entity); // ¡No olvidar!
+$this->entityManager->flush();
+```
+
+## Prevención
+- Añadir comprobación de persistencia a la lista de revisión de código
+- Considerar el auto-flush en la clase base de servicio
+```
+
+### Lista de Verificación de Documentación
+
+- [ ] El mensaje de commit describe el bug y la corrección
+- [ ] El rastreador de incidencias actualizado con la resolución
+- [ ] La documentación relacionada actualizada
+- [ ] Entrada en la base de conocimiento si es un patrón
 
 ---
 
-## Procedimiento Hotfix
+## Procedimientos de Hotfix
+
+Para bugs críticos en producción.
+
+### Flujo de Trabajo de Hotfix
+
+```
+1. Crear rama de hotfix desde producción
+2. Aplicar la corrección mínima
+3. Testear a fondo
+4. Desplegar a producción
+5. Fusionar de vuelta a main
+```
+
+### Paso a Paso
 
 ```bash
-# 1. Crear rama hotfix
+# 1. Crear rama de hotfix
 git checkout production
-git checkout -b hotfix/issue-123
+git checkout -b hotfix/issue-123-login-failure
 
-# 2. Aplicar corrección y test
+# 2. Aplicar la corrección
+# ... hacer cambios ...
 
-# 3. Verificar
+# 3. Escribir test de regresión
+# ... añadir test ...
+
+# 4. Verificar
 make test
 /symfony:check-compliance
 
-# 4. Crear PR
-gh pr create --base production --title "HOTFIX: Fallo de inicio de sesión"
+# 5. Commit con mensaje claro
+git commit -m "fix(auth): resolver fallo crítico de inicio de sesión tras restablecimiento de contraseña
 
-# 5. Después de merge, mergear a main
+HOTFIX para incidencia de producción.
+Causa raíz: Hash de contraseña no persistido tras el restablecimiento.
+
+Closes #123"
+
+# 6. Crear PR para revisión
+gh pr create --base production --title "HOTFIX: Fallo de inicio de sesión tras restablecimiento de contraseña"
+
+# 7. Tras la fusión, desplegar
+# ... proceso de despliegue ...
+
+# 8. Fusionar de vuelta a main
 git checkout main
-git merge hotfix/issue-123
+git merge hotfix/issue-123-login-failure
+git push origin main
+```
+
+### Lista de Verificación de Hotfix
+
+- [ ] Rama de hotfix desde producción
+- [ ] Corrección mínima y enfocada únicamente
+- [ ] Test de regresión añadido
+- [ ] Todos los tests pasando
+- [ ] PR revisada y aprobada
+- [ ] Desplegado a producción
+- [ ] Verificado en producción
+- [ ] Fusionado de vuelta a main
+
+---
+
+## Ejemplo Completo
+
+Veamos la corrección de un bug real.
+
+### Informe de Bug
+
+```
+Incidencia #456: Total del pedido calculado incorrectamente
+
+Pasos para reproducir:
+1. Añadir artículo con precio $10.00, cantidad 3
+2. Añadir artículo con precio $5.50, cantidad 2
+3. Ver el carrito
+
+Esperado: Total = $41.00 (30 + 11)
+Real: Total = $36.00
+
+Entorno: Producción v2.3.1
+Reportado por: Soporte al cliente
+Prioridad: Alta
+```
+
+### Paso 1: Reproducir
+
+```php
+// Test local rápido
+$order = new Order();
+$order->addItem(new Item('A', 10.00), 3);  // $30
+$order->addItem(new Item('B', 5.50), 2);   // $11
+echo $order->getTotal(); // Muestra 36.00 - ¡confirmado!
+```
+
+### Paso 2: Diagnosticar
+
+```markdown
+@tdd-coach Ayúdame a encontrar el bug en el cálculo del total del pedido
+
+El total debería ser 41.00 pero muestra 36.00
+La diferencia es 5.00, que es exactamente el precio de uno de los artículos B
+
+Hipótesis: ¿la cantidad del segundo artículo no se está contando?
+```
+
+La investigación revela:
+
+```php
+// Bug encontrado en Order::calculateTotal()
+public function calculateTotal(): Money
+{
+    $total = Money::zero();
+    foreach ($this->items as $item) {
+        // BUG: ¡Usando 1 en lugar de la cantidad del artículo!
+        $total = $total->add($item->getPrice()->multiply(1));
+    }
+    return $total;
+}
+```
+
+### Paso 3: Escribir Test de Regresión
+
+```php
+/**
+ * @test
+ * @see https://github.com/company/shop/issues/456
+ *
+ * Bug: El total del pedido ignoraba las cantidades de los artículos
+ */
+public function test_order_total_includes_all_quantities(): void
+{
+    $order = new Order();
+    $order->addItem($this->createItem(10.00), 3);  // $30
+    $order->addItem($this->createItem(5.50), 2);   // $11
+
+    $total = $order->calculateTotal();
+
+    $this->assertEquals(41.00, $total->getAmount());
+}
+
+/**
+ * @test
+ * Caso límite: artículo único con cantidad > 1
+ */
+public function test_single_item_quantity_multiplied(): void
+{
+    $order = new Order();
+    $order->addItem($this->createItem(10.00), 5);
+
+    $this->assertEquals(50.00, $order->calculateTotal()->getAmount());
+}
+```
+
+Ejecutar el test: confirma que falla.
+
+### Paso 4: Corregir
+
+```php
+public function calculateTotal(): Money
+{
+    $total = Money::zero();
+    foreach ($this->items as $item) {
+        // Corregido: Usar la cantidad real del artículo del pedido
+        $total = $total->add(
+            $item->getPrice()->multiply($item->getQuantity())
+        );
+    }
+    return $total;
+}
+```
+
+### Paso 5: Validar
+
+```bash
+# El test de regresión pasa
+./vendor/bin/phpunit --filter test_order_total
+
+# Todos los tests pasan
+make test
+
+# Comprobación de calidad
+/symfony:check-compliance
+# Puntuación: 94/100 ✓
+```
+
+### Paso 6: Documentar
+
+```bash
+git commit -m "fix(order): corregir el cálculo del total para incluir las cantidades
+
+Bug: El total del pedido ignoraba las cantidades de los artículos, usando siempre 1
+Causa raíz: multiply(1) codificado en lugar de multiply(quantity)
+Corrección: Usar getQuantity() del artículo del pedido en el cálculo
+
+Closes #456
+
+Tests de regresión añadidos:
+- test_order_total_includes_all_quantities
+- test_single_item_quantity_multiplied"
 ```
 
 ---
 
-## Checklist de Corrección
+## Consejos para la Prevención de Bugs
 
-- [ ] Bug reproducido localmente
-- [ ] Test de regresión escrito (falla)
-- [ ] Código corregido
-- [ ] Test pasa
-- [ ] Sin regresiones
-- [ ] Commit con referencia a issue
+1. **Escribir tests primero**: El TDD previene muchos bugs
+2. **Revisión de código**: Los ojos frescos detectan problemas
+3. **Análisis estático**: Las herramientas encuentran errores comunes
+4. **Tests de integración**: Detectan bugs de interacción
+5. **Monitorear producción**: Detectar problemas a tiempo
+6. **Usar `/loop`**: Configurar comprobaciones de calidad recurrentes (p. ej., `/loop 5m /common:pre-commit-check`)
+7. **Guardar aprendizajes**: Usar `/memory` para persistir patrones de bugs entre sesiones
 
 ---
 

--- a/docs/guides/es/05-tools-reference.md
+++ b/docs/guides/es/05-tools-reference.md
@@ -1,41 +1,370 @@
-# Referencia de Herramientas
+# Guía de Referencia de Herramientas
 
-Guía de las herramientas utilitarias incluidas con Claude-Craft.
+Esta guía cubre las herramientas utilitarias incluidas con Claude-Craft para gestionar perfiles, visualización de estado, configuración de proyectos, y los comandos y funcionalidades de Claude Code (v8.7).
+
+---
+
+## Tabla de Contenidos
+
+1. [Comandos de Claude Code](#comandos-de-claude-code)
+2. [Eventos de Hook](#eventos-de-hook)
+3. [Frontmatter de Agentes](#frontmatter-de-agentes)
+4. [Búsqueda de Herramientas MCP](#búsqueda-de-herramientas-mcp)
+5. [Modo Auto](#modo-auto)
+6. [Plantillas de Hook](#plantillas-de-hook)
+7. [Configuración Administrada](#configuración-administrada)
+8. [Gestor MultiAccount](#gestor-multiaccount)
+9. [StatusLine](#statusline)
+10. [Gestor ProjectConfig](#gestor-projectconfig)
+11. [Instalación](#instalación)
+
+---
+
+## Comandos de Claude Code
+
+Claude Code proporciona comandos integrados para la gestión del contexto y las sesiones. Están disponibles en cualquier sesión de Claude Code (v2.1.47+).
+
+### Comandos de Gestión del Contexto
+
+| Comando | Versión | Descripción |
+|---------|---------|-------------|
+| `/clear` | Todas | Limpiar el contexto entre tareas no relacionadas |
+| `/compact` | Todas | Compactar el contexto de forma proactiva (ejecutar al ~70% de uso) |
+| `/context` | v2.1.74+ | Obtener sugerencias accionables para optimizar el contexto |
+| `/effort low\|medium\|high` | v2.1.72+ | Ajustar el esfuerzo de razonamiento del modelo según la complejidad de la tarea |
+| `/memory` | v2.1.59+ | Guardar aprendizajes persistentes entre sesiones y compactaciones |
+| `/model haiku\|sonnet\|opus` | v2.1.72+ | Cambiar de modelo a mitad de sesión según la complejidad de la tarea |
+
+### Comandos de Sesión
+
+| Comando | Versión | Descripción |
+|---------|---------|-------------|
+| `/loop [intervalo] [comando]` | v2.1.71+ | Ejecutar tareas recurrentes (p. ej., `/loop 5m /common:pre-commit-check`) |
+| `/proactive` | v2.1.105+ | Alias para `/loop` |
+| `/color` | v2.1.94+ | Cambiar el esquema de colores del terminal |
+| `/rename` | v2.1.94+ | Renombrar la sesión actual |
+| `/powerup` | v2.1.94+ | Activar funcionalidades adicionales |
+
+### Ejemplos de Uso
+
+```bash
+# Ajustar el esfuerzo para una búsqueda sencilla
+/effort low
+
+# Cambiar a un modelo más económico para exploración
+/model sonnet
+
+# Configurar monitoreo recurrente de CI
+/loop 5m "Check if CI pipeline passed"
+
+# Guardar contexto importante antes de la compactación
+/memory "Authentication uses JWT with RS256, refresh tokens in HttpOnly cookies"
+```
+
+---
+
+## Eventos de Hook
+
+Claude Code soporta 24 eventos de hook (8 añadidos en versiones recientes de Claude Code) para automatizar flujos de trabajo:
+
+### Todos los Eventos de Hook
+
+| Evento | Momento | Caso de Uso |
+|--------|---------|-------------|
+| **PreToolUse** | Antes de ejecutar la herramienta | Bloquear comandos peligrosos, reescribir con RTK |
+| **PostToolUse** | Después de ejecutar la herramienta | Filtrar salida verbosa, resumir resultados |
+| **PreCompact** | Antes de la compactación del contexto | Guardar contexto crítico; el código de salida 2 bloquea la compactación (v2.1.105+) |
+| **PostCompact** | Después de la compactación del contexto | Re-inyectar contexto esencial |
+| **SessionStart** | Al iniciar la sesión | Cargar elementos esenciales del contexto, configurar el entorno |
+| **StopFailure** | En parada inesperada | Guardar estado, alertar sobre fallos |
+| **Notification** | En eventos de notificación | Alertas personalizadas |
+| **TaskCreated** | Cuando se crea una tarea de sub-agente | Rastrear el trabajo de sub-agentes |
+| **CwdChanged** | Cambio del directorio de trabajo | Actualizar el entorno según el directorio |
+| **FileChanged** | Modificación de archivo detectada | Activar reconstrucciones, linting |
+| **PermissionDenied** | Fallo en la comprobación de permisos | Registrar eventos de seguridad |
+| **Elicitation** | Antes del prompt del usuario | Personalizar el flujo de elicitación |
+| **ElicitationResult** | Después de la respuesta del usuario | Procesar los resultados de elicitación |
+| **Stop** | Al detener la sesión | Limpieza |
+
+### Mejoras de Hook (v8.7)
+
+| Funcionalidad | Descripción |
+|---------------|-------------|
+| **`if` condicional** | Ejecutar hooks solo cuando la condición coincide |
+| **`defer`** | Diferir la ejecución del hook para evitar bloqueos |
+| **Bloqueo PreCompact** | El código de salida 2 en el hook PreCompact bloquea la compactación (v2.1.105+) |
+
+### Ejemplo: Filtro de Salida PostToolUse
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "echo '$TOOL_OUTPUT' | head -100"
+      }]
+    }]
+  }
+}
+```
+
+---
+
+## Frontmatter de Agentes
+
+Los agentes personalizados (v2.1.78+) soportan campos frontmatter para controlar el comportamiento y el coste:
+
+```yaml
+---
+effort: low          # Esfuerzo de razonamiento (low/medium/high)
+maxTurns: 10         # Número máximo de turnos de conversación
+disallowedTools:     # Herramientas que el agente no puede usar
+  - Edit
+  - Write
+---
+```
+
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| `effort` | string | Esfuerzo de razonamiento `low`, `medium` o `high` |
+| `maxTurns` | number | Número máximo de turnos antes de detenerse |
+| `disallowedTools` | lista | Herramientas que el agente no tiene permitido usar |
+
+Esto es útil para crear agentes de exploración económicos que pueden leer pero no modificar código.
+
+---
+
+## Búsqueda de Herramientas MCP
+
+La Búsqueda de Herramientas MCP (v2.1.80+) permite la carga diferida de herramientas MCP, reduciendo el consumo de contexto en un 95%:
+
+| Enfoque | Coste de Contexto |
+|---------|-------------------|
+| MCP clásico (todas las herramientas cargadas) | ~500-2000 tokens/herramienta/turno |
+| MCP con Búsqueda de Herramientas (diferida) | ~50 tokens en total |
+
+### Uso
+
+```bash
+# Cargar una herramienta específica bajo demanda
+ToolSearch with query: "select:tool_name"
+
+# Buscar por palabra clave
+ToolSearch with query: "slack send"
+```
+
+En lugar de cargar todas las herramientas del servidor MCP al iniciar, la Búsqueda de Herramientas las carga solo cuando se necesitan.
+
+---
+
+## Modo Auto
+
+El Modo Auto (v2.1.94+) es un clasificador de permisos basado en IA que reemplaza `--dangerously-skip-permissions` de forma más segura:
+
+| Modo | Protección | Velocidad | Caso de Uso |
+|------|-----------|-----------|-------------|
+| Manual | Máxima | Lenta | Flujos de trabajo auditados, alta seguridad |
+| Modo Auto | Alta | Rápida | Flujos de trabajo de desarrollo confiables |
+| Omitir Permisos | Mínima | Máxima | Solo proyectos locales/personales |
+
+**Funcionalidades de seguridad:**
+- Un modelo de seguridad en segundo plano evalúa cada llamada a herramienta
+- Las operaciones seguras (lecturas, pruebas) se aprueban automáticamente
+- Las acciones de riesgo (eliminación masiva, exfiltración) se bloquean
+- 3 bloqueos consecutivos revierten al modo manual
+- Más de 20 bloqueos en una sesión revierten al modo manual completo
+
+Disponible para planes Team con aprobación de administrador.
+
+---
+
+## Plantillas de Hook
+
+Claude-Craft proporciona plantillas de hook listas para usar en `.claude/templates/hooks/`:
+
+| Plantilla | Propósito |
+|-----------|-----------|
+| `output-filter.json` | Filtro PostToolUse para salidas grandes de CLI |
+| `pre-compact.json` | Hook PreCompact para preservar el contexto crítico |
+| `context-reinject.json` | Hook SessionStart para re-inyección de contexto después de la compactación |
+
+### Instalación
+
+Copia las plantillas al archivo `.claude/settings.json` de tu proyecto o combínalas en tu configuración de hooks:
+
+```bash
+# Ver plantillas disponibles
+ls .claude/templates/hooks/
+
+# Aplicar a tu proyecto (combinar manualmente en settings.json)
+cat .claude/templates/hooks/output-filter.json
+```
+
+---
+
+## Configuración Administrada
+
+El directorio `managed-settings.d/` (v2.1.83+) permite la configuración modular mediante combinación en orden alfabético:
+
+```
+.claude/
+  managed-settings.d/
+    00-base.json          # Configuración base
+    10-security.json      # Reglas de seguridad
+    20-team.json          # Preferencias del equipo
+```
+
+Los archivos se combinan en orden alfabético, lo que permite a los equipos superponer configuraciones sin conflictos.
 
 ---
 
 ## Gestor MultiAccount
 
-Gestiona múltiples perfiles de Claude Code.
+Gestiona múltiples perfiles de Claude Code para diferentes cuentas o contextos.
+
+### Propósito
+
+- Cambiar entre cuentas de Claude (personal, trabajo, cliente)
+- Gestionar los límites de velocidad cambiando de perfil
+- Mantener los contextos de proyecto aislados
+- Compartir o aislar configuraciones
 
 ### Instalación
+
 ```bash
+# Mediante Makefile
 make install-multiaccount
+
+# O manualmente
+cp Tools/MultiAccount/claude-accounts.sh ~/.local/bin/
+chmod +x ~/.local/bin/claude-accounts.sh
 ```
 
-### Uso Interactivo
+### Uso
+
+#### Modo Interactivo
+
 ```bash
+# Lanzar el menú interactivo
 ./claude-accounts.sh
+# O si está instalado globalmente
+claude-accounts.sh
 ```
 
-### Modo CLI
+Opciones del menú:
+```
+1. Listar perfiles
+2. Añadir un perfil
+3. Eliminar un perfil
+4. Autenticar un perfil
+5. Lanzar Claude Code
+6. Instalar la función ccsp()
+7. Migrar perfil heredado
+8. Ayuda
+9. Salir
+```
+
+#### Modo CLI
+
 ```bash
-./claude-accounts.sh list              # Listar perfiles
-./claude-accounts.sh add <nombre>      # Añadir perfil
-./claude-accounts.sh remove <nombre>   # Eliminar perfil
-./claude-accounts.sh auth <nombre>     # Autenticar perfil
-./claude-accounts.sh launch <nombre>   # Lanzar Claude con perfil
+# Listar todos los perfiles
+./claude-accounts.sh list
+
+# Añadir nuevo perfil
+./claude-accounts.sh add <nombre-de-perfil>
+
+# Eliminar perfil
+./claude-accounts.sh remove <nombre-de-perfil>
+
+# Autenticar perfil
+./claude-accounts.sh auth <nombre-de-perfil>
+
+# Lanzar Claude Code con perfil
+./claude-accounts.sh launch <nombre-de-perfil>
+
+# Mostrar ayuda
+./claude-accounts.sh --help
 ```
 
 ### Modos de Perfil
-- **shared**: Comparte configuración con `~/.claude`
-- **isolated**: Configuración independiente
 
-### Función ccsp()
+#### Modo Compartido (Predeterminado)
+
+El perfil comparte la configuración con `~/.claude` principal:
+
 ```bash
-ccsp           # Listar perfiles
-ccsp trabajo   # Cambiar a perfil "trabajo"
-claude         # Lanzar con perfil actual
+./claude-accounts.sh add trabajo --mode=shared
+```
+
+- La configuración está vinculada simbólicamente a `~/.claude`
+- Adecuado para: cambiar entre cuentas manteniendo la configuración
+- Caso de uso: Gestión de límites de velocidad
+
+#### Modo Aislado
+
+El perfil tiene una configuración completamente independiente:
+
+```bash
+./claude-accounts.sh add cliente-a --mode=isolated
+```
+
+- Copia independiente de la configuración
+- Adecuado para: trabajo con clientes con reglas separadas
+- Caso de uso: Diferentes configuraciones de proyecto
+
+### Cambio Rápido de Perfil
+
+Instala la función de shell `ccsp()`:
+
+```bash
+# Añadir al perfil mediante la opción 6 del menú
+# O añadir manualmente a ~/.bashrc o ~/.zshrc:
+
+ccsp() {
+    if [ -z "$1" ]; then
+        claude-accounts.sh list
+    else
+        export CLAUDE_CONFIG_DIR="$HOME/.claude-profiles/$1"
+        echo "Switched to profile: $1"
+    fi
+}
+```
+
+Uso:
+```bash
+# Listar perfiles
+ccsp
+
+# Cambiar a un perfil
+ccsp trabajo
+
+# Lanzar Claude Code (usa el perfil actual)
+claude
+```
+
+### Estructura de Perfiles
+
+```
+~/.claude-profiles/
+├── trabajo/
+│   ├── .mode              # "shared" o "isolated"
+│   ├── config/            # Configuración de Claude
+│   └── settings.json      # Configuración del perfil
+├── cliente-a/
+│   └── ...
+└── personal/
+    └── ...
+```
+
+### Soporte de Idiomas
+
+```bash
+# Usar en un idioma específico
+./claude-accounts.sh --lang=fr list
+./claude-accounts.sh --lang=es add trabajo
+./claude-accounts.sh --lang=de --help
 ```
 
 ---
@@ -44,60 +373,345 @@ claude         # Lanzar con perfil actual
 
 Muestra información contextual en la barra de estado de Claude Code.
 
+### Propósito
+
+- Mostrar el perfil actual
+- Visualizar el modelo en uso
+- Mostrar la rama y el estado de git
+- Rastrear el porcentaje de uso del contexto
+- Monitorear los costes de sesión y semanales
+- Mostrar los límites de uso
+
 ### Instalación
+
 ```bash
+# Mediante Makefile
 make install-statusline
+
+# O manualmente
+cp Tools/StatusLine/statusline.sh ~/.claude/statusline.sh
+cp Tools/StatusLine/statusline.conf.example ~/.claude/statusline.conf
+chmod +x ~/.claude/statusline.sh
 ```
 
-### Formato
-```
-🔑 pro | 🧠 Opus | 🌿 main +2~1 | 📁 proyecto | 📊 45% | ⏱️ 5h: 23% | 📅 Sem: 45% | 💰 $0.42 | 🕐 14:32
+### Configurar Claude Code
+
+Añadir a `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  }
+}
 ```
 
-### Configuración (`~/.claude/statusline.conf`)
+### Formato de la Línea de Estado
+
+```
+🔑 pro | 🧠 Opus | 🌿 main +2~1 | 📁 my-project | 📊 45% | ⏱️ 5h: 23% | 📅 Sem: 45% | 💰 $0.42 | 🕐 14:32
+```
+
+| Elemento | Descripción |
+|----------|-------------|
+| 🔑 pro | Nombre del perfil activo |
+| 🧠 Opus | Modelo actual (🧠 Opus, 🎵 Sonnet, 🍃 Haiku) |
+| 🌿 main +2~1 | Rama de git + estado (+staged ~modificado ?sin-seguimiento) |
+| 📁 my-project | Nombre del directorio del proyecto |
+| 📊 45% | Uso de la ventana de contexto |
+| ⏱️ 5h: 23% | Porcentaje de uso de la sesión (5h) |
+| 📅 Sem: 45% | Porcentaje de uso semanal |
+| 💰 $0.42 | Coste de la sesión |
+| 🕐 14:32 | Hora actual |
+
+### Código de Colores
+
+Los indicadores de uso cambian de color según los umbrales:
+
+| Color | Significado | Umbral |
+|-------|-------------|--------|
+| Verde | Uso bajo | < 60% |
+| Amarillo | Uso moderado | 60-80% |
+| Rojo | Uso alto | > 80% |
+
+### Configuración
+
+Editar `~/.claude/statusline.conf`:
+
 ```bash
-SESSION_COST_LIMIT=500.00    # Límite sesión (Max 20x)
-WEEKLY_COST_LIMIT=3000.00    # Límite semanal
-USAGE_WARN_THRESHOLD=60      # Amarillo a 60%
-USAGE_CRIT_THRESHOLD=80      # Rojo a 80%
+# =============================================================================
+# LÍMITES DE USO
+# =============================================================================
+# Valores recomendados por plan:
+#   - Pro ($20/mes)        : SESSION=25,   WEEKLY=150
+#   - Max 5x ($100/mes)   : SESSION=125,  WEEKLY=750
+#   - Max 20x ($200/mes)  : SESSION=500,  WEEKLY=3000
+
+SESSION_COST_LIMIT=500.00
+WEEKLY_COST_LIMIT=3000.00
+
+# =============================================================================
+# UMBRALES DE ALERTA (porcentaje)
+# =============================================================================
+USAGE_WARN_THRESHOLD=60    # Amarillo al 60%
+USAGE_CRIT_THRESHOLD=80    # Rojo al 80%
+
+# =============================================================================
+# CACHÉ (rendimiento)
+# =============================================================================
+SESSION_CACHE_TTL=60       # Refresco de sesión cada 60s
+WEEKLY_CACHE_TTL=300       # Refresco semanal cada 5min
+
+# =============================================================================
+# OPCIONES DE VISUALIZACIÓN
+# =============================================================================
+SHOW_SESSION_LIMIT=true
+SHOW_WEEKLY_LIMIT=true
+
+# Etiquetas personalizadas
+SESSION_LABEL="⏱️ 5h"
+WEEKLY_LABEL="📅 Sem"
 ```
 
 ### Dependencias
+
 ```bash
-brew install jq   # Requerido
-npm install -g ccusage  # Opcional
+# Requerido: jq (procesador JSON)
+# macOS
+brew install jq
+
+# Linux
+sudo apt install jq
+
+# Opcional: ccusage (seguimiento de costes)
+npm install -g ccusage
+```
+
+### Solución de Problemas
+
+**La línea de estado no se muestra:**
+```bash
+# Verificar que el script es ejecutable
+ls -la ~/.claude/statusline.sh
+
+# Probar manualmente
+echo '{"model":{"display_name":"Test"}}' | ~/.claude/statusline.sh
+```
+
+**El coste muestra $0.00:**
+```bash
+# Verificar que ccusage funciona
+npx ccusage daily --json
+```
+
+**Los porcentajes de uso no se muestran:**
+```bash
+# Comprobar los archivos de caché
+ls -la /tmp/.ccusage_*
+
+# Limpiar caché para refrescar
+rm /tmp/.ccusage_*
 ```
 
 ---
 
 ## Gestor ProjectConfig
 
-Gestiona configuraciones de proyecto Claude-Craft via YAML.
+Gestiona las configuraciones de proyecto de Claude-Craft mediante YAML.
+
+### Propósito
+
+- Definir la configuración del proyecto en YAML
+- Gestionar múltiples proyectos
+- Manejar configuraciones de monorepo
+- Validar configuraciones
+- Instalar reglas desde la configuración
 
 ### Instalación
-```bash
-make install-projectconfig
-```
 
-### Modo CLI
 ```bash
-./claude-projects.sh list                  # Listar proyectos
-./claude-projects.sh validate              # Validar config
-./claude-projects.sh install <nombre>      # Instalar proyecto
-./claude-projects.sh install-all           # Instalar todos
+# Mediante Makefile
+make install-projectconfig
+
+# O manualmente
+cp Tools/ProjectConfig/claude-projects.sh ~/.local/bin/
+chmod +x ~/.local/bin/claude-projects.sh
 ```
 
 ### Dependencias
+
 ```bash
-brew install yq  # Requerido
+# Requerido: yq (procesador YAML)
+# macOS
+brew install yq
+
+# Linux (snap)
+sudo snap install yq
+
+# Linux (binario)
+wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+chmod +x /usr/local/bin/yq
+```
+
+### Uso
+
+#### Modo Interactivo
+
+```bash
+./claude-projects.sh
+```
+
+Opciones del menú:
+```
+1. Listar proyectos
+2. Añadir un proyecto
+3. Editar un proyecto
+4. Añadir un módulo
+5. Eliminar un proyecto
+6. Validar configuración
+7. Instalar proyecto
+8. Ayuda
+9. Salir
+```
+
+#### Modo CLI
+
+```bash
+# Listar proyectos configurados
+./claude-projects.sh list
+
+# Validar el archivo de configuración
+./claude-projects.sh validate [archivo-de-config]
+
+# Instalar un proyecto específico
+./claude-projects.sh install <nombre-de-proyecto>
+
+# Instalar todos los proyectos
+./claude-projects.sh install-all
+
+# Mostrar los detalles del proyecto
+./claude-projects.sh show <nombre-de-proyecto>
+
+# Añadir nuevo proyecto
+./claude-projects.sh add <nombre-de-proyecto> <ruta>
+
+# Eliminar proyecto
+./claude-projects.sh remove <nombre-de-proyecto>
+```
+
+### Archivo de Configuración
+
+Ubicación predeterminada: `./claude-projects.yaml`
+
+```yaml
+settings:
+  default_lang: "fr"
+
+projects:
+  - name: "my-saas"
+    description: "Plataforma SaaS"
+    path: "~/Projects/my-saas"
+    modules:
+      - name: "api"
+        path: "backend"
+        technologies: ["symfony"]
+      - name: "web"
+        path: "frontend"
+        technologies: ["react"]
+      - name: "mobile"
+        path: "app"
+        technologies: ["flutter"]
+
+  - name: "internal-tool"
+    path: "~/Projects/internal"
+    technologies: ["python"]
+    lang: "en"
+```
+
+### Validación
+
+```bash
+# Validar la configuración
+./claude-projects.sh validate
+
+# O mediante Makefile
+make config-validate CONFIG=claude-projects.yaml
+```
+
+Las comprobaciones de validación incluyen:
+- Sintaxis YAML válida
+- Campos requeridos presentes
+- Rutas existentes
+- Tecnologías válidas
+- Idiomas válidos
+
+### Instalación desde Configuración
+
+```bash
+# Instalar un proyecto individual
+./claude-projects.sh install my-saas
+
+# O mediante Makefile
+make config-install CONFIG=claude-projects.yaml PROJECT=my-saas
+
+# Instalar todos los proyectos
+make config-install-all CONFIG=claude-projects.yaml
+
+# Simulacro (dry run)
+make config-install CONFIG=claude-projects.yaml PROJECT=my-saas OPTIONS="--dry-run"
+```
+
+### Soporte de Idiomas
+
+```bash
+# Usar en un idioma específico
+./claude-projects.sh --lang=fr list
+./claude-projects.sh --lang=de validate
 ```
 
 ---
 
-## Instalar Todas las Herramientas
+## Instalación
+
+### Instalar Todas las Herramientas
 
 ```bash
 make install-tools
+```
+
+Esto instala:
+- Gestor MultiAccount
+- StatusLine
+- Gestor ProjectConfig
+
+### Instalar Herramientas Individualmente
+
+```bash
+# Solo MultiAccount
+make install-multiaccount
+
+# Solo StatusLine
+make install-statusline
+
+# Solo ProjectConfig
+make install-projectconfig
+```
+
+### Verificar la Instalación
+
+```bash
+# Comprobar MultiAccount
+which claude-accounts.sh
+claude-accounts.sh --version
+
+# Comprobar StatusLine
+ls ~/.claude/statusline.sh
+cat ~/.claude/settings.json | jq '.statusLine'
+
+# Comprobar ProjectConfig
+which claude-projects.sh
+claude-projects.sh --version
 ```
 
 ---
@@ -105,24 +719,43 @@ make install-tools
 ## Referencia Rápida
 
 ### Comandos MultiAccount
+
 | Comando | Descripción |
 |---------|-------------|
-| `list` | Mostrar perfiles |
-| `add <nombre>` | Crear perfil |
+| `list` | Mostrar todos los perfiles |
+| `add <nombre>` | Crear nuevo perfil |
 | `remove <nombre>` | Eliminar perfil |
-| `launch <nombre>` | Iniciar Claude |
+| `auth <nombre>` | Autenticar perfil |
+| `launch <nombre>` | Iniciar Claude con el perfil |
+| `migrate` | Convertir perfil heredado |
 
-### Elementos StatusLine
+### Elementos de StatusLine
+
 | Emoji | Significado |
 |-------|-------------|
 | 🔑 | Perfil |
-| 🧠/🎵/🍃 | Modelo (Opus/Sonnet/Haiku) |
-| 🌿 | Rama Git |
+| 🧠 | Modelo Opus |
+| 🎵 | Modelo Sonnet |
+| 🍃 | Modelo Haiku |
+| 🌿 | Rama de git |
 | 📁 | Proyecto |
-| 📊 | Contexto % |
-| ⏱️ | Uso sesión |
+| 📊 | % de contexto |
+| ⏱️ | Uso de sesión |
 | 📅 | Uso semanal |
 | 💰 | Coste |
+| 🕐 | Hora |
+
+### Comandos ProjectConfig
+
+| Comando | Descripción |
+|---------|-------------|
+| `list` | Mostrar todos los proyectos |
+| `validate` | Comprobar la validez de la configuración |
+| `install <nombre>` | Instalar reglas del proyecto |
+| `install-all` | Instalar todos los proyectos |
+| `show <nombre>` | Mostrar los detalles del proyecto |
+| `add <nombre> <ruta>` | Añadir nuevo proyecto |
+| `remove <nombre>` | Eliminar proyecto |
 
 ---
 

--- a/docs/guides/es/06-troubleshooting.md
+++ b/docs/guides/es/06-troubleshooting.md
@@ -1,138 +1,695 @@
 # Guía de Solución de Problemas
 
-Problemas comunes y sus soluciones al usar Claude-Craft.
+Esta guía cubre los problemas más comunes y sus soluciones al usar Claude-Craft.
+
+---
+
+## Tabla de Contenidos
+
+1. [Problemas de Instalación](#problemas-de-instalación)
+2. [Problemas de Agentes](#problemas-de-agentes)
+3. [Problemas de Comandos](#problemas-de-comandos)
+4. [Problemas de Configuración](#problemas-de-configuración)
+5. [Problemas de Herramientas](#problemas-de-herramientas)
+6. [Problemas de Rendimiento](#problemas-de-rendimiento)
+7. [Obtener Ayuda](#obtener-ayuda)
 
 ---
 
 ## Problemas de Instalación
 
-### Comandos No Reconocidos
-**Soluciones:**
-1. Reiniciar Claude Code (`exit` + `claude`)
-2. Verificar instalación: `ls -la .claude/commands/`
-3. Verificar formato de archivos de comandos
+### Comandos No Reconocidos Tras la Instalación
 
-### Archivos No Encontrados
-**Soluciones:**
-1. Verificar ruta de Claude-Craft: `pwd && ls Dev/scripts/`
-2. Verificar archivos de idioma: `ls Dev/i18n/es/`
-3. Usar ruta TARGET absoluta
+**Síntomas:**
+- Los comandos de barra diagonal como `/symfony:check-compliance` no funcionan
+- Claude no reconoce los comandos instalados
 
-### Errores de Permisos
-```bash
-chmod +x Dev/scripts/*.sh
-chmod +x Tools/*/*.sh
-```
+**Soluciones:**
+
+1. **Reiniciar Claude Code**
+   ```bash
+   # Salir de Claude Code completamente
+   exit
+
+   # Iniciar de nuevo
+   claude
+   ```
+
+2. **Verificar la instalación**
+   ```bash
+   ls -la .claude/commands/
+   # Debería mostrar los directorios de comandos
+   ```
+
+3. **Comprobar el formato del archivo de comandos**
+   ```bash
+   head -5 .claude/commands/symfony/check-compliance.md
+   # Debería comenzar con la cabecera markdown adecuada
+   ```
+
+### Archivos No Encontrados Durante la Instalación
+
+**Síntomas:**
+- Errores de "Archivo fuente no encontrado"
+- Faltan reglas o plantillas
+
+**Soluciones:**
+
+1. **Verificar la ruta de Claude-Craft**
+   ```bash
+   # Comprobar que se ejecuta desde el directorio claude-craft
+   pwd
+   ls -la Dev/scripts/
+   ```
+
+2. **Comprobar que existen los archivos de idioma**
+   ```bash
+   ls -la Dev/i18n/en/Symfony/rules/
+   ```
+
+3. **Usar ruta TARGET absoluta**
+   ```bash
+   # En lugar de
+   make install-symfony TARGET=./backend
+
+   # Usar
+   make install-symfony TARGET=/ruta/completa/al/backend
+   ```
+
+### Errores de Permiso Denegado
+
+**Síntomas:**
+- No se pueden ejecutar los scripts de instalación
+- No se puede escribir en el directorio de destino
+
+**Soluciones:**
+
+1. **Hacer los scripts ejecutables**
+   ```bash
+   chmod +x Dev/scripts/*.sh
+   chmod +x Project/*.sh
+   chmod +x Infra/*.sh
+   chmod +x Tools/*/*.sh
+   ```
+
+2. **Comprobar los permisos del directorio de destino**
+   ```bash
+   ls -la ~/my-project/
+   # Asegurarse de tener permisos de escritura
+   ```
+
+3. **Ejecutar con el usuario adecuado**
+   ```bash
+   # No usar sudo a menos que sea necesario
+   # Comprobar la propiedad del directorio
+   ls -la ~/my-project
+   ```
+
+### La Instalación Crea un Directorio Vacío
+
+**Síntomas:**
+- El directorio `.claude/` se crea pero está vacío o faltan archivos
+
+**Soluciones:**
+
+1. **Comprobar errores en la salida**
+   ```bash
+   # Ejecutar con salida detallada
+   make install-symfony TARGET=./backend 2>&1 | tee install.log
+   ```
+
+2. **Verificar que existe la fuente**
+   ```bash
+   ls -la Dev/i18n/en/Symfony/
+   ```
+
+3. **Intentar la ejecución directa del script**
+   ```bash
+   ./Dev/scripts/install-symfony-rules.sh --lang=en ./backend
+   ```
 
 ---
 
 ## Problemas de Agentes
 
 ### Agente No Disponible
-1. Verificar archivos: `ls .claude/agents/`
-2. Verificar formato frontmatter
-3. Reinstalar: `make install-common TARGET=. OPTIONS="--force"`
 
-### Respuestas Irrelevantes
-1. Proporcionar más contexto en la solicitud
-2. Ser específico en la petición
-3. Verificar `00-project-context.md`
+**Síntomas:**
+- `@api-designer` u otros agentes no responden
+- Errores del tipo "agente desconocido"
+
+**Soluciones:**
+
+1. **Verificar que existen los archivos de agente**
+   ```bash
+   ls -la .claude/agents/
+   # Debería listar los archivos .md de agentes
+   ```
+
+2. **Comprobar el formato del archivo de agente**
+   ```bash
+   head -20 .claude/agents/api-designer.md
+   # Debería tener el frontmatter adecuado con nombre y descripción
+   ```
+
+3. **Reinstalar los agentes**
+   ```bash
+   make install-common TARGET=. OPTIONS="--force"
+   ```
+
+### El Agente Da Respuestas Irrelevantes
+
+**Síntomas:**
+- El agente no sigue sus instrucciones especializadas
+- Respuestas genéricas en lugar de consejos de experto
+
+**Soluciones:**
+
+1. **Proporcionar más contexto**
+   ```markdown
+   @symfony-reviewer Revisa mi implementación de UserService
+
+   Contexto:
+   - Symfony 7 con API Platform
+   - Clean Architecture
+   - Enfoque DDD
+
+   Código a revisar:
+   [pegar código aquí]
+   ```
+
+2. **Ser específico en la petición**
+   ```markdown
+   # En lugar de
+   @database-architect Ayuda con mi base de datos
+
+   # Usar
+   @database-architect Diseña el esquema para el agregado User con:
+   - Entidad User (id, email, password_hash)
+   - Entidad Role (muchos-a-muchos con User)
+   - Entidad Permission (muchos-a-muchos con Role)
+   - Historial de auditoría para cambios de usuario
+   ```
+
+3. **Comprobar el archivo de contexto del proyecto**
+   ```bash
+   cat .claude/rules/00-project-context.md
+   # Asegurarse de que describe el proyecto con precisión
+   ```
+
+### El Agente Entra en Conflicto con las Reglas del Proyecto
+
+**Síntomas:**
+- Las sugerencias del agente contradicen las convenciones del proyecto
+- Consejos inconsistentes
+
+**Soluciones:**
+
+1. **Actualizar el contexto del proyecto**
+   - Añadir convenciones específicas a `00-project-context.md`
+   - Incluir preferencias y restricciones del equipo
+
+2. **Ser explícito en las peticiones**
+   ```markdown
+   @api-designer Diseña el endpoint siguiendo nuestras convenciones RESTful
+   (ver 00-project-context.md para nuestros estándares de API)
+   ```
 
 ---
 
 ## Problemas de Comandos
 
 ### Comando No Encontrado
-1. Verificar directorio: `ls .claude/commands/symfony/`
-2. Verificar namespace correcto
-3. Listar comandos: `/help`
 
-### Errores de Ejecución
-1. Verificar prerrequisitos
-2. Revisar archivo de comando
-3. Proporcionar parámetros requeridos
+**Síntomas:**
+- `/symfony:generate-crud` devuelve "comando desconocido"
+- Las sugerencias de comandos no aparecen
+
+**Soluciones:**
+
+1. **Comprobar el directorio de comandos**
+   ```bash
+   ls .claude/commands/symfony/
+   # Debería incluir generate-crud.md
+   ```
+
+2. **Verificar el espacio de nombres**
+   ```bash
+   # Los comandos tienen el formato: /{espacio-de-nombres}:{comando}
+   # Espacios de nombres disponibles:
+   ls .claude/commands/
+   # common/, symfony/, flutter/, python/, react/, reactnative/, docker/
+   ```
+
+3. **Listar los comandos disponibles**
+   ```bash
+   # En Claude Code, escribe:
+   /help
+   ```
+
+### Errores de Ejecución de Comandos
+
+**Síntomas:**
+- El comando empieza pero falla
+- Salida o errores inesperados
+
+**Soluciones:**
+
+1. **Comprobar los requisitos previos**
+   - Algunos comandos requieren herramientas específicas
+   - Verificar que las dependencias requeridas están instaladas
+
+2. **Revisar el archivo de comandos**
+   ```bash
+   cat .claude/commands/symfony/generate-crud.md
+   # Entender qué espera el comando
+   ```
+
+3. **Proporcionar los parámetros requeridos**
+   ```bash
+   # En lugar de
+   /symfony:generate-crud
+
+   # Usar
+   /symfony:generate-crud User --with-api --with-tests
+   ```
+
+### Salida de Comandos Incorrecta
+
+**Síntomas:**
+- El código generado no coincide con el estilo del proyecto
+- Se usan patrones de tecnología incorrectos
+
+**Soluciones:**
+
+1. **Actualizar el contexto del proyecto**
+   ```bash
+   # Editar .claude/rules/00-project-context.md
+   # Añadir patrones y convenciones específicos
+   ```
+
+2. **Personalizar las plantillas**
+   ```bash
+   # Editar las plantillas en .claude/templates/
+   # Ajustar para que coincida con el estilo de tu proyecto
+   ```
 
 ---
 
 ## Problemas de Configuración
 
-### YAML Inválido
-```bash
-yq e '.' claude-projects.yaml  # Validar sintaxis
-make config-validate CONFIG=claude-projects.yaml
-```
+### Configuración YAML Inválida
 
-### Proyecto No Encontrado
-1. Verificar ortografía del nombre (sensible a mayúsculas)
-2. Verificar ruta del archivo de configuración
+**Síntomas:**
+- `make config-validate` falla
+- Errores de sintaxis en la configuración
+
+**Soluciones:**
+
+1. **Comprobar la sintaxis YAML**
+   ```bash
+   # Validar YAML
+   yq e '.' claude-projects.yaml
+   ```
+
+2. **Errores YAML comunes:**
+   ```yaml
+   # Incorrecto: indentación inconsistente
+   projects:
+     - name: "project"
+       path: "/path"  # 2 espacios
+        technologies: ["symfony"]  # 3 espacios - ¡ERROR!
+
+   # Correcto: indentación consistente
+   projects:
+     - name: "project"
+       path: "/path"
+       technologies: ["symfony"]
+   ```
+
+3. **Validar con la herramienta**
+   ```bash
+   make config-validate CONFIG=claude-projects.yaml
+   ```
+
+### Proyecto No Encontrado en la Configuración
+
+**Síntomas:**
+- "Proyecto no encontrado" al instalar
+- El proyecto no aparece en la lista
+
+**Soluciones:**
+
+1. **Comprobar la ortografía del nombre del proyecto**
+   ```bash
+   # Listar proyectos
+   make config-list CONFIG=claude-projects.yaml
+
+   # Los nombres distinguen mayúsculas de minúsculas
+   ```
+
+2. **Verificar la ruta del archivo de configuración**
+   ```bash
+   # Por defecto busca claude-projects.yaml en el directorio actual
+   # Especificar explícitamente:
+   make config-install CONFIG=/ruta/a/config.yaml PROJECT=myproject
+   ```
+
+### La Configuración No Se Aplica
+
+**Síntomas:**
+- Los cambios en la configuración no surten efecto
+- La configuración antigua persiste
+
+**Soluciones:**
+
+1. **Reinstalar con fuerza**
+   ```bash
+   make config-install CONFIG=claude-projects.yaml PROJECT=myproject OPTIONS="--force"
+   ```
+
+2. **Comprobar conflictos**
+   ```bash
+   # Eliminar la instalación existente
+   rm -rf /ruta/al/proyecto/.claude
+
+   # Reinstalar
+   make config-install CONFIG=claude-projects.yaml PROJECT=myproject
+   ```
 
 ---
 
 ## Problemas de Herramientas
 
 ### StatusLine No Se Muestra
-```bash
-ls -la ~/.claude/statusline.sh  # Verificar instalación
-echo '{"model":{"display_name":"Test"}}' | ~/.claude/statusline.sh  # Test
-```
+
+**Síntomas:**
+- La barra de estado está vacía o muestra la configuración predeterminada
+- La línea de estado personalizada no se muestra
+
+**Soluciones:**
+
+1. **Verificar que el script está instalado**
+   ```bash
+   ls -la ~/.claude/statusline.sh
+   # Debe existir y ser ejecutable
+   ```
+
+2. **Comprobar settings.json**
+   ```bash
+   cat ~/.claude/settings.json | jq '.statusLine'
+   # Debería mostrar:
+   # {
+   #   "type": "command",
+   #   "command": "~/.claude/statusline.sh"
+   # }
+   ```
+
+3. **Probar el script manualmente**
+   ```bash
+   echo '{"model":{"display_name":"Test","id":"claude-opus"}}' | ~/.claude/statusline.sh
+   # Debería producir una línea de estado formateada
+   ```
+
+4. **Comprobar que jq está instalado**
+   ```bash
+   which jq
+   # Instalar si no está: brew install jq / apt install jq
+   ```
 
 ### Problemas de Perfil MultiAccount
+
+**Síntomas:**
+- No se puede cambiar de perfil
+- El perfil no se reconoce
+
+**Soluciones:**
+
+1. **Listar los perfiles**
+   ```bash
+   ./claude-accounts.sh list
+   ```
+
+2. **Comprobar el directorio de perfiles**
+   ```bash
+   ls -la ~/.claude-profiles/
+   # Debería contener los directorios de perfiles
+   ```
+
+3. **Verificar el archivo de modo del perfil**
+   ```bash
+   cat ~/.claude-profiles/miperfil/.mode
+   # Debería contener "shared" o "isolated"
+   ```
+
+4. **Recrear el perfil problemático**
+   ```bash
+   ./claude-accounts.sh remove miperfil
+   ./claude-accounts.sh add miperfil --mode=shared
+   ```
+
+### Errores de yq en ProjectConfig
+
+**Síntomas:**
+- "yq: command not found"
+- Errores de análisis de YAML
+
+**Soluciones:**
+
+1. **Instalar yq**
+   ```bash
+   # macOS
+   brew install yq
+
+   # Linux
+   sudo snap install yq
+   # o
+   sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+   sudo chmod +x /usr/local/bin/yq
+   ```
+
+2. **Verificar la versión de yq**
+   ```bash
+   yq --version
+   # Debe ser v4.x (mikefarah/yq, no kislyuk/yq)
+   ```
+
+---
+
+## Problemas de Hooks
+
+### El Hook No Se Dispara
+
+**Síntomas:**
+- Los hooks PreToolUse/PostToolUse no se ejecutan
+- No hay salida de los comandos del hook
+
+**Soluciones:**
+
+1. **Verificar la configuración del hook en settings.json**
+   ```bash
+   cat .claude/settings.json | jq '.hooks'
+   ```
+
+2. **Comprobar la sintaxis del matcher**
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [{
+         "matcher": "Bash",
+         "hooks": [{"type": "command", "command": "echo test"}]
+       }]
+     }
+   }
+   ```
+   El `matcher` debe coincidir exactamente con el nombre de la herramienta (p. ej., `Bash`, `Edit`, `Write`).
+
+3. **Probar el comando del hook de forma independiente**
+   ```bash
+   # Ejecutar el comando del hook manualmente para verificar que funciona
+   bash -c 'echo test'
+   ```
+
+### Bloqueo del Hook PreCompact
+
+**Síntomas:**
+- La compactación del contexto no ocurre cuando se espera
+- La compactación parece atascada
+
+**Solución:** Los hooks PreCompact (v2.1.105+) pueden bloquear la compactación con el código de salida 2. Comprueba tus hooks:
 ```bash
-./claude-accounts.sh list
-ls -la ~/.claude-profiles/
+cat .claude/settings.json | jq '.hooks.PreCompact'
+# Asegurarse de que los scripts de hook no devuelven accidentalmente el código de salida 2
 ```
 
-### Errores yq
-```bash
-# Instalar yq v4.x (mikefarah/yq)
-brew install yq  # macOS
-sudo snap install yq  # Linux
-yq --version  # Verificar versión
-```
+### Errores de Sandbox
+
+**Síntomas:**
+- Errores de "Sandbox unavailable"
+- Problemas de permisos en subprocesos
+
+**Soluciones:**
+
+1. **Comprobar la versión de Claude Code** (el sandboxing requiere v2.1.98+)
+   ```bash
+   claude --version
+   ```
+
+2. **En Linux, verificar el soporte de espacio de nombres PID**
+   ```bash
+   # Comprobar si unshare está disponible
+   which unshare
+   ```
+
+3. **Deshabilitar el sandbox estricto si es necesario** (no recomendado por seguridad)
+   - Eliminar `sandbox.failIfUnavailable` de la configuración si se añadió
+
+### Fallos de Hooks Relacionados con Seguridad
+
+Si se usan servidores MCP con hooks, asegurarse de tener Claude Code v2.1.97+ para evitar CVEs conocidas:
+- CVE-2025-59536: Inyección de comandos a través de entradas MCP en el pipeline de hooks
+- CVE-2026-35020: Bypass de comandos compuestos
+- CVE-2026-35022: Inyección de prefijo de variables de entorno
 
 ---
 
 ## Problemas de Rendimiento
 
-### Ejecución Lenta
-1. Ajustar TTL de caché en `statusline.conf`
-2. Limpiar cachés: `rm /tmp/.ccusage_*`
-3. Verificar conexión de red
+### Ejecución Lenta de Comandos
 
-### Alto Uso de Contexto
-1. Usar `/compact` para compactar el contexto proactivamente
-2. Usar `/clear` entre tareas no relacionadas
-3. Usar `/effort low` para tareas simples (reduce consumo de tokens)
-4. Usar `/context` para obtener sugerencias de optimización
-5. Configurar RTK para ahorro de tokens del 60-90% (`/common:setup-rtk`)
-6. Delegar investigaciones a sub-agentes
+**Síntomas:**
+- Los comandos tardan mucho en responder
+- StatusLine se actualiza lentamente
+
+**Soluciones:**
+
+1. **Comprobar la configuración de caché**
+   ```bash
+   # En ~/.claude/statusline.conf
+   SESSION_CACHE_TTL=60   # Reducir si es demasiado lento
+   WEEKLY_CACHE_TTL=300   # Reducir si es demasiado lento
+   ```
+
+2. **Limpiar las cachés**
+   ```bash
+   rm /tmp/.ccusage_*
+   ```
+
+3. **Comprobar la red**
+   - Algunas funcionalidades requieren red (ccusage)
+   - Red lenta = actualizaciones lentas
+
+### Alto Uso de la Ventana de Contexto
+
+**Síntomas:**
+- El indicador de contexto muestra un porcentaje alto rápidamente
+- Advertencias de "límite de contexto"
+
+**Soluciones:**
+
+1. **Usar `/context` para sugerencias de optimización** (v2.1.74+)
+   ```bash
+   /context
+   ```
+
+2. **Ajustar el nivel de esfuerzo** para tareas sencillas (v2.1.72+)
+   ```bash
+   /effort low    # Búsquedas simples
+   /effort medium # Trabajo estándar
+   ```
+
+3. **Compactar de forma proactiva** al ~70% de uso
+   ```bash
+   /compact
+   ```
+
+4. **Usar `/clear` entre tareas no relacionadas**
+
+5. **Guardar aprendizajes clave** antes de la compactación
+   ```bash
+   /memory "Importante: auth usa JWT RS256 con expiración de 15min"
+   ```
+
+6. **Configurar RTK** para un ahorro de tokens del 55-65%
+   ```bash
+   /common:setup-rtk
+   ```
+
+7. **Usar agentes para tareas complejas**
+   ```markdown
+   # En lugar de pegar todo el código base
+   @research-assistant Busca todos los archivos relacionados con autenticación en src/
+   ```
 
 ---
 
 ## Obtener Ayuda
 
-### Documentación
-- `docs/AGENTS.md` - Referencia de agentes
-- `docs/COMMANDS.md` - Referencia de comandos
-- `docs/TECHNOLOGIES.md` - Guía de tecnologías
+### Consultar la Documentación
 
-### Versiones
+1. **Documentación principal**: directorio `docs/`
+2. **Referencia de agentes**: `docs/AGENTS.md`
+3. **Referencia de comandos**: `docs/COMMANDS.md`
+4. **Guía de tecnologías**: `docs/TECHNOLOGIES.md`
+
+### Obtener Información de Versión
+
 ```bash
+# Scripts de instalación
 ./Dev/scripts/install-symfony-rules.sh --version
+
+# Herramientas
 ./Tools/MultiAccount/claude-accounts.sh --version
+./Tools/ProjectConfig/claude-projects.sh --version
+```
+
+### Reportar Incidencias
+
+Si encuentras bugs:
+
+1. Recopilar información:
+   - Versión de Claude-Craft
+   - Sistema operativo
+   - Pasos para reproducir
+   - Mensajes de error
+
+2. Comprobar las incidencias existentes en GitHub
+
+3. Crear una nueva incidencia con los detalles
+
+### Pedir Ayuda
+
+```markdown
+@research-assistant Tengo problemas con [describe el problema]
+
+Entorno:
+- SO: [tu SO]
+- Versión de Claude-Craft: [versión]
+- Tecnología: [symfony/flutter/etc.]
+
+Lo que intenté:
+1. [paso 1]
+2. [paso 2]
+
+Mensaje de error:
+[pegar el error]
 ```
 
 ---
 
-## Checklist de Correcciones Rápidas
+## Lista de Verificación de Correcciones Rápidas
+
+Cuando algo no funciona:
 
 - [ ] Reiniciar Claude Code
-- [ ] Verificar instalación (`ls .claude/`)
-- [ ] Verificar permisos de archivos
-- [ ] Validar configuración
-- [ ] Limpiar cachés
-- [ ] Verificar dependencias (jq, yq)
-- [ ] Intentar reinstalación con `--force`
+- [ ] Verificar la instalación (`ls .claude/`)
+- [ ] Comprobar los permisos de archivos
+- [ ] Validar la configuración
+- [ ] Limpiar las cachés
+- [ ] Comprobar las dependencias (jq, yq)
+- [ ] Intentar la reinstalación con `--force`
+- [ ] Consultar la documentación
+- [ ] Pedir ayuda
 
 ---
 

--- a/docs/guides/es/07-backlog-management.md
+++ b/docs/guides/es/07-backlog-management.md
@@ -1,24 +1,35 @@
-# Guia de Gestion del Backlog
+# Guía de Gestión del Backlog
 
 Flujo de trabajo completo para crear y gestionar un backlog SCRUM con Claude-Craft.
 
 ---
 
-## Vision General
+## Visión General
 
-Claude-Craft proporciona un conjunto completo de comandos para gestionar tu product backlog siguiendo la metodologia SCRUM:
+Claude-Craft proporciona un conjunto completo de comandos para gestionar tu product backlog siguiendo la metodología SCRUM:
 
 - **15 comandos slash** para operaciones de backlog
 - **5 plantillas** para estructura consistente
-- **Vertical slicing** obligatorio en todas las capas
-- **Validacion INVEST** para User Stories
+- **Vertical slicing** obligatorio en todas las capas tecnológicas
+- **Validación del modelo INVEST** para las User Stories
+
+### Filosofía
+
+Basada en:
+- Principios del Manifiesto Ágil
+- Los 12 Principios Ágiles
+- Fundamentos de SCRUM
+- Vertical slicing (cada US atraviesa todas las capas)
 
 ---
 
-## Generacion Inicial del Backlog
+## Generación Inicial del Backlog
+
+### Desde Especificaciones
+
+Coloca las especificaciones de tu proyecto en `./docs/` y luego ejecuta:
 
 ```bash
-# Desde especificaciones en ./docs/
 /project:generate-backlog symfony+flutter
 ```
 
@@ -26,175 +37,299 @@ Claude-Craft proporciona un conjunto completo de comandos para gestionar tu prod
 
 ```
 project-management/
-├── README.md                    # Vision general del proyecto
-├── personas.md                  # Personas (min. 3)
-├── definition-of-done.md        # Niveles DoD progresivos
+├── README.md                    # Visión general del proyecto
+├── personas.md                  # Personas de usuario (mín. 3)
+├── definition-of-done.md        # Niveles de DoD progresivos
+├── dependencies-matrix.md       # Dependencias entre EPICs y US
 ├── backlog/
-│   ├── epics/                   # EPIC-XXX-nombre.md
-│   └── user-stories/            # US-XXX-nombre.md
+│   ├── epics/                   # Archivos EPIC-XXX-nombre.md
+│   └── user-stories/            # Archivos US-XXX-nombre.md
 └── sprints/
-    └── sprint-XXX-objetivo/
+    └── sprint-XXX-objetivo/     # Planes de sprint
 ```
 
 ---
 
 ## Estructura SCRUM
 
-### Personas (minimo 3)
-- Identidad, objetivos, frustraciones
-- Formato: P-001, P-002...
+### Personas
+
+Se requieren mínimo 3 personas, cada una con:
+- **Identidad**: Nombre, rol, datos demográficos
+- **Objetivos**: Lo que quieren lograr
+- **Frustraciones**: Puntos de dolor que resolver
+
+Formato: `P-001`, `P-002`, `P-003`...
 
 ### EPICs
-- ID unico (EPIC-XXX)
-- MMF (Minimum Marketable Feature)
-- Objetivos de negocio y criterios de exito
 
-### User Stories (modelo INVEST)
+Funcionalidades grandes que contienen múltiples User Stories:
 
-| Letra | Significado |
+| Campo | Descripción |
 |-------|-------------|
-| **I** | Independent - Sin dependencias |
-| **N** | Negotiable - Detalles negociables |
-| **V** | Valuable - Valor para el usuario |
-| **E** | Estimable - Puede estimarse |
-| **S** | Sized - Max 8 puntos |
-| **T** | Testable - Criterios claros |
+| ID | Identificador único (EPIC-001, EPIC-002...) |
+| MMF | Minimum Marketable Feature |
+| Estado | Draft, Ready, In Progress, Done |
+| Objetivos de Negocio | Por qué este EPIC es importante |
+| Criterios de Éxito | Cómo medir el éxito |
 
-#### Criterios de Aceptacion (Gherkin)
-- 1 escenario nominal
+### User Stories
+
+Siguen el modelo **INVEST**:
+
+| Letra | Significado | Validación |
+|-------|-------------|------------|
+| **I** | Independent (Independiente) | Sin dependencias de otras US |
+| **N** | Negotiable (Negociable) | Los detalles pueden discutirse |
+| **V** | Valuable (Valiosa) | Aporta valor al usuario |
+| **E** | Estimable | Puede dimensionarse en puntos |
+| **S** | Sized (Dimensionada) | Máx. 8 story points |
+| **T** | Testable (Verificable) | Tiene criterios de aceptación claros |
+
+#### Las 3 C
+
+1. **Card (Tarjeta)**: Descripción breve
+2. **Conversation (Conversación)**: Detalles de la discusión
+3. **Confirmation (Confirmación)**: Criterios de aceptación
+
+#### Criterios de Aceptación (Gherkin)
+
+Cada US requiere:
+- 1 escenario nominal (happy path)
 - 2 escenarios alternativos
 - 2 escenarios de error
 
-### Tasks (Tareas)
+```gherkin
+Scenario: El usuario inicia sesión correctamente
+  Given un usuario registrado con credenciales válidas
+  When envía el formulario de inicio de sesión
+  Then debería ver su panel de control
+  And se debería crear una sesión
+```
 
-| Tipo | Descripcion |
-|------|-------------|
-| `[DB]` | Base de datos |
-| `[BE]` | Backend |
-| `[FE-WEB]` | Frontend Web |
-| `[FE-MOB]` | Frontend Mobile |
-| `[TEST]` | Testing |
-| `[DOC]` | Documentacion |
-| `[OPS]` | DevOps |
-| `[REV]` | Code review |
+### Tareas
+
+Elementos de trabajo técnico dentro de una User Story:
+
+| Tipo | Descripción | Duración Típica |
+|------|-------------|-----------------|
+| `[DB]` | Base de datos (entidades, migraciones) | 1-3h |
+| `[BE]` | Backend (servicios, APIs) | 2-4h |
+| `[FE-WEB]` | Frontend Web (controladores, plantillas) | 2-4h |
+| `[FE-MOB]` | Frontend Móvil (pantallas, blocs) | 3-5h |
+| `[TEST]` | Testing (unitario, integración, E2E) | 2-4h |
+| `[DOC]` | Documentación | 0.5-1h |
+| `[OPS]` | DevOps (CI/CD, despliegue) | 1-2h |
+| `[REV]` | Revisión de código | 1-2h |
+
+**Reglas de estimación:**
+- Duración de tarea: 0.5h - 8h máx.
+- Story points (Fibonacci): 1, 2, 3, 5, 8, 13, 21
+- Tamaño máx. de US: 8 puntos (dividir si es mayor)
 
 ---
 
 ## Flujo de Trabajo
 
+### Flujo de Estados
+
 ```
-To Do ──→ In Progress ──→ Done
-   │            │
-   └────→ Blocked ←────┘
+┌─────────┐     ┌─────────────┐     ┌──────┐
+│  To Do  │ ──→ │ In Progress │ ──→ │ Done │
+└─────────┘     └─────────────┘     └──────┘
+     │                │
+     │                ↓
+     └────────→ ┌─────────┐
+                │ Blocked │
+                └─────────┘
+                     │
+                     ↓
+              ┌─────────────┐
+              │ In Progress │
+              └─────────────┘
 ```
+
+**Transiciones prohibidas:**
+- To Do → Done (debe pasar por In Progress)
+- Cualquier estado → To Do (excepto reapertura manual)
 
 ---
 
 ## Referencia de Comandos
 
-### Comandos de Creacion
+### Comandos de Creación
 
-| Comando | Descripcion |
+| Comando | Descripción |
 |---------|-------------|
-| `/project:generate-backlog [stack]` | Generar backlog desde specs |
-| `/project:add-epic` | Crear nuevo EPIC |
-| `/project:add-story` | Agregar User Story |
-| `/project:add-task` | Crear tarea tecnica |
+| `/project:generate-backlog [stack]` | Generar backlog completo desde specs |
+| `/project:add-epic` | Crear un nuevo EPIC |
+| `/project:add-story` | Añadir una User Story a un EPIC |
+| `/project:add-task` | Crear una tarea técnica para una US |
 
-### Comandos de Visualizacion
+### Comandos de Visualización
 
-| Comando | Descripcion |
+| Comando | Descripción |
 |---------|-------------|
-| `/project:list-epics` | Listar EPICs |
-| `/project:list-stories` | Listar User Stories |
-| `/project:list-tasks` | Listar tareas |
-| `/project:board` | Tablero Kanban |
-| `/sprint:status` | Estado del sprint |
+| `/project:list-epics` | Mostrar todos los EPICs con su estado |
+| `/project:list-stories [filtro]` | Listar User Stories (por EPIC, Sprint, Estado) |
+| `/project:list-tasks [filtro]` | Listar tareas (por US, Sprint, Tipo, Estado) |
+| `/project:board [sprint]` | Mostrar tablero Kanban |
+| `/sprint:status [sprint]` | Informe detallado de progreso del sprint |
 
-### Comandos de Actualizacion
+### Comandos de Actualización
 
-| Comando | Descripcion |
+| Comando | Descripción |
 |---------|-------------|
-| `/sprint:transition` | Cambiar estado/sprint de US |
-| `/project:move-task` | Cambiar estado de tarea |
-| `/project:update-epic` | Modificar EPIC |
-| `/project:update-story` | Modificar User Story |
+| `/sprint:transition [id] [estado/sprint]` | Cambiar estado de US o asignarla a un sprint |
+| `/project:move-task [id] [estado]` | Cambiar estado de una tarea |
+| `/project:update-epic [id]` | Modificar un EPIC existente |
+| `/project:update-story [id]` | Modificar una User Story existente |
 
 ### Comandos Avanzados
 
-| Comando | Descripcion |
+| Comando | Descripción |
 |---------|-------------|
-| `/project:decompose-tasks` | Descomponer US en tareas |
-| `/gate:validate-backlog` | Auditar calidad SCRUM |
+| `/project:decompose-tasks [sprint]` | Descomponer las US del sprint en tareas |
+| `/gate:validate-backlog` | Auditar la calidad del backlog (conformidad SCRUM) |
 
 ---
 
-## Ejemplo Completo
+## Ejemplo Completo: Proyecto Nuevo
 
-```markdown
-## Paso 1: Generar backlog inicial
+### Paso 1: Generar el Backlog Inicial
+
+```bash
+# Asegúrate de que las specs estén en ./docs/
 /project:generate-backlog symfony+flutter
-
-## Paso 2: Validar calidad
-/gate:validate-backlog
-
-## Paso 3: Ver Sprint 1
-/project:board 1
-
-## Paso 4: Descomponer en tareas
-/project:decompose-tasks 1
-
-## Paso 5: Comenzar trabajo
-/project:move-task TASK-001 in-progress
 ```
 
+### Paso 2: Validar la Calidad
+
+```bash
+/gate:validate-backlog
+```
+
+Esto genera `scrum-validation-report.md` con:
+- Puntuación de conformidad INVEST
+- Verificación de las 3 C
+- Análisis de criterios SMART
+- Consistencia de estimaciones
+
+### Paso 3: Revisar el Sprint 1
+
+```bash
+/project:board 1
+```
+
+Muestra el tablero Kanban con columnas:
+- To Do | In Progress | In Review | Done | Blocked
+
+### Paso 4: Descomponer en Tareas
+
+```bash
+/project:decompose-tasks 1
+```
+
+Crea un desglose detallado de tareas:
+- Tareas agrupadas por US
+- Grafo de dependencias (Mermaid)
+- Estimaciones de tiempo por capa
+
+### Paso 5: Empezar a Trabajar
+
+```bash
+# Mover la primera tarea a en progreso
+/project:move-task TASK-001 in-progress
+
+# Después, marcar como hecha
+/project:move-task TASK-001 done
+
+# Si está bloqueada
+/project:move-task TASK-002 blocked "Esperando specs de la API"
+```
+
+### Paso 6: Seguir el Progreso
+
+```bash
+/sprint:status 1
+```
+
+### Paso 7: Configurar Monitoreo Recurrente (Opcional)
+
+Usa `/loop` (v2.1.71+) para monitorear automáticamente el progreso del sprint:
+
+```bash
+# Verificar el estado del sprint cada 30 minutos
+/loop 30m /sprint:status 1
+
+# Ejecutar verificaciones pre-commit cada 5 minutos durante el desarrollo
+/loop 5m /common:pre-commit-check
+```
+
+Alias: `/proactive` (v2.1.105+).
+
+Muestra:
+- Progreso global y burndown
+- Métricas por User Story
+- Bloqueantes y riesgos
+- Acciones recomendadas
+
 ---
 
-## Plantillas Disponibles
+## Plantillas
 
-| Plantilla | Proposito |
+Claude-Craft proporciona 5 plantillas para una estructura de backlog consistente:
+
+| Plantilla | Propósito |
 |-----------|-----------|
-| `epic.md` | Estructura de EPIC |
-| `user-story.md` | Estructura de User Story |
-| `task.md` | Estructura de tarea |
-| `board.md` | Tablero Kanban |
-| `index.md` | Indice del backlog |
+| `epic.md` | Estructura de archivo EPIC con metadatos, objetivos y lista de US |
+| `user-story.md` | Estructura de US con criterios Gherkin y tabla de tareas |
+| `task.md` | Estructura de tarea con checklist de DoD |
+| `board.md` | Tablero Kanban con cálculo de métricas |
+| `index.md` | Índice del backlog con resumen global |
 
 ---
 
-## Reglas SCRUM
+## Reglas SCRUM Aplicadas
 
 | Regla | Valor |
 |-------|-------|
-| Duracion sprint | 2 semanas |
+| Duración del sprint | 2 semanas (fija) |
 | Velocidad | 20-40 puntos/sprint |
-| Max US | 8 puntos |
-| Estimacion | Fibonacci (1,2,3,5,8,13,21) |
-| Duracion tarea | 0.5h - 8h max |
+| Tamaño máx. de US | 8 puntos (dividir si es mayor) |
+| Escala de estimación | Fibonacci (1, 2, 3, 5, 8, 13, 21) |
+| Duración de tarea | 0.5h - 8h máx. |
 
-### Sprint 1 = Walking Skeleton
-- Infraestructura completa
-- 1 feature end-to-end
-- Testable en Web y Mobile
+### Sprint 1: Walking Skeleton
+
+El primer sprint debe incluir:
+- Configuración completa de la infraestructura
+- 1 funcionalidad end-to-end (no solo configuración)
+- Verificable tanto en Web como en Móvil
 
 ### Vertical Slicing
-Cada US debe atravesar todas las capas:
+
+**Cada User Story DEBE atravesar todas las capas:**
+
 ```
-UI → API → Logica de Negocio → Base de Datos
+UI (Web/Móvil) → API → Lógica de Negocio → Base de Datos
 ```
+
+No se permiten User Stories solo de "Backend", solo de "Frontend" o solo de "Móvil".
 
 ---
 
-## Checklist
+## Checklist: Backlog Listo
 
-- [ ] Minimo 3 personas definidas
-- [ ] EPICs con MMF y criterios de exito
-- [ ] User Stories siguen INVEST
-- [ ] Criterios en formato Gherkin
-- [ ] Estimacion en Fibonacci
+- [ ] Mínimo 3 personas definidas
+- [ ] Los EPICs tienen MMF y criterios de éxito
+- [ ] Las User Stories siguen el modelo INVEST
+- [ ] Criterios de aceptación en formato Gherkin
+- [ ] Historias estimadas en puntos Fibonacci
 - [ ] Sprint 1 = Walking Skeleton
-- [ ] Backlog validado
+- [ ] Definition of Done documentada
+- [ ] Backlog validado (`/gate:validate-backlog`)
 
 ---
 
-[&larr; Solucion de Problemas](06-troubleshooting.md) | [Siguiente: Configuracion Proyecto Nuevo &rarr;](08-setup-new-project.md)
+[&larr; Solución de Problemas](06-troubleshooting.md) | [Siguiente: Configuración de Proyecto Nuevo &rarr;](08-setup-new-project.md)

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -1,151 +1,511 @@
-# Guía de Flujo de Trabajo Completo: De la Idea a Producción
+# Guía de Flujo de Trabajo Completo: De la Idea a la Producción
 
-Guía completa paso a paso para construir una aplicación completa con Claude Craft, desde la idea inicial hasta el despliegue en producción.
+Una guía completa paso a paso para construir una aplicación completa usando Claude Craft, desde la idea inicial hasta el despliegue en producción.
 
 ---
 
 ## Visión General
 
-Esta guía te acompaña a través del ciclo de desarrollo completo:
+Esta guía te lleva a través del ciclo de vida de desarrollo completo:
 
-1. **Ideación** - Definir tu visión del producto
-2. **Requisitos** - Documentar lo que estás construyendo
-3. **Arquitectura** - Diseñar la solución técnica
-4. **Planificación** - Crear sprints accionables
-5. **Desarrollo** - Implementar con TDD
-6. **Calidad** - Validar y probar
-7. **Despliegue** - Enviar a producción
+1. **Ideación** - Define la visión de tu producto
+2. **Requisitos** - Documenta qué estás construyendo
+3. **Arquitectura** - Diseña la solución técnica
+4. **Planificación** - Crea sprints accionables
+5. **Desarrollo** - Implementa con TDD
+6. **Calidad** - Valida y prueba
+7. **Despliegue** - Lanza a producción
+
+**Prerequisitos:**
+- Claude Craft v8.8.1 instalado en tu proyecto
+- Claude Code v2.1.159 (recomendado) o v2.1.97+ (mínimo, CVE-2025-59536 parcheado)
+- Comprensión básica de tu stack tecnológico elegido
 
 ---
 
 ## Fase 1: Ideación (5-10 minutos)
 
-### Iniciar con BMAD
+### Configura tu Sesión
+
+Antes de empezar, configura tu sesión para un rendimiento óptimo:
+
+```bash
+# Ajustar el esfuerzo de razonamiento para la planificación (alto para tareas complejas)
+/effort high
+
+# Opcionalmente configurar la optimización de tokens
+/common:setup-rtk
+```
+
+### Comenzar con BMAD
 
 ```bash
 # Inicializar BMAD en tu proyecto
 /bmad:init
 
-# O iniciar un workflow
+# O iniciar un flujo de trabajo
 /workflow:init
 ```
 
 ### Definir la Visión
 
+Trabaja con el agente de Product Manager:
+
 ```
-@pm Quiero construir una plataforma e-commerce para vender productos artesanales.
+@pm Quiero construir una plataforma de e-commerce para vender productos artesanales.
 Características clave:
 - Catálogo de productos con categorías
-- Carrito de compras y checkout
+- Carrito de compras y pago
 - Autenticación de usuarios
 - Gestión de pedidos
 ```
+
+El PM te ayudará a:
+- Clarificar el problema que estás resolviendo
+- Identificar los usuarios objetivo
+- Definir las métricas de éxito
+
+### Crear el Documento de Visión Inicial
+
+```
+@pm Crea un documento de visión para este proyecto
+```
+
+Salida: `docs/vision.md`
 
 ---
 
 ## Fase 2: Requisitos (15-30 minutos)
 
-### Crear PRD
+### Analizar los Requisitos
+
+Trabaja con el Analista de Negocio:
 
 ```
-@pm Crea un Product Requirements Document
+@ba Analiza los requisitos para la plataforma de e-commerce basándose en la visión
+```
+
+El BA hará lo siguiente:
+- Desglosar las funcionalidades en historias de usuario
+- Identificar dependencias
+- Crear un mapa de historias de usuario
+
+### Crear el PRD
+
+```
+@pm Crea un Documento de Requisitos de Producto
+```
+
+### Validar el PRD
+
+```
 /gate:validate-prd docs/prd.md
 ```
 
+Asegúrate de pasar la Puerta del PRD (≥80%):
+- [ ] Declaración del problema definida
+- [ ] Usuarios objetivo identificados
+- [ ] Objetivos claros
+- [ ] Métricas de éxito definidas
+- [ ] Límites del alcance establecidos
+
 ---
 
-## Fase 3: Arquitectura (20-45 minutes)
+## Fase 3: Arquitectura (20-45 minutos)
 
-### Diseñar Arquitectura
+### Diseñar la Arquitectura
+
+Trabaja con el Arquitecto:
 
 ```
-@architect Diseña la arquitectura del sistema para la plataforma e-commerce
+@architect Diseña la arquitectura del sistema para la plataforma de e-commerce
+Considera:
+- Backend Symfony con API Platform
+- Base de datos PostgreSQL
+- Caché Redis
+- Despliegue con Docker
 ```
 
-### Validar Especificación Técnica
+El Arquitecto creará:
+- Diagrama de arquitectura del sistema
+- Diseño de componentes
+- Modelo de datos
+- Contratos de API
+
+### Crear la Especificación Técnica
+
+```
+@architect Crea la especificación técnica a partir del PRD
+```
+
+Salida: `docs/tech-spec.md`
+
+### Documentar las Decisiones
+
+Para elecciones importantes:
+
+```
+@architect Crea un ADR para elegir JWT sobre autenticación basada en sesión
+```
+
+Salida: `docs/adr/001-jwt-authentication.md`
+
+### Validar la Especificación Técnica
 
 ```
 /gate:validate-techspec docs/tech-spec.md
 ```
+
+Asegúrate de pasar la Puerta de la Especificación Técnica (≥90%):
+- [ ] Arquitectura documentada
+- [ ] Contratos de API definidos
+- [ ] Seguridad abordada
+- [ ] Requisitos de rendimiento establecidos
+- [ ] Estrategia de testing definida
+- [ ] Plan de despliegue creado
 
 ---
 
 ## Fase 4: Planificación (15-30 minutos)
 
-### Crear Backlog
+### Crear el Backlog
+
+Trabaja con el Product Owner:
 
 ```
-@po Crea user stories desde la especificación técnica
-@sm Planifica el sprint 1
+@po Crea historias de usuario a partir de la especificación técnica
+Prioriza usando el método MoSCoW
+```
+
+El PO creará historias como:
+```
+EPIC-001: Autenticación de Usuarios
+├── US-001: Registro de usuarios
+├── US-002: Inicio de sesión de usuarios
+├── US-003: Restablecimiento de contraseña
+└── US-004: Inicio de sesión social
+
+EPIC-002: Catálogo de Productos
+├── US-005: Explorar productos
+├── US-006: Búsqueda de productos
+├── US-007: Filtrado por categoría
+└── US-008: Detalles del producto
+```
+
+### Validar el Backlog
+
+```
+/gate:validate-backlog
+```
+
+Cada historia debe pasar INVEST:
+- **I**ndependiente
+- **N**egociable
+- **V**aliosa
+- **E**stimable
+- **S**mall (pequeña)
+- **T**estable
+
+### Planificar el Primer Sprint
+
+Trabaja con el Scrum Master:
+
+```
+@sm Planifica el sprint 1 con las historias de mayor prioridad
+Incluye:
+- US-001: Registro de usuarios
+- US-002: Inicio de sesión de usuarios
+- US-005: Explorar productos
+```
+
+### Validar el Sprint
+
+```
 /gate:validate-sprint
 ```
 
 ---
 
-## Fase 5: Desarrollo
+## Fase 5: Desarrollo (Variable)
 
-### Ciclo TDD
+### Iniciar el Desarrollo del Sprint
 
-```bash
-# Obtener siguiente historia
+```
+/sprint:dev 1
+```
+
+O trabaja historia por historia:
+
+### 5.1 Obtener la Siguiente Historia
+
+```
 /sprint:next-story --claim
+```
 
-# Implementar con TDD
-@dev Implementa US-001 usando TDD
+Ejemplo: US-001 (Registro de Usuarios)
 
-# 🔴 Rojo - Escribir test fallando
-# 🟢 Verde - Implementar
-# 🔵 Refactorizar
+### 5.2 Transicionar a En Progreso
 
-# Validar
+```
+/sprint:transition US-001 in-progress
+```
+
+### 5.3 Fase Roja TDD (Escribir Test Fallido)
+
+Trabaja con el agente Desarrollador:
+
+```
+@dev Comienza TDD para US-001 (Registro de Usuarios)
+Empieza con la fase 🔴 Roja - escribe tests fallidos
+```
+
+Crea los tests primero:
+```php
+// tests/Feature/UserRegistrationTest.php
+class UserRegistrationTest extends TestCase
+{
+    public function test_user_can_register_with_valid_data(): void
+    {
+        $response = $this->post('/api/register', [
+            'email' => 'test@example.com',
+            'password' => 'SecurePass123!',
+            'name' => 'Test User'
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
+    }
+}
+```
+
+### 5.4 Fase Verde TDD (Implementar)
+
+```
+@dev Ahora implementa la fase 🟢 Verde - haz que los tests pasen
+```
+
+Genera código:
+```
+/symfony:generate-crud User
+```
+
+### 5.5 Fase de Refactorización TDD
+
+```
+@dev 🔵 Refactorizar - limpia la implementación
+```
+
+### 5.6 Revisión de Código
+
+```
+@symfony-reviewer Revisa la implementación del registro de usuarios
+```
+
+### 5.7 Validar la DoD de la Historia
+
+```
 /gate:validate-story US-001
+```
+
+### 5.8 Transicionar a Revisión
+
+```
+/sprint:transition US-001 review
+```
+
+### 5.9 Validación QA
+
+```
+@qa Valida los criterios de aceptación para US-001
+```
+
+### 5.10 Completar la Historia
+
+```
 /sprint:transition US-001 done
 ```
 
+### 5.11 Repetir
+
+Continúa con la siguiente historia hasta completar el sprint.
+
 ---
 
-## Fase 6: Calidad
+## Fase 6: Calidad (A lo Largo del Desarrollo)
+
+### Gestión del Contexto
+
+Durante el desarrollo, gestiona tu ventana de contexto de manera eficiente:
 
 ```bash
+# Verificar sugerencias de optimización del contexto
+/context
+
+# Cambiar a un esfuerzo menor para tareas simples
+/effort low
+
+# Limpiar el contexto entre tareas no relacionadas
+/clear
+
+# Guardar aprendizajes importantes que persistan entre sesiones
+/memory "Decisión arquitectónica clave: usando CQRS para el módulo de pedidos"
+```
+
+### Verificaciones de Calidad Continuas
+
+Ejecuta regularmente durante el desarrollo:
+
+```bash
+# Configurar monitoreo de calidad recurrente
+/loop 5m /common:pre-commit-check
+
+# Verificación de arquitectura
 /symfony:check-architecture
+
+# Calidad del código
+/symfony:check-code-quality
+
+# Auditoría de seguridad
+/symfony:check-security
+
+# Cobertura de tests
+/symfony:check-testing
+```
+
+### Auditoría Completa Antes del Lanzamiento
+
+```
 /team:audit --sequential
+```
+
+### Validación Pre-Commit
+
+Siempre antes de hacer commit:
+
+```
 /common:pre-commit-check
 ```
 
+### Revisión del Sprint
+
+Al final del sprint:
+
+```
+@sm Ejecuta la revisión del sprint 1
+```
+
+### Retrospectiva
+
+```
+@sm Ejecuta la retrospectiva del sprint
+```
+
 ---
 
-## Fase 7: Despliegue
+## Fase 7: Despliegue (30-60 minutos)
 
-```bash
+### Preparar la Configuración Docker
+
+```
+@docker-architect Diseña la arquitectura Docker para producción
+```
+
+### Crear los Archivos Docker
+
+```
 /docker:compose-setup symfony postgresql redis
+```
+
+### Crear el Pipeline CI/CD
+
+```
 /docker:cicd-pipeline github-actions
+```
+
+### Verificación de Seguridad
+
+```
+/docker:security-scan
+```
+
+### Lista de Verificación Pre-Lanzamiento
+
+```
 /common:release-checklist
 ```
 
----
-
-## Usando Ralph para Automatización
+### Desplegar
 
 ```bash
-/common:ralph-run "Implementar autenticación de usuario con TDD"
+# Construir y probar
+docker compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml up -d
+
+# Ejecutar migraciones
+docker compose exec app php bin/console doctrine:migrations:migrate
+
+# Verificar salud
+curl https://tu-app.com/health
 ```
 
 ---
 
-## Secuencia de Comandos Completa
+## Usar Ralph para la Automatización
+
+Para ciclos de desarrollo automatizados, usa Ralph Wiggum:
 
 ```bash
+# Implementar una funcionalidad automáticamente
+/common:ralph-run "Implementar el registro de usuarios con TDD"
+
+# Con verificaciones completas de DoD
+/common:ralph-run --full "Añadir la funcionalidad de restablecimiento de contraseña"
+```
+
+Ralph iterará hasta que:
+- Todos los tests pasen
+- El lint pase
+- Los validadores de DoD pasen
+
+---
+
+## Secuencia Completa de Comandos
+
+Aquí hay una secuencia condensada para una funcionalidad típica:
+
+```bash
+# 0. Configuración de la sesión
+/effort high                    # Planificación compleja
+/common:setup-rtk               # Optimización de tokens (solo la primera vez)
+
+# 1. Inicializar
 /bmad:init
-@pm Crea el PRD
+
+# 2. Definir (PM)
+@pm Crea el PRD para la funcionalidad
 /gate:validate-prd docs/prd.md
+
+# 3. Diseñar (Arquitecto)
 @architect Crea la especificación técnica
 /gate:validate-techspec docs/tech-spec.md
-@po Crea las user stories
+
+# 4. Planificar (PO + SM)
+@po Crea historias de usuario
 @sm Planifica el sprint 1
+/gate:validate-sprint
+
+# 5. Desarrollar (Dev)
 /sprint:next-story --claim
-@dev Implementa con TDD
+@dev Implementar con TDD
 /gate:validate-story US-001
+/sprint:transition US-001 done
+
+# 6. Revisar (QA)
+@qa Valida los criterios de aceptación
 /team:audit --sequential
+
+# 7. Desplegar
+/docker:cicd-pipeline github-actions
 /common:release-checklist
 ```
 
@@ -153,22 +513,78 @@ Características clave:
 
 ## Consejos para el Éxito
 
-1. **No saltes los Quality Gates**
-2. **Usa los agentes colaborativamente** - Claude-Craft incluye **70 agentes** especializados
-3. **TDD es no negociable**: 🔴 → 🟢 → 🔵
-4. **Documenta las decisiones** con ADRs
-5. **Revisiones regulares**: `/common:daily-standup`, `@{tech}-reviewer`
-6. **Gestiona tu contexto**:
-   - `/effort high` para tareas complejas, `/effort low` para lookups
-   - `/context` para sugerencias de optimización del contexto
-   - `/compact` proactivamente cuando el contexto supere el 70%
-   - `/clear` entre tareas no relacionadas
-   - `/loop` para tareas recurrentes (ej: `/loop 5m /common:pre-commit-check`)
+### 0. Gestiona tu Ventana de Contexto
+
+La ventana de contexto es tu recurso más crítico:
+- Usa `/effort low` para tareas simples, `/effort high` para tareas complejas
+- Usa `/context` regularmente para verificar sugerencias de optimización
+- Ejecuta `/clear` entre tareas no relacionadas
+- Usa `/memory` para persistir las decisiones clave entre sesiones
+- Configura `/loop` para verificaciones recurrentes en lugar de ejecuciones manuales
+
+### 1. No Omitas las Puertas de Calidad
+
+Cada puerta detecta diferentes problemas:
+- Puerta PRD → Evita construir lo incorrecto
+- Puerta de Especificación Técnica → Evita problemas arquitectónicos
+- Puerta de Backlog → Asegura que las historias sean implementables
+- DoD de Historia → Asegura código de calidad
+
+### 2. Usa los Agentes de Forma Colaborativa
+
+Deja que los agentes se pasen el trabajo entre sí:
+```
+@bmad-master Enruta esto al agente apropiado
+```
+
+### 3. TDD No es Negociable
+
+Sigue siempre 🔴 Rojo → 🟢 Verde → 🔵 Refactorizar.
+
+### 4. Documenta las Decisiones
+
+Usa ADRs para elecciones importantes:
+```
+@architect Crea un ADR para elegir X sobre Y
+```
+
+### 5. Revisiones Regulares
+
+- Diarias: `/common:daily-standup`
+- Al final del Sprint: `@sm Ejecuta la revisión del sprint`
+- Continuas: `@{tech}-reviewer Revisa este código`
 
 ---
 
-## Ver También
+## Solución de Problemas
 
-- [Guía Práctica BMAD](../BMAD-PRACTICAL-GUIDE.md)
-- [Guía Ralph Wiggum](../RALPH-GUIDE.md)
-- [Referencia de Comandos](../COMMANDS.md)
+### Falla en la Puerta de Calidad
+
+```
+/gate:report
+```
+
+Comprueba qué criterios faltan.
+
+### Historia Bloqueada
+
+```
+/sprint:transition US-001 blocked --reason="Esperando la API"
+```
+
+### Necesitar Revertir Cambios
+
+Si usas Ralph con puntos de control de Git:
+```bash
+git log --oneline --grep="[ralph]"
+git reset --hard HEAD~3
+```
+
+---
+
+## Próximos Pasos
+
+- [Guía Práctica de BMAD](../BMAD-PRACTICAL-GUIDE.md) - Profundización en BMAD
+- [Guía de Ralph Wiggum](../RALPH-GUIDE.md) - Desarrollo automatizado
+- [Referencia de Comandos](../COMMANDS.md) - Todos los comandos disponibles
+- [Referencia de Agentes](../AGENTS.md) - Todos los agentes disponibles

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -17,7 +17,7 @@ Esta guía te lleva a través del ciclo de vida de desarrollo completo:
 7. **Despliegue** - Lanza a producción
 
 **Prerequisitos:**
-- Claude Craft v8.8.1 instalado en tu proyecto
+- Claude Craft v8.8.2 instalado en tu proyecto
 - Claude Code v2.1.159 (recomendado) o v2.1.97+ (mínimo, CVE-2025-59536 parcheado)
 - Comprensión básica de tu stack tecnológico elegido
 

--- a/docs/guides/fr/05-tools-reference.md
+++ b/docs/guides/fr/05-tools-reference.md
@@ -1,15 +1,222 @@
 # Guide de Référence des Outils
 
-Ce guide couvre les outils utilitaires inclus avec Claude-Craft pour gérer les profils, l'affichage du statut et la configuration des projets.
+Ce guide couvre les outils utilitaires inclus avec Claude-Craft pour gérer les profils, l'affichage du statut, la configuration des projets, ainsi que les commandes et fonctionnalités de Claude Code (v8.7).
 
 ---
 
 ## Table des Matières
 
-1. [Gestionnaire MultiAccount](#gestionnaire-multiaccount)
-2. [StatusLine](#statusline)
-3. [Gestionnaire ProjectConfig](#gestionnaire-projectconfig)
-4. [Installation](#installation)
+1. [Commandes Claude Code](#commandes-claude-code)
+2. [Événements de Hook](#événements-de-hook)
+3. [Frontmatter des Agents](#frontmatter-des-agents)
+4. [MCP Tool Search](#mcp-tool-search)
+5. [Mode Auto](#mode-auto)
+6. [Templates de Hooks](#templates-de-hooks)
+7. [Paramètres Gérés](#paramètres-gérés)
+8. [Gestionnaire MultiAccount](#gestionnaire-multiaccount)
+9. [StatusLine](#statusline)
+10. [Gestionnaire ProjectConfig](#gestionnaire-projectconfig)
+11. [Installation](#installation)
+
+---
+
+## Commandes Claude Code
+
+Claude Code fournit des commandes intégrées pour la gestion du contexte et des sessions. Elles sont disponibles dans toute session Claude Code (v2.1.47+).
+
+### Commandes de Gestion du Contexte
+
+| Commande | Version | Description |
+|---------|---------|-------------|
+| `/clear` | Toutes | Effacer le contexte entre tâches sans lien |
+| `/compact` | Toutes | Compacter le contexte de manière proactive (lancer à ~70% d'utilisation) |
+| `/context` | v2.1.74+ | Obtenir des suggestions actionnables pour optimiser le contexte |
+| `/effort low\|medium\|high` | v2.1.72+ | Ajuster l'effort de raisonnement du modèle selon la complexité de la tâche |
+| `/memory` | v2.1.59+ | Sauvegarder des apprentissages persistants entre sessions et compactions |
+| `/model haiku\|sonnet\|opus` | v2.1.72+ | Changer de modèle en cours de session selon la complexité de la tâche |
+
+### Commandes de Session
+
+| Commande | Version | Description |
+|---------|---------|-------------|
+| `/loop [intervalle] [commande]` | v2.1.71+ | Exécuter des tâches récurrentes (ex. `/loop 5m /common:pre-commit-check`) |
+| `/proactive` | v2.1.105+ | Alias de `/loop` |
+| `/color` | v2.1.94+ | Changer le schéma de couleurs du terminal |
+| `/rename` | v2.1.94+ | Renommer la session courante |
+| `/powerup` | v2.1.94+ | Activer les fonctionnalités power-up |
+
+### Exemples d'Utilisation
+
+```bash
+# Ajuster l'effort pour une simple recherche
+/effort low
+
+# Basculer vers un modèle moins coûteux pour l'exploration
+/model sonnet
+
+# Configurer une surveillance CI récurrente
+/loop 5m "Check if CI pipeline passed"
+
+# Sauvegarder le contexte important avant une compaction
+/memory "L'authentification utilise JWT avec RS256, refresh tokens dans des cookies HttpOnly"
+```
+
+---
+
+## Événements de Hook
+
+Claude Code supporte 24 événements de hook (8 ajoutés dans les versions récentes de Claude Code) pour automatiser les workflows :
+
+### Tous les Événements de Hook
+
+| Événement | Moment | Cas d'Usage |
+|-------|--------|----------|
+| **PreToolUse** | Avant l'exécution de l'outil | Bloquer les commandes dangereuses, réécrire avec RTK |
+| **PostToolUse** | Après l'exécution de l'outil | Filtrer les sorties verbeuses, résumer les résultats |
+| **PreCompact** | Avant la compaction du contexte | Sauvegarder le contexte critique ; le code de sortie 2 bloque la compaction (v2.1.105+) |
+| **PostCompact** | Après la compaction du contexte | Réinjecter le contexte essentiel |
+| **SessionStart** | Au démarrage d'une session | Charger les essentiels du contexte, configurer l'environnement |
+| **StopFailure** | Lors d'un arrêt inattendu | Sauvegarder l'état, alerter sur les échecs |
+| **Notification** | Sur les événements de notification | Alertes personnalisées |
+| **TaskCreated** | Lors de la création d'une tâche sous-agent | Suivre le travail des sous-agents |
+| **CwdChanged** | Changement de répertoire de travail | Mettre à jour l'environnement par répertoire |
+| **FileChanged** | Modification de fichier détectée | Déclencher des rebuilds, du linting |
+| **PermissionDenied** | Échec de vérification de permission | Journaliser les événements de sécurité |
+| **Elicitation** | Avant le prompt utilisateur | Personnaliser le flux d'élicitation |
+| **ElicitationResult** | Après la réponse utilisateur | Traiter les résultats d'élicitation |
+| **Stop** | Lors de l'arrêt de la session | Nettoyage |
+
+### Améliorations des Hooks (v8.7)
+
+| Fonctionnalité | Description |
+|---------|-------------|
+| **`if` conditionnel** | Exécuter les hooks uniquement lorsqu'une condition est remplie |
+| **`defer`** | Différer l'exécution du hook pour éviter le blocage |
+| **Blocage PreCompact** | Le code de sortie 2 dans le hook PreCompact bloque la compaction (v2.1.105+) |
+
+### Exemple : Filtre de Sortie PostToolUse
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "echo '$TOOL_OUTPUT' | head -100"
+      }]
+    }]
+  }
+}
+```
+
+---
+
+## Frontmatter des Agents
+
+Les agents personnalisés (v2.1.78+) supportent des champs de frontmatter pour contrôler le comportement et les coûts :
+
+```yaml
+---
+effort: low          # Effort de raisonnement (low/medium/high)
+maxTurns: 10         # Nombre maximum de tours de conversation
+disallowedTools:     # Outils que l'agent ne peut pas utiliser
+  - Edit
+  - Write
+---
+```
+
+| Champ | Type | Description |
+|-------|------|-------------|
+| `effort` | string | Effort de raisonnement : `low`, `medium` ou `high` |
+| `maxTurns` | number | Nombre maximum de tours avant l'arrêt |
+| `disallowedTools` | liste | Outils que l'agent n'est pas autorisé à utiliser |
+
+Utile pour créer des agents d'exploration économiques qui peuvent lire sans modifier le code.
+
+---
+
+## MCP Tool Search
+
+MCP Tool Search (v2.1.80+) permet le chargement paresseux des outils MCP, réduisant la consommation de contexte de 95% :
+
+| Approche | Coût Contexte |
+|----------|-------------|
+| MCP classique (tous les outils chargés) | ~500-2000 tokens/outil/tour |
+| MCP avec Tool Search (chargement paresseux) | ~50 tokens au total |
+
+### Utilisation
+
+```bash
+# Charger un outil spécifique à la demande
+ToolSearch with query: "select:tool_name"
+
+# Rechercher par mot-clé
+ToolSearch with query: "slack send"
+```
+
+Au lieu de charger tous les outils du serveur MCP au démarrage, Tool Search les charge uniquement lorsque nécessaire.
+
+---
+
+## Mode Auto
+
+Le Mode Auto (v2.1.94+) est un classificateur de permissions basé sur l'IA qui remplace `--dangerously-skip-permissions` de manière plus sûre :
+
+| Mode | Protection | Vitesse | Cas d'Usage |
+|------|-----------|-------|----------|
+| Manuel | Maximum | Lente | Workflows audités, haute sécurité |
+| Mode Auto | Élevée | Rapide | Workflows de développement de confiance |
+| Skip Permissions | Minimale | Maximum | Projets locaux/personnels uniquement |
+
+**Fonctionnalités de sécurité :**
+- Un modèle de sécurité en arrière-plan évalue chaque appel d'outil
+- Les opérations sûres (lectures, tests) sont auto-approuvées
+- Les actions risquées (suppression massive, exfiltration) sont bloquées
+- 3 blocages consécutifs reviennent au mode manuel
+- 20+ blocages dans une session reviennent au mode manuel complet
+
+Disponible pour les plans Team avec approbation administrative.
+
+---
+
+## Templates de Hooks
+
+Claude-Craft fournit des templates de hooks prêts à l'emploi dans `.claude/templates/hooks/` :
+
+| Template | Objectif |
+|----------|---------|
+| `output-filter.json` | Filtre PostToolUse pour les sorties CLI volumineuses |
+| `pre-compact.json` | Hook PreCompact pour préserver le contexte critique |
+| `context-reinject.json` | Hook SessionStart pour la réinjection du contexte après compaction |
+
+### Installation
+
+Copier les templates dans le `.claude/settings.json` de votre projet ou fusionner dans votre configuration de hooks :
+
+```bash
+# Voir les templates disponibles
+ls .claude/templates/hooks/
+
+# Appliquer à votre projet (fusionner manuellement dans settings.json)
+cat .claude/templates/hooks/output-filter.json
+```
+
+---
+
+## Paramètres Gérés
+
+Le répertoire `managed-settings.d/` (v2.1.83+) permet une configuration modulaire via fusion alphabétique :
+
+```
+.claude/
+  managed-settings.d/
+    00-base.json          # Configuration de base
+    10-security.json      # Règles de sécurité
+    20-team.json          # Préférences d'équipe
+```
+
+Les fichiers sont fusionnés dans l'ordre alphabétique, permettant aux équipes de superposer des configurations sans conflits.
 
 ---
 
@@ -343,8 +550,8 @@ brew install yq
 sudo snap install yq
 
 # Linux (binaire)
-sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
-sudo chmod +x /usr/local/bin/yq
+wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+chmod +x /usr/local/bin/yq
 ```
 
 ### Utilisation
@@ -402,9 +609,9 @@ settings:
   default_lang: "fr"
 
 projects:
-  - name: "mon-saas"
-    description: "Plateforme SaaS"
-    path: "~/Projets/mon-saas"
+  - name: "my-saas"
+    description: "SaaS platform"
+    path: "~/Projects/my-saas"
     modules:
       - name: "api"
         path: "backend"
@@ -416,8 +623,8 @@ projects:
         path: "app"
         technologies: ["flutter"]
 
-  - name: "outil-interne"
-    path: "~/Projets/interne"
+  - name: "internal-tool"
+    path: "~/Projects/internal"
     technologies: ["python"]
     lang: "en"
 ```
@@ -443,16 +650,16 @@ Vérifications de validation :
 
 ```bash
 # Installer un projet unique
-./claude-projects.sh install mon-saas
+./claude-projects.sh install my-saas
 
 # Ou via Makefile
-make config-install CONFIG=claude-projects.yaml PROJECT=mon-saas
+make config-install CONFIG=claude-projects.yaml PROJECT=my-saas
 
 # Installer tous les projets
 make config-install-all CONFIG=claude-projects.yaml
 
 # Dry run
-make config-install CONFIG=claude-projects.yaml PROJECT=mon-saas OPTIONS="--dry-run"
+make config-install CONFIG=claude-projects.yaml PROJECT=my-saas OPTIONS="--dry-run"
 ```
 
 ### Support Multilingue
@@ -509,65 +716,12 @@ claude-projects.sh --version
 
 ---
 
-## Optimisation des Tokens avec RTK
-
-### Objectif
-
-RTK (Rust Token Killer) est un proxy CLI qui réduit la consommation de tokens de 60-90% sur les commandes de développement courantes.
-
-### Installation Rapide
-
-Utilisez la commande intégrée pour configurer automatiquement toutes les optimisations :
-
-```bash
-/common:setup-rtk
-```
-
-Cela installe et configure :
-- **RTK** avec le hook PreToolUse (réécriture transparente des commandes)
-- **Ultra-compact mode** pour les sorties CLI
-- **CLAUDE_CODE_SUBAGENT_MODEL=sonnet** pour réduire les coûts des sous-agents
-- **Hooks PostToolUse** pour filtrer les sorties volumineuses
-
-### Utilisation
-
-Une fois configuré, RTK est transparent. Vos commandes sont automatiquement réécrites par le hook :
-
-```bash
-# Vous tapez :
-git status
-
-# RTK réécrit en :
-rtk git status
-# → sortie compacte, 60-90% de tokens en moins
-```
-
-### Commandes RTK Natives
-
-```bash
-rtk gain              # Afficher les économies de tokens
-rtk gain --history    # Historique des commandes avec économies
-rtk discover          # Analyser l'historique Claude Code pour les opportunités manquées
-rtk --version         # Vérifier la version installée
-```
-
-### Économies Attendues
-
-| Optimisation | Économie |
-|---|---|
-| RTK + ultra-compact | 60-90% sur outputs CLI |
-| SUBAGENT_MODEL=sonnet | 40-60% coût sous-agents |
-| PostToolUse hook | Réduit pollution contexte |
-| **Total combiné** | **55-65% réduction globale** |
-
----
-
 ## Référence Rapide
 
 ### Commandes MultiAccount
 
 | Commande | Description |
-|----------|-------------|
+|---------|-------------|
 | `list` | Afficher tous les profils |
 | `add <nom>` | Créer un nouveau profil |
 | `remove <nom>` | Supprimer un profil |
@@ -594,7 +748,7 @@ rtk --version         # Vérifier la version installée
 ### Commandes ProjectConfig
 
 | Commande | Description |
-|----------|-------------|
+|---------|-------------|
 | `list` | Afficher tous les projets |
 | `validate` | Vérifier la validité de la config |
 | `install <nom>` | Installer les règles du projet |

--- a/docs/guides/pt/01-getting-started.md
+++ b/docs/guides/pt/01-getting-started.md
@@ -1,65 +1,84 @@
-# Primeiros Passos com Claude-Craft
+# Primeiros Passos com o Claude-Craft
 
-Bem-vindo ao Claude-Craft! Este guia ajudará você a entender o que é o Claude-Craft e a iniciar seu primeiro projeto em apenas 5 minutos.
+Bem-vindo ao Claude-Craft! Este guia vai ajudá-lo a entender o que é o Claude-Craft e a colocar seu primeiro projeto em funcionamento em apenas 5 minutos.
 
 ---
 
-## O que é Claude-Craft?
+## O que é o Claude-Craft?
 
-Claude-Craft é um framework completo para desenvolvimento assistido por IA com Claude Code. Ele fornece:
+O Claude-Craft é um framework completo para desenvolvimento assistido por IA com o Claude Code. Ele fornece:
 
-- **125 Comandos Slash** - Ações rápidas em 15 namespaces para geração, análise e qualidade de código
-- **70 Agentes IA (31 especializados + 39 infra sob demanda)** - Assistentes especializados para diferentes tarefas (design de API, arquitetura, revisão de código, DevOps, etc.)
+- **125 Comandos Slash** - Ações rápidas em 15 namespaces para geração de código, análise e verificações de qualidade
+- **70 Agentes de IA (31 especializados + 39 de infraestrutura sob demanda)** - Assistentes especializados com níveis de esforço otimizados e memória persistente
 - **11 Stacks Tecnológicos** - De .NET/C# a Vue.js, com regras e agentes dedicados
-- **48 Skills** - Melhores práticas para arquitetura, testes, segurança e qualidade de código
-- **21 Templates** - Padrões de código prontos para usar
-- **10 Checklists** - Portões de qualidade para features e releases
+- **48 Skills** - Melhores práticas de arquitetura, testes e segurança
+- **21 Templates** - Padrões de código prontos para uso em componentes comuns
+- **10 Checklists** - Portões de qualidade para features, releases e auditorias de segurança
+- **937 Testes** - Validação abrangente (vitest + bats)
 
 ### Tecnologias Suportadas
 
 | Tecnologia | Foco | Casos de Uso |
 |------------|------|--------------|
-| **Symfony / PHP** | Clean Architecture + DDD | APIs, Apps web, Serviços backend |
-| **React** | Hooks + State Management | SPAs web, Dashboards |
-| **Flutter / Dart** | Padrão BLoC | Apps móveis (iOS/Android) |
-| **Python** | FastAPI + async/await | APIs, Serviços de dados, ML |
-| **Angular** | Signals + Standalone | SPAs enterprise |
-| **Vue.js** | Composition API + Pinia | SPAs web, Dashboards |
-| **React Native** | New Architecture | Apps móveis multiplataforma |
-| **C# / .NET** | Clean Architecture + CQRS | APIs enterprise, Microserviços |
-| **Laravel** | Actions Pattern | APIs, CMS, E-commerce |
-| **PHP** | PSR-12 + PHPStan | Bibliotecas, APIs |
-| **Docker** | Containerização | Dev local, CI/CD |
-| **Coolify** | PaaS auto-hospedado | Deploys simples |
-| **Kubernetes** | Orquestração | Microserviços, Scale |
-| **OpenTofu** | IaC | Multi-cloud |
-| **Ansible** | Automação | Gestão de configuração |
-| **Hcloud** | Hetzner Cloud | Hospedagem europeia |
-| **PgBouncer** | Connection pooling | PostgreSQL alta carga |
-| **FrankenPHP** | Servidor PHP/Go | Performance PHP |
+| **.NET / C#** | Clean Architecture + CQRS | APIs, Aplicações enterprise |
+| **Symfony** | Clean Architecture + DDD | APIs, Aplicações web, Serviços backend |
+| **Flutter** | Padrão BLoC | Aplicações móveis (iOS/Android) |
+| **Python** | FastAPI + async/await | APIs, Serviços de dados, Backends de ML |
+| **React** | Hooks + Gerenciamento de estado | SPAs web, Dashboards |
+| **React Native** | Mobile multiplataforma | Aplicações móveis com JS |
+| **Angular** | Signals + Standalone | Aplicações web enterprise |
+| **Vue.js** | Composition API + Pinia | SPAs web, Aplicações progressivas |
+| **Laravel** | Clean Architecture + Actions | APIs, Aplicações web |
+| **PHP** | PSR-12 + PHPStan | Bibliotecas, Serviços backend |
+| **Docker** | Infraestrutura | Containerização, CI/CD |
 
 ### Idiomas Suportados
 
-Todo o conteúdo está disponível em 5 idiomas: Inglês (en), Francês (fr), Espanhol (es), Alemão (de), Português (pt)
+Todo o conteúdo está disponível em 5 idiomas:
+- Inglês (en)
+- Francês (fr)
+- Espanhol (es)
+- Alemão (de)
+- Português (pt)
 
 ---
 
 ## Pré-requisitos
 
 ### Obrigatórios
-- **Bash** - Shell para executar scripts de instalação
-- **Claude Code** - O assistente de codificação IA da Anthropic
+
+- **Bash** - Shell para executar os scripts de instalação
+- **Claude Code** - O assistente de codificação por IA da Anthropic
+
+### Compatibilidade com o Claude Code
+
+| Versão | Status |
+|--------|--------|
+| **2.1.159** | Recomendada (suporte completo a recursos) |
+| **2.1.97+** | Mínima suportada (CVE-2025-59536 corrigido) |
 
 ### Opcionais (Recomendados)
-```bash
-# yq - Processador YAML
-brew install yq  # macOS
-sudo apt install yq  # Linux
 
-# jq - Processador JSON (para StatusLine)
-brew install jq  # macOS
-sudo apt install jq  # Linux
-```
+- **yq** - Processador YAML para arquivos de configuração
+  ```bash
+  # macOS
+  brew install yq
+
+  # Linux (Debian/Ubuntu)
+  sudo apt install yq
+
+  # Linux (snap)
+  sudo snap install yq
+  ```
+
+- **jq** - Processador JSON (para a ferramenta StatusLine)
+  ```bash
+  # macOS
+  brew install jq
+
+  # Linux
+  sudo apt install jq
+  ```
 
 ---
 
@@ -68,90 +87,200 @@ sudo apt install jq  # Linux
 ### Método 1: Makefile (Recomendado)
 
 ```bash
+# Clonar o Claude-Craft
 git clone https://github.com/thebeardedcto/claude-craft.git
 cd claude-craft
 
-# Instalar para projeto Symfony (em português)
-make install-symfony TARGET=~/meu-projeto LANG=pt
+# Instalar para um projeto Symfony (em francês)
+make install-symfony TARGET=~/my-project LANG=fr
+
+# Ou para um projeto Flutter (em inglês)
+make install-flutter TARGET=~/my-app LANG=en
 ```
 
 ### Método 2: Script Direto
 
 ```bash
-./Dev/scripts/install-symfony-rules.sh --lang=pt ~/meu-projeto
+# Navegar até o Claude-Craft
+cd claude-craft
+
+# Executar o script de instalação
+./Dev/scripts/install-symfony-rules.sh --lang=fr ~/my-project
 ```
 
 ### Método 3: Configuração YAML (para Monorepos)
 
 ```bash
+# Criar o arquivo de configuração
 cp claude-projects.yaml.example claude-projects.yaml
+
+# Editar com seus projetos
 nano claude-projects.yaml
-make config-install CONFIG=claude-projects.yaml PROJECT=meu-projeto
+
+# Instalar a partir da configuração
+make config-install CONFIG=claude-projects.yaml PROJECT=my-project
 ```
 
 ---
 
 ## Seu Primeiro Projeto em 5 Minutos
 
+Vamos criar um novo projeto de API Symfony com regras em francês.
+
+### Passo 1: Criar o Diretório do Projeto
+
 ```bash
-# Passo 1: Criar diretório do projeto
-mkdir ~/minha-api && cd ~/minha-api && git init
-
-# Passo 2: Instalar regras Claude-Craft
-make install-symfony TARGET=~/minha-api LANG=pt
-
-# Passo 3: Verificar instalação
-ls -la ~/minha-api/.claude/
-
-# Passo 4: Configurar contexto do projeto (escolha uma opção)
-# Opção A: Interativa (recomendada)
-cd ~/minha-api && claude
-# Depois execute: /common:setup-project-context
-
-# Opção B: Manual
-nano ~/minha-api/.claude/rules/00-project-context.md
-
-# Passo 5: Iniciar Claude Code
-cd ~/minha-api && claude
+mkdir ~/my-api
+cd ~/my-api
+git init
 ```
+
+### Passo 2: Instalar as Regras do Claude-Craft
+
+```bash
+# A partir do diretório claude-craft
+make install-symfony TARGET=~/my-api LANG=fr
+```
+
+### Passo 3: Verificar a Instalação
+
+```bash
+ls -la ~/my-api/.claude/
+```
+
+Você deverá ver:
+```
+.claude/
+├── CLAUDE.md           # Configuração principal
+├── .claudeignore       # Padrões de exclusão para redução de contexto
+├── settings.json       # Padrões otimizados com hook PostCompact
+├── settings.local.json # Permissões locais (padrões com wildcard)
+├── rules/              # 21 arquivos de regras
+├── agents/             # Agentes de IA com otimização de esforço/memória
+├── commands/           # Comandos slash
+│   ├── common/         # Comandos transversais
+│   └── symfony/        # Comandos específicos do Symfony
+├── templates/          # Templates de código
+└── checklists/         # Portões de qualidade
+```
+
+### Passo 4: Configurar o Contexto do Projeto
+
+Você pode configurar o contexto do projeto de forma interativa ou manual:
+
+**Opção A: Interativa (Recomendada)**
+```bash
+cd ~/my-api && claude
+# Em seguida, execute:
+/common:setup-project-context
+```
+
+**Opção B: Manual**
+```bash
+nano ~/my-api/.claude/rules/00-project-context.md
+```
+
+Atualize estas seções:
+- Nome e descrição do projeto
+- Detalhes do stack técnico
+- Convenções da equipe
+- Restrições específicas
+
+### Passo 5: Iniciar o Claude Code
+
+```bash
+cd ~/my-api
+claude
+```
+
+Agora você pode usar todos os comandos e agentes instalados!
 
 ---
 
 ## Entendendo a Estrutura
 
 ### Regras (`rules/`)
-Diretrizes que o Claude segue ao trabalhar no seu projeto, numeradas por prioridade (00-12+).
+
+As regras são diretrizes que o Claude segue ao trabalhar no seu projeto. Elas são numeradas por prioridade:
+
+| Número | Tema |
+|--------|------|
+| 00 | Contexto do projeto (personalize este!) |
+| 01 | Fluxo de trabalho e análise |
+| 02 | Arquitetura |
+| 03 | Padrões de codificação |
+| 04 | Princípios SOLID |
+| 05 | KISS, DRY, YAGNI |
+| 06 | Docker e ferramentas |
+| 07 | Testes |
+| 08 | Ferramentas de qualidade |
+| 09 | Fluxo de trabalho Git |
+| 10 | Documentação |
+| 11 | Segurança |
+| 12+ | Tópicos avançados (DDD, CQRS, etc.) |
 
 ### Agentes (`agents/`)
+
+Os agentes são personas de IA especializadas que você pode invocar para tarefas específicas:
+
 ```markdown
 @api-designer Projete a API REST para gestão de usuários
-@database-architect Crie o esquema para o agregado Pedido
+@database-architect Crie o esquema para o agregado de Pedidos
 @symfony-reviewer Revise minha implementação do UserService
+@tdd-coach Ajude-me a escrever testes para o fluxo de autenticação
 ```
 
 ### Comandos (`commands/`)
+
+Os comandos slash são ações rápidas:
+
 ```bash
+# Gerar código
 /symfony:generate-crud User
+
+# Verificar qualidade
 /symfony:check-compliance
+
+# Analisar arquitetura
 /common:architecture-decision
 ```
 
 ### Templates (`templates/`)
-service.md, value-object.md, aggregate-root.md, test-unit.md
+
+Os templates fornecem padrões de código:
+- `service.md` - Template de classe de serviço
+- `value-object.md` - Template de Value Object
+- `aggregate-root.md` - Template de Aggregate Root DDD
+- `test-unit.md` - Template de teste unitário
 
 ### Checklists (`checklists/`)
-feature-checklist.md, pre-commit.md, release.md, security-audit.md
+
+Portões de qualidade para diferentes cenários:
+- `feature-checklist.md` - Antes de concluir uma feature
+- `pre-commit.md` - Antes de commitar código
+- `release.md` - Antes de fazer um release
+- `security-audit.md` - Revisão de segurança
 
 ---
 
 ## Conceitos-Chave
 
 ### 1. Fluxo de Trabalho TDD
+
+O Claude-Craft impõe o Desenvolvimento Orientado a Testes (TDD):
+
 ```
-1. Analisar → 2. Testes → 3. Implementar → 4. Refatorar → 5. Revisar
+1. Analisar requisitos
+2. Escrever testes com falha
+3. Implementar código
+4. Refatorar
+5. Revisar
 ```
 
 ### 2. Clean Architecture
+
+Todos os stacks tecnológicos seguem os princípios da Clean Architecture:
+
 ```
 ┌─────────────────────────────────────┐
 │           Apresentação              │
@@ -164,20 +293,83 @@ feature-checklist.md, pre-commit.md, release.md, security-audit.md
 └─────────────────────────────────────┘
 ```
 
-### 3. Qualidade Primeiro
-- 80%+ cobertura de testes
+### 3. Qualidade em Primeiro Lugar
+
+Cada feature deve passar pelos portões de qualidade:
+- 80%+ de cobertura de testes
 - Análise estática aprovada
-- Auditoria de segurança limpa
+- Auditoria de segurança sem pendências
 - Documentação atualizada
+
+---
+
+## Otimizações Automáticas (v8.7)
+
+O Claude-Craft agora inclui padrões otimizados prontos para uso:
+
+**Instalado automaticamente:**
+- ✓ `.claudeignore` para reduzir ruído de contexto
+- ✓ `settings.json` com hook PostCompact para reinjeção de contexto
+- ✓ `settings.local.json` com permissões wildcard
+- ✓ `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` aplicado para economia de custos
+- ✓ `--ultra-compact` do RTK aplicado automaticamente durante a instalação
+
+**Opcional: Integração com RTK**
+
+Para máxima redução do output de CLI (economia de 60–90%):
+
+```bash
+# No Claude Code, execute o comando de configuração
+/common:setup-rtk
+```
+
+**Economia esperada:** 55–65% de redução total de tokens com RTK completo + otimizações. Consulte o [Guia de Configuração](08-setup-new-project.md) para detalhes.
 
 ---
 
 ## Próximos Passos
 
-1. **[Guia de Criação de Projeto](02-project-creation.md)**
-2. **[Guia de Desenvolvimento de Features](03-feature-development.md)**
-3. **[Guia de Correção de Bugs](04-bug-fixing.md)**
+Agora que você compreende o básico, continue com:
+
+1. **[Guia de Criação de Projeto](02-project-creation.md)** - Configuração detalhada para diferentes cenários
+2. **[Guia de Desenvolvimento de Features](03-feature-development.md)** - Fluxo de trabalho TDD com agentes e comandos
+3. **[Guia de Correção de Bugs](04-bug-fixing.md)** - Diagnóstico e fluxo de testes de regressão
 
 ---
 
-[Próximo: Criação de Projeto &rarr;](02-project-creation.md)
+## Referência Rápida
+
+### Comandos Comuns
+
+```bash
+# Instalação
+make install-{tech} TARGET=caminho LANG=xx
+
+# Listar opções disponíveis
+make help
+
+# Validar configuração YAML
+make config-validate CONFIG=arquivo.yaml
+```
+
+### Agentes Úteis
+
+| Agente | Finalidade |
+|--------|-----------|
+| `@api-designer` | Design e documentação de API |
+| `@database-architect` | Design de esquema de banco de dados |
+| `@tdd-coach` | Auxílio na escrita de testes |
+| `@{tech}-reviewer` | Revisão de código para a tecnologia específica |
+
+### Comandos Essenciais
+
+| Comando | Finalidade |
+|---------|-----------|
+| `/common:analyze-feature` | Analisar requisitos |
+| `/{tech}:generate-crud` | Gerar código CRUD |
+| `/{tech}:check-compliance` | Auditoria completa de qualidade |
+| `/common:security-audit` | Revisão de segurança |
+
+---
+
+[Próximo: Guia de Criação de Projeto &rarr;](02-project-creation.md)

--- a/docs/guides/pt/02-project-creation.md
+++ b/docs/guides/pt/02-project-creation.md
@@ -1,130 +1,421 @@
 # Guia de Criação de Projeto
 
-Este guia acompanha você na configuração de um novo projeto com Claude-Craft.
+Este guia acompanha você na configuração de um novo projeto com o Claude-Craft, desde a escolha da stack de tecnologia até a configuração do ambiente de desenvolvimento.
 
 ---
 
-## Escolher Sua Tecnologia
+## Sumário
 
-Claude-Craft suporta **11 stacks de aplicação** (+ 8 de infraestrutura):
+1. [Escolhendo a Sua Tecnologia](#escolhendo-a-sua-tecnologia)
+2. [Métodos de Instalação](#métodos-de-instalação)
+3. [Projetos de Tecnologia Única](#projetos-de-tecnologia-única)
+4. [Projetos Monorepo](#projetos-monorepo)
+5. [Configuração Pós-Instalação](#configuração-pós-instalação)
+6. [Lista de Verificação de Início de Projeto](#lista-de-verificação-de-início-de-projeto)
 
-### Stacks de Desenvolvimento
+---
 
-| Tecnologia | Ideal Para | Arquitetura | Características Principais |
-|------------|------------|-------------|---------------------------|
-| **C# / .NET** | APIs backend, Enterprise | Clean Architecture | CQRS, MediatR, EF Core |
-| **Symfony / PHP** | APIs backend, Apps web | Clean Architecture + DDD | Doctrine, Messenger, API Platform |
-| **Laravel / PHP** | Apps web, APIs rápidas | Clean Architecture | Actions, Pest PHP, Sanctum |
-| **PHP** | Clean Architecture genérica | Clean Architecture | PSR-12, PHPStan, Pest PHP |
-| **Flutter / Dart** | Apps móveis | Feature-based + BLoC | Material/Cupertino, Gestão de estado |
+## Escolhendo a Sua Tecnologia
+
+### Comparação de Tecnologias
+
+| Tecnologia | Melhor Para | Arquitetura | Características Principais |
+|------------|-------------|-------------|---------------------------|
+| **.NET / C#** | APIs corporativas | Clean Architecture + CQRS | MediatR, EF Core, C# 14 |
+| **Symfony** | APIs backend, Apps web | Clean Architecture + DDD | Doctrine, Messenger, API Platform |
+| **Flutter** | Apps móveis | Feature-based + BLoC | Material/Cupertino, gerenciamento de estado |
 | **Python** | APIs, Serviços de dados | Clean Architecture | FastAPI, async/await, Pydantic |
-| **React** | SPAs web | Feature-based + Hooks | Zustand, React Query, acessibilidade |
-| **React Native** | Móvel multiplataforma | Feature-based | Navigation 7, Reanimated 4 |
-| **Angular** | Apps empresariais | Domain-driven | Signals, Standalone, RxJS |
+| **React** | SPAs web | Feature-based + Hooks | Gerenciamento de estado, acessibilidade |
+| **React Native** | Mobile multiplataforma | Baseada em navegação | Módulos nativos, código específico por plataforma |
+| **Angular** | Apps web corporativos | Domain-driven | Signals, Standalone, RxJS |
 | **Vue.js** | SPAs web | Composition API | Pinia, Vitest, TypeScript |
+| **Laravel** | APIs PHP, Apps web | Clean Architecture | Actions, Pest PHP, Sanctum |
+| **PHP** | Bibliotecas, Backend | Clean Architecture | PSR-12, PHPStan, Pest PHP |
 
-### Stacks de Infraestrutura
-
-Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hetzner Cloud, PgBouncer, FrankenPHP
-
-### Escolha por Tipo de Projeto
+### Escolhendo com Base no Tipo de Projeto
 
 | Tipo de Projeto | Stack Recomendado |
 |-----------------|-------------------|
-| API REST | Symfony, Laravel ou Python |
-| App móvel (nativa) | Flutter |
+| API REST | Symfony ou Python |
+| App móvel (sensação nativa) | Flutter |
 | App móvel (equipe JS) | React Native |
-| SPA Web | React, Vue.js ou Angular |
+| SPA Web | React |
 | Full-stack web | Symfony + React |
 | Full-stack móvel | Symfony + Flutter |
-| Microserviços | Python (FastAPI) |
-| Enterprise | C# / .NET ou Angular |
+| Microsserviços | Python (FastAPI) |
+
+### Combinações Comuns
+
+```
+Aplicação Web:      Symfony (backend) + React (frontend)
+Aplicação Móvel:    Symfony (API) + Flutter (mobile)
+Plataforma Completa: Symfony (API) + React (web) + Flutter (mobile)
+Plataforma de Dados: Python (API) + React (dashboard)
+```
 
 ---
 
 ## Métodos de Instalação
 
+O Claude-Craft oferece múltiplos métodos de instalação para se adaptar a diferentes fluxos de trabalho.
+
 ### Método 1: Makefile (Recomendado)
 
+A abordagem mais simples e flexível.
+
 ```bash
+# Sintaxe básica
 make install-{tecnologia} TARGET=caminho LANG=idioma
 
 # Exemplos
-make install-symfony TARGET=./backend LANG=pt
-make install-flutter TARGET=./mobile LANG=pt
+make install-symfony TARGET=./backend LANG=en
+make install-flutter TARGET=./mobile LANG=fr
+make install-python TARGET=./api LANG=es
+make install-react TARGET=./frontend LANG=de
+make install-reactnative TARGET=./app LANG=pt
 ```
 
-#### Opções
+#### Opções Disponíveis
+
+| Opção | Descrição | Exemplo |
+|-------|-----------|---------|
+| `TARGET` | Caminho de instalação | `TARGET=~/projects/myapp` |
+| `LANG` | Código do idioma | `LANG=fr` |
+| `OPTIONS` | Flags adicionais | `OPTIONS="--force --backup"` |
+
+#### Flags de Opção
+
 ```bash
-OPTIONS="--dry-run"      # Pré-visualização sem alterações
-OPTIONS="--force"        # Sobrescrever arquivos
-OPTIONS="--backup"       # Criar backup
-OPTIONS="--interactive"  # Modo interativo
-OPTIONS="--update"       # Apenas atualizar
+# Pré-visualizar mudanças sem aplicar
+make install-symfony TARGET=./backend OPTIONS="--dry-run"
+
+# Forçar sobrescrita de arquivos existentes (cria backup)
+make install-symfony TARGET=./backend OPTIONS="--force"
+
+# Criar backup antes da instalação
+make install-symfony TARGET=./backend OPTIONS="--backup"
+
+# Modo interativo (solicita informações do projeto)
+make install-symfony TARGET=./backend OPTIONS="--interactive"
+
+# Apenas atualizar (preserva arquivos específicos do projeto)
+make install-symfony TARGET=./backend OPTIONS="--update"
 ```
 
-### Método 2: Script Direto
+### Método 2: Execução Direta de Script
+
+Execute os scripts de instalação diretamente para mais controle.
 
 ```bash
-./Dev/scripts/install-symfony-rules.sh --lang=pt ~/meu-projeto
+# Sintaxe
+./Dev/scripts/install-{tecnologia}-rules.sh [OPTIONS] [TARGET]
+
+# Exemplos
+./Dev/scripts/install-symfony-rules.sh --lang=fr ~/meu-projeto
+./Dev/scripts/install-flutter-rules.sh --lang=en --dry-run .
+./Dev/scripts/install-python-rules.sh --force --backup ~/api
+```
+
+#### Opções do Script
+
+```bash
+--lang=XX       # Idioma (en, fr, es, de, pt)
+--install       # Modo de instalação completa
+--update        # Atualizar apenas as regras comuns
+--force         # Sobrescrever todos os arquivos
+--dry-run       # Pré-visualizar sem alterações
+--backup        # Criar backup primeiro
+--interactive   # Solicitar informações do projeto
+--help          # Mostrar ajuda
+--version       # Mostrar versão
 ```
 
 ### Método 3: Configuração YAML
 
-```yaml
-# claude-projects.yaml
-settings:
-  default_lang: "pt"
-
-projects:
-  - name: "minha-plataforma"
-    path: "~/Projetos/minha-plataforma"
-    modules:
-      - name: "api"
-        path: "backend"
-        technologies: ["symfony"]
-      - name: "mobile"
-        path: "app"
-        technologies: ["flutter"]
-```
+Melhor para monorepos e configurações com múltiplos projetos.
 
 ```bash
-make config-install CONFIG=claude-projects.yaml PROJECT=minha-plataforma
+# Criar a configuração
+cp claude-projects.yaml.example claude-projects.yaml
+
+# Editar a configuração
+nano claude-projects.yaml
+
+# Validar a configuração
+make config-validate CONFIG=claude-projects.yaml
+
+# Instalar um projeto específico
+make config-install CONFIG=claude-projects.yaml PROJECT=my-project
+
+# Instalar todos os projetos
+make config-install-all CONFIG=claude-projects.yaml
 ```
 
 ---
 
-## Projetos Mono-Tecnologia
+## Projetos de Tecnologia Única
 
 ### Projeto Symfony
+
 ```bash
-mkdir ~/minha-api && cd ~/minha-api && git init
-make install-symfony TARGET=. LANG=pt
+# Criar o diretório do projeto
+mkdir ~/minha-api-symfony
+cd ~/minha-api-symfony
+composer create-project symfony/skeleton .
+git init
+
+# Instalar as regras Claude-Craft
+make install-symfony TARGET=. LANG=fr
+
+# Verificar a instalação
+ls -la .claude/
 ```
+
+**Conteúdo instalado:**
+- 21 regras específicas para Symfony (Clean Architecture, DDD, CQRS, etc.)
+- 10+ comandos Symfony (`/symfony:generate-crud`, `/symfony:check-compliance`, etc.)
+- Agente revisor do Symfony
+- Templates de código (Service, ValueObject, Aggregate, etc.)
+- Listas de verificação de qualidade
 
 ### Projeto Flutter
+
 ```bash
-flutter create minha_app && cd minha_app && git init
-make install-flutter TARGET=. LANG=pt
+# Criar o projeto
+flutter create my_flutter_app
+cd my_flutter_app
+git init
+
+# Instalar as regras Claude-Craft
+make install-flutter TARGET=. LANG=en
+
+# Verificar
+ls -la .claude/
 ```
 
+**Conteúdo instalado:**
+- 13 regras específicas para Flutter (BLoC, gerenciamento de estado, testes)
+- 10 comandos Flutter
+- Agente revisor do Flutter
+- Templates de Widget e BLoC
+- Listas de verificação de qualidade
+
 ### Projeto Python
+
 ```bash
-mkdir ~/minha-api-python && cd ~/minha-api-python && git init
-make install-python TARGET=. LANG=pt
+# Criar o projeto
+mkdir ~/minha-api-python
+cd ~/minha-api-python
+python -m venv venv
+git init
+
+# Instalar as regras Claude-Craft
+make install-python TARGET=. LANG=en
+
+# Verificar
+ls -la .claude/
+```
+
+**Conteúdo instalado:**
+- 12 regras específicas para Python (FastAPI, async, tipagem)
+- 10 comandos Python
+- Agente revisor do Python
+- Templates de serviço e API
+- Listas de verificação de qualidade
+
+### Projeto React
+
+```bash
+# Criar o projeto
+npx create-react-app my-react-app
+cd my-react-app
+
+# Instalar as regras Claude-Craft
+make install-react TARGET=. LANG=en
+
+# Verificar
+ls -la .claude/
+```
+
+### Projeto React Native
+
+```bash
+# Criar o projeto
+npx react-native init MyApp
+cd MyApp
+
+# Instalar as regras Claude-Craft
+make install-reactnative TARGET=. LANG=en
+
+# Verificar
+ls -la .claude/
+```
+
+---
+
+## Projetos Monorepo
+
+### Entendendo a Estrutura do Monorepo
+
+Um monorepo típico pode ter a seguinte estrutura:
+
+```
+my-platform/
+├── backend/          # API Symfony
+├── web/              # Frontend React
+├── mobile/           # App Flutter
+├── shared/           # Tipos/contratos compartilhados
+└── claude-projects.yaml
+```
+
+### Estrutura da Configuração YAML
+
+```yaml
+# claude-projects.yaml
+
+settings:
+  default_lang: "fr"              # Idioma padrão para todos os projetos
+  claude_craft_path: "~/claude-craft"  # Caminho para o claude-craft (opcional)
+
+projects:
+  - name: "my-platform"
+    description: "Plataforma SaaS full-stack"
+    path: "~/Projects/my-platform"
+    modules:
+      - name: "api"
+        path: "backend"
+        technologies: ["symfony"]
+        lang: "en"                # Substituir o idioma padrão
+
+      - name: "web"
+        path: "web"
+        technologies: ["react"]
+
+      - name: "mobile"
+        path: "mobile"
+        technologies: ["flutter"]
+```
+
+### Campos de Configuração
+
+#### Nível do Projeto
+
+| Campo | Obrigatório | Descrição |
+|-------|-------------|-----------|
+| `name` | Sim | Identificador do projeto |
+| `description` | Não | Descrição do projeto |
+| `path` | Sim | Caminho absoluto para a raiz do projeto |
+| `lang` | Não | Substituição de idioma |
+| `modules` | Não | Lista de módulos (para monorepos) |
+| `technologies` | Não | Tecnologias se não houver módulos |
+
+#### Nível do Módulo
+
+| Campo | Obrigatório | Descrição |
+|-------|-------------|-----------|
+| `name` | Sim | Identificador do módulo |
+| `path` | Sim | Caminho relativo a partir da raiz do projeto |
+| `technologies` | Sim | Lista de tecnologias |
+| `lang` | Não | Substituição de idioma |
+| `skip_common` | Não | Pular regras comuns (padrão: false) |
+
+### Comandos de Instalação
+
+```bash
+# Validar a configuração
+make config-validate CONFIG=claude-projects.yaml
+
+# Listar projetos configurados
+make config-list CONFIG=claude-projects.yaml
+
+# Instalar um projeto específico
+make config-install CONFIG=claude-projects.yaml PROJECT=my-platform
+
+# Instalar um módulo específico
+make config-install CONFIG=claude-projects.yaml PROJECT=my-platform MODULE=api
+
+# Dry-run para pré-visualizar
+make config-install CONFIG=claude-projects.yaml PROJECT=my-platform OPTIONS="--dry-run"
+
+# Instalar todos os projetos
+make config-install-all CONFIG=claude-projects.yaml
+```
+
+### Exemplos do Mundo Real
+
+#### Exemplo 1: Plataforma SaaS
+
+```yaml
+projects:
+  - name: "saas-platform"
+    path: "~/Projects/saas"
+    modules:
+      - name: "api"
+        path: "services/api"
+        technologies: ["symfony"]
+      - name: "admin"
+        path: "apps/admin"
+        technologies: ["react"]
+      - name: "mobile"
+        path: "apps/mobile"
+        technologies: ["flutter"]
+```
+
+#### Exemplo 2: Microsserviços
+
+```yaml
+projects:
+  - name: "microservices"
+    path: "~/Projects/micro"
+    modules:
+      - name: "gateway"
+        path: "gateway"
+        technologies: ["python"]
+      - name: "users"
+        path: "services/users"
+        technologies: ["symfony"]
+      - name: "orders"
+        path: "services/orders"
+        technologies: ["symfony"]
+      - name: "analytics"
+        path: "services/analytics"
+        technologies: ["python"]
+```
+
+#### Exemplo 3: Múltiplos Projetos Independentes
+
+```yaml
+settings:
+  default_lang: "fr"
+
+projects:
+  - name: "client-a"
+    path: "~/Clients/client-a"
+    technologies: ["symfony", "react"]
+
+  - name: "client-b"
+    path: "~/Clients/client-b"
+    technologies: ["flutter"]
+    lang: "en"
+
+  - name: "internal-tool"
+    path: "~/Internal/tool"
+    technologies: ["python"]
 ```
 
 ---
 
 ## Configuração Pós-Instalação
 
+Após a instalação, configure estes arquivos para o seu projeto específico.
+
 ### 1. Contexto do Projeto (`rules/00-project-context.md`)
 
-Este é o arquivo mais importante para personalizar.
+Este é o arquivo mais importante para personalizar. Ele informa ao Claude sobre o seu projeto específico.
 
 **Opção A: Configuração Interativa (Recomendada)**
 
-Execute este comando no Claude Code para detectar sua stack e responder perguntas direcionadas:
+Execute este comando no Claude Code para detectar automaticamente a sua stack e responder perguntas direcionadas:
 ```bash
 /common:setup-project-context
 ```
@@ -136,49 +427,179 @@ Edite o arquivo diretamente com os detalhes do seu projeto:
 ```markdown
 # Contexto do Projeto
 
-## Informações
-- **Nome**: Minha API E-commerce
+## Informações do Projeto
+- **Nome**: Minha API Incrível
 - **Tipo**: API REST para plataforma e-commerce
+- **Tamanho da Equipe**: 3 desenvolvedores
 
 ## Stack Técnico
 - PHP 8.3 com Symfony 7.0
 - PostgreSQL 16
 - Redis para cache
+- RabbitMQ para mensageria
 
 ## Convenções
-- Código em inglês, documentação em português
+- Padrão de codificação PSR-12
+- Tipagem estrita habilitada
+- Código em inglês, documentação em francês
+
+## Restrições
+- Conformidade com RGPD obrigatória
+- Deve suportar arquitetura multitenant
+- Tempo máximo de resposta: 200ms
+
+## Dependências Externas
+- Stripe para pagamentos
+- SendGrid para e-mails
+- S3 para armazenamento de arquivos
 ```
 
 ### 2. Configuração Principal (`CLAUDE.md`)
 
-Revisar e ajustar:
-- Configuração de idioma
-- Requisitos de arquitetura
-- Requisitos de qualidade
-- Requisitos Docker
+O arquivo CLAUDE.md no diretório `.claude/` contém a configuração principal. Seções-chave para revisar:
+
+```markdown
+# Configuração do Projeto
+
+## Configurações de Idioma
+- Código: Inglês
+- Documentação: Francês
+- Comentários: Inglês
+
+## Arquitetura
+Clean Architecture + DDD + Hexagonal
+
+## Requisitos de Qualidade
+- Cobertura de testes: 80%+
+- Nível PHPStan: 9
+- Sem problemas críticos de segurança
+
+## Requisitos Docker
+Todos os comandos devem usar Docker via targets do make.
+```
+
+### 3. Configuração dos Agentes
+
+Revise os agentes instalados em `.claude/agents/` e personalize se necessário:
+
+```bash
+ls .claude/agents/
+# api-designer.md
+# database-architect.md
+# symfony-reviewer.md
+# tdd-coach.md
+# ...
+```
 
 ---
 
-## Checklist de Início
+## Lista de Verificação de Início de Projeto
+
+Use esta lista ao configurar um novo projeto:
 
 ### Pré-Instalação
+
 - [ ] Diretório do projeto criado
 - [ ] Repositório Git inicializado
-- [ ] Stack tecnológico decidido
+- [ ] Stack de tecnologia decidido
+- [ ] Preferência de idioma escolhida
 
 ### Instalação
+
 - [ ] Regras Claude-Craft instaladas
 - [ ] Instalação verificada (`ls .claude/`)
+- [ ] Sem erros na saída da instalação
 
 ### Configuração
-- [ ] `00-project-context.md` personalizado
-- [ ] `CLAUDE.md` revisado
+
+- [ ] `00-project-context.md` personalizado com os detalhes do projeto
+- [ ] `CLAUDE.md` revisado e ajustado
+- [ ] Convenções da equipe documentadas
+- [ ] Restrições e requisitos listados
 
 ### Verificação
-- [ ] Claude Code iniciado no diretório
-- [ ] Comandos disponíveis
-- [ ] Agentes respondendo
+
+- [ ] Claude Code iniciado no diretório do projeto
+- [ ] Comandos disponíveis (tente `/symfony:check-compliance`)
+- [ ] Agentes respondendo (tente `@symfony-reviewer hello`)
+
+### Configuração da Equipe
+
+- [ ] Diretório `.claude/` commitado no git
+- [ ] Membros da equipe informados sobre os comandos disponíveis
+- [ ] README atualizado com informações de uso do Claude-Craft
 
 ---
 
-[&larr; Primeiros Passos](01-getting-started.md) | [Desenvolvimento de Features &rarr;](03-feature-development.md)
+## Padrões Comuns
+
+### Instalando Apenas as Regras Comuns
+
+Para bibliotecas ou pacotes compartilhados que não se encaixam em uma tecnologia específica:
+
+```bash
+make install-common TARGET=./shared-lib LANG=en
+```
+
+### Instalando Ferramentas de Gerenciamento de Projeto
+
+Para rastreamento de sprint e gerenciamento de backlog:
+
+```bash
+make install-project TARGET=. LANG=fr
+```
+
+### Instalando Ferramentas de Infraestrutura
+
+Para suporte a Docker e CI/CD:
+
+```bash
+make install-infra TARGET=. LANG=en
+```
+
+### Instalação Completa (Todas as Tecnologias)
+
+```bash
+make install-all TARGET=. LANG=fr
+```
+
+---
+
+### Configuração de Otimização de Tokens
+
+Após instalar as regras, opcionalmente configure o RTK para economia de tokens:
+
+```bash
+# Na sessão do Claude Code
+/common:setup-rtk
+```
+
+Isso configura o proxy RTK, a otimização do modelo de sub-agentes e templates de hook para uma redução geral de tokens de 55-65%.
+
+---
+
+## Atualizando as Regras
+
+Quando o Claude-Craft lançar novas versões:
+
+```bash
+# Atualizar para a versão mais recente (preserva arquivos específicos do projeto)
+make install-symfony TARGET=./backend OPTIONS="--update"
+
+# Forçar reinstalação completa (backup criado automaticamente)
+make install-symfony TARGET=./backend OPTIONS="--force"
+```
+
+---
+
+## Próximos Passos
+
+Seu projeto está agora configurado! Continue com:
+
+1. **[Guia de Desenvolvimento de Funcionalidades](03-feature-development.md)** - Aprenda o fluxo de trabalho TDD
+2. **[Guia de Correção de Bugs](04-bug-fixing.md)** - Trate bugs de forma eficaz
+3. **[Referência de Ferramentas](05-tools-reference.md)** - Explore ferramentas adicionais
+
+---
+
+[&larr; Primeiros Passos](01-getting-started.md) | [Desenvolvimento de Funcionalidades &rarr;](03-feature-development.md)

--- a/docs/guides/pt/03-feature-development.md
+++ b/docs/guides/pt/03-feature-development.md
@@ -1,174 +1,655 @@
-# Guia de Desenvolvimento de Features
+# Guia de Desenvolvimento de Funcionalidades
 
-Fluxo de trabalho completo para desenvolver novas features com Claude-Craft.
+Este guia cobre o fluxo de trabalho completo para desenvolver novas funcionalidades usando o Claude-Craft, desde a análise inicial até a revisão final.
 
 ---
 
-## Fluxo de Trabalho TDD
+## Sumário
+
+1. [Visão Geral do Fluxo TDD](#visão-geral-do-fluxo-tdd)
+2. [Fase 1: Análise](#fase-1-análise)
+3. [Fase 2: Design](#fase-2-design)
+4. [Fase 3: Escrita de Testes](#fase-3-escrita-de-testes)
+5. [Fase 4: Implementação](#fase-4-implementação)
+6. [Fase 5: Refatoração](#fase-5-refatoração)
+7. [Fase 6: Revisão](#fase-6-revisão)
+8. [Exemplo Completo](#exemplo-completo)
+9. [Recursos Disponíveis](#recursos-disponíveis)
+
+---
+
+## Visão Geral do Fluxo TDD
+
+O Claude-Craft impõe um fluxo de Desenvolvimento Orientado a Testes (TDD):
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ 1. Analisar │ --> │ 2. Projetar │ --> │  3. Testes  │
+│  1. Analisar│ --> │  2. Design  │ --> │  3. Testes  │
 └─────────────┘     └─────────────┘     └─────────────┘
                                               │
                                               v
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│  6. Revisar │ <-- │5. Refatorar │ <-- │4. Implementar│
+│  6. Revisão │ <-- │5. Refatorar │ <-- │4. Implementar│
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
+
+### Por Que TDD?
+
+- **Confiança**: Os testes provam que o seu código funciona
+- **Documentação**: Os testes descrevem o comportamento esperado
+- **Design**: Escrever os testes primeiro leva a APIs melhores
+- **Regressão**: Os testes detectam bugs futuros
 
 ---
 
 ## Fase 1: Análise
 
+Antes de escrever qualquer código, entenda o que precisa ser construído.
+
+### Definir o Nível de Esforço
+
+Para fases de análise que exigem raciocínio profundo, defina alto esforço:
+
 ```bash
-/common:analyze-feature "Autenticação de usuários com tokens JWT"
+/effort high
 ```
+
+Use `/effort low` para buscas simples e `/effort medium` para trabalho de implementação padrão.
+
+### Usando o Comando de Análise
+
+```bash
+/common:analyze-feature "Autenticação de usuário com tokens JWT e controle de acesso baseado em papéis"
+```
+
+Este comando irá:
+1. Decompor a funcionalidade em componentes
+2. Identificar requisitos técnicos
+3. Listar possíveis casos extremos
+4. Sugerir a abordagem de implementação
+
+### Usando o Agente de Pesquisa
 
 ```markdown
 @research-assistant Pesquise as melhores práticas para autenticação JWT no Symfony 7
 ```
 
+O agente de pesquisa irá:
+- Buscar documentação e melhores práticas
+- Resumir as descobertas
+- Fornecer exemplos de código
+- Destacar considerações de segurança
+
+### Lista de Verificação da Análise
+
+- [ ] História de usuário claramente definida
+- [ ] Critérios de aceitação documentados
+- [ ] Casos extremos identificados
+- [ ] Abordagem técnica escolhida
+- [ ] Dependências identificadas
+- [ ] Implicações de segurança revisadas
+
 ---
 
-## Fase 2: Projeto
+## Fase 2: Design
 
-### Banco de Dados
+Projete a arquitetura antes da implementação.
+
+### Design do Banco de Dados
+
 ```markdown
-@database-architect Projete o esquema para a entidade User com funções e permissões
+@database-architect Projete o esquema para a entidade User com papéis e permissões
+
+Requisitos:
+- O usuário pode ter múltiplos papéis
+- Os papéis possuem permissões
+- Suporte a exclusão lógica (soft delete)
+- Trilha de auditoria para alterações
 ```
 
-### API
+O arquiteto de banco de dados irá:
+- Projetar um esquema normalizado
+- Sugerir índices
+- Considerar relacionamentos
+- Planejar as migrações
+
+### Design da API
+
 ```markdown
-@api-designer Projete a API REST para gestão de usuários
+@api-designer Projete a API REST para o gerenciamento de usuários
+
+Endpoints necessários:
+- Operações CRUD para usuários
+- Atribuição de papéis
+- Autenticação (login/logout)
+- Fluxo de redefinição de senha
 ```
 
-### Decisão Arquitetural
+O designer de API irá:
+- Definir os endpoints e métodos
+- Especificar os formatos de requisição/resposta
+- Documentar os requisitos de autenticação
+- Planejar as respostas de erro
+
+### Decisão de Arquitetura
+
 ```bash
-/common:architecture-decision "Como implementar controle de acesso baseado em funções"
+/common:architecture-decision "Como implementar controle de acesso baseado em papéis"
 ```
+
+Use este comando para escolhas arquiteturais importantes. Ele cria um Registro de Decisão de Arquitetura (ADR) documentando:
+- Contexto e problema
+- Opções consideradas
+- Solução escolhida
+- Consequências
+
+### Lista de Verificação do Design
+
+- [ ] Esquema de banco de dados projetado
+- [ ] Endpoints da API definidos
+- [ ] Decisões de arquitetura documentadas
+- [ ] Modelo de segurança definido
+- [ ] Estratégia de tratamento de erros planejada
 
 ---
 
-## Fase 3: Escrever Testes
+## Fase 3: Escrita de Testes
+
+Escreva os testes ANTES da implementação. Este é o "TD" do TDD.
+
+### Usando o Coach de TDD
 
 ```markdown
-@tdd-coach Ajude-me a escrever testes para o método de autenticação de UserService
+@tdd-coach Ajude-me a escrever testes para o método de autenticação do UserService
+
+O método deve:
+- Aceitar e-mail e senha
+- Retornar token JWT em caso de sucesso
+- Lançar exceção para credenciais inválidas
+- Bloquear a conta após 5 tentativas falhas
 ```
 
-### Tipos de Testes
+O coach de TDD irá:
+- Sugerir casos de teste
+- Escrever exemplos de código de teste
+- Explicar as asserções
+- Identificar casos extremos
 
-**Testes Unitários:**
+### Categorias de Testes
+
+#### Testes Unitários
+
+Teste componentes individuais em isolamento:
+
 ```php
+// tests/Unit/Domain/User/UserTest.php
 public function test_user_can_change_password(): void
 {
-    $user = User::create('test@example.com', 'old-password');
+    $user = User::create(
+        email: 'test@example.com',
+        password: 'old-password'
+    );
+
     $user->changePassword('new-password');
+
     $this->assertTrue($user->verifyPassword('new-password'));
+    $this->assertFalse($user->verifyPassword('old-password'));
 }
 ```
 
-**Testes de Integração:**
+#### Testes de Integração
+
+Teste as interações entre componentes:
+
 ```php
+// tests/Integration/UserServiceTest.php
 public function test_user_service_creates_user_in_database(): void
 {
     $service = $this->container->get(UserService::class);
-    $user = $service->createUser('test@example.com', 'password');
+
+    $user = $service->createUser(
+        email: 'test@example.com',
+        password: 'secure-password'
+    );
+
     $this->assertNotNull($user->getId());
+    $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
 }
 ```
+
+#### Testes BDD/Funcionais
+
+Teste cenários de negócio:
+
+```gherkin
+# features/authentication.feature
+Feature: Autenticação de Usuário
+  Como um usuário
+  Quero fazer login com minhas credenciais
+  Para que eu possa acessar recursos protegidos
+
+  Scenario: Login bem-sucedido
+    Given Tenho um usuário registrado com o e-mail "user@example.com"
+    When Envio credenciais válidas
+    Then Devo receber um token JWT
+    And O token deve ser válido por 1 hora
+```
+
+### Comandos de Teste por Tecnologia
+
+```bash
+# Symfony
+/symfony:check-testing
+
+# Flutter
+/flutter:check-testing
+
+# Python
+/python:check-testing
+
+# React
+/react:check-testing
+```
+
+### Lista de Verificação de Escrita de Testes
+
+- [ ] Testes unitários para a lógica de domínio
+- [ ] Testes de integração para os serviços
+- [ ] Testes de API para os endpoints
+- [ ] Casos extremos cobertos
+- [ ] Cenários de erro testados
+- [ ] Todos os testes falhando (ainda não implementados)
 
 ---
 
 ## Fase 4: Implementação
 
-### Comandos de Geração
+Agora implemente o código para fazer os testes passarem.
+
+### Comandos de Geração de Código
+
+#### Symfony
 
 ```bash
-# Symfony
+# Gerar CRUD com testes
 /symfony:generate-crud User
+
+# Gerar endpoint de API
 /symfony:api-endpoint POST /api/users CreateUserRequest
 
-# Flutter
-/flutter:generate-feature Authentication
-/flutter:generate-widget LoginScreen
+# Gerar comando
+/symfony:generate-command SendWelcomeEmailCommand
+```
 
-# Python
+#### Flutter
+
+```bash
+# Gerar BLoC
+/flutter:generate-bloc Authentication
+
+# Gerar tela
+/flutter:generate-screen LoginScreen
+
+# Gerar widget
+/flutter:generate-widget UserAvatar
+```
+
+#### Python
+
+```bash
+# Gerar endpoint FastAPI
 /python:generate-endpoint POST /users CreateUser
-/python:generate-model User
 
-# React
+# Gerar serviço
+/python:generate-service UserService
+
+# Gerar modelo
+/python:generate-model User
+```
+
+#### React
+
+```bash
+# Gerar componente
 /react:generate-component UserProfile
+
+# Gerar hook
 /react:generate-hook useAuth
 
-# Angular
-/angular:generate-component UserProfile
-
-# Vue.js
-/vuejs:generate-component UserProfile
-
-# C# / .NET
-/csharp:generate-feature User
-
-# Laravel
-/laravel:generate-controller UserController
-
-# React Native
-/reactnative:generate-screen LoginScreen
+# Gerar contexto
+/react:generate-context AuthContext
 ```
+
+### Usando Templates
+
+Os templates fornecem padrões de código prontos para uso. Acesse-os com:
+
+```markdown
+Mostre-me o template de serviço para Symfony
+```
+
+Templates disponíveis por tecnologia:
+
+| Symfony | Flutter | Python | React |
+|---------|---------|--------|-------|
+| service.md | bloc.md | service.md | component.md |
+| value-object.md | widget.md | repository.md | hook.md |
+| aggregate-root.md | screen.md | endpoint.md | context.md |
+| domain-event.md | state.md | model.md | reducer.md |
+| repository.md | cubit.md | schema.md | - |
+
+### Boas Práticas de Implementação
+
+1. **Um teste de cada vez**: Faça um teste passar antes de avançar para o próximo
+2. **Código mínimo**: Escreva apenas o suficiente para passar no teste
+3. **Sem otimização prematura**: Foque na corretude primeiro
+4. **Siga os padrões existentes**: Use templates e convenções
+
+### Lista de Verificação da Implementação
+
+- [ ] Todos os testes unitários passando
+- [ ] Todos os testes de integração passando
+- [ ] Todos os testes de API passando
+- [ ] Sem valores hardcoded
+- [ ] Tratamento de erros implementado
+- [ ] Logging adicionado
 
 ---
 
 ## Fase 5: Refatoração
 
+Com os testes passando, melhore a qualidade do código.
+
+### Comandos de Refatoração
+
 ```bash
+# Verificar qualidade do código
 /symfony:check-code-quality
+/flutter:check-code-quality
+/python:check-code-quality
+/react:check-code-quality
+
+# Verificar conformidade de arquitetura
 /symfony:check-architecture
+/flutter:check-architecture
 ```
 
+### Usando o Especialista em Refatoração
+
 ```markdown
-@refactoring-specialist Revise esta classe de serviço para melhorias potenciais
+@refactoring-specialist Revise esta classe de serviço em busca de possíveis melhorias
+
+[cole o código aqui]
 ```
+
+O especialista em refatoração irá:
+- Identificar code smells
+- Sugerir melhorias
+- Mostrar exemplos refatorados
+- Explicar os trade-offs
+
+### Padrões Comuns de Refatoração
+
+1. **Extrair Método**: Dividir métodos longos em métodos menores
+2. **Extrair Classe**: Dividir classes grandes
+3. **Introduzir Value Object**: Substituir primitivos por tipos de domínio
+4. **Substituir Condicional por Polimorfismo**: Usar o padrão strategy
+5. **Mover Método**: Colocar os métodos onde eles pertencem
+
+### Lista de Verificação da Refatoração
+
+- [ ] Sem duplicação de código
+- [ ] Métodos com menos de 20 linhas
+- [ ] Classes com menos de 200 linhas
+- [ ] Nomenclatura clara
+- [ ] Estilo consistente
+- [ ] Todos os testes ainda passando
 
 ---
 
 ## Fase 6: Revisão
 
+Verificação de qualidade final antes da conclusão.
+
+### Auditoria de Conformidade
+
 ```bash
-# Auditoria completa (pontuação /100)
+# Verificação de conformidade completa (retorna pontuação /100)
 /symfony:check-compliance
+/flutter:check-compliance
+/python:check-compliance
+/react:check-compliance
 ```
 
+Esta auditoria abrangente verifica:
+- Conformidade de arquitetura
+- Qualidade do código
+- Cobertura de testes
+- Problemas de segurança
+- Documentação
+
+### Revisão de Código com Agentes
+
 ```markdown
-@symfony-reviewer Revise minha implementação completa de autenticação de User
+@symfony-reviewer Revise minha implementação completa de autenticação de usuário
+
+Arquivos alterados:
+- src/Domain/User/User.php
+- src/Application/Service/AuthenticationService.php
+- src/Infrastructure/Security/JwtTokenGenerator.php
+- tests/Unit/Domain/User/UserTest.php
+- tests/Integration/AuthenticationServiceTest.php
 ```
+
+O revisor irá:
+- Verificar a conformidade de arquitetura
+- Identificar possíveis problemas
+- Sugerir melhorias
+- Verificar as melhores práticas
+
+### Auditoria de Segurança
 
 ```bash
 /common:security-audit
 ```
 
----
+Ou use o agente focado em segurança:
 
-## Checklist de Feature
+```markdown
+@devops-engineer Revise a segurança do sistema de autenticação
 
-- [ ] User story definida
-- [ ] Testes escritos (TDD)
-- [ ] Código implementado
-- [ ] Testes passam (80%+ cobertura)
-- [ ] Revisão efetuada
+Preocupações:
+- Segurança do token JWT
+- Armazenamento de senhas
+- Rate limiting
+- Configuração de CORS
+```
+
+### Lista de Verificação da Funcionalidade
+
+Use a lista de verificação integrada:
+
+```bash
+cat .claude/checklists/feature-checklist.md
+```
+
+Itens-chave:
+- [ ] Requisitos da história de usuário atendidos
+- [ ] Todos os critérios de aceitação verificados
+- [ ] Testes escritos e passando (cobertura de 80%+)
+- [ ] Código revisado
+- [ ] Auditoria de segurança aprovada
 - [ ] Documentação atualizada
+- [ ] Sem problemas críticos na análise estática
+- [ ] Desempenho aceitável
+- [ ] Pronto para revisão de código
 
 ---
 
-## Resumo de Agentes
+## Exemplo Completo
 
-| Agente | Uso |
-|--------|-----|
-| `@api-designer` | Design de endpoints API |
-| `@database-architect` | Design de esquemas BD |
-| `@tdd-coach` | Guia para escrita de testes |
+Vamos percorrer uma funcionalidade completa: Adicionar o registro de usuário.
+
+### Passo 1: Analisar
+
+```markdown
+/common:analyze-feature "Registro de usuário com verificação de e-mail"
+
+Esperado:
+- O usuário envia e-mail e senha
+- O sistema envia um e-mail de verificação
+- O usuário clica no link para verificar
+- A conta se torna ativa
+```
+
+### Passo 2: Projetar o Banco de Dados
+
+```markdown
+@database-architect Projete o esquema para User com verificação de e-mail
+
+Campos necessários:
+- id, email, password_hash
+- email_verified_at (timestamp nullable)
+- verification_token
+- created_at, updated_at
+```
+
+### Passo 3: Projetar a API
+
+```markdown
+@api-designer Projete os endpoints de API para o registro
+
+POST /api/register - Criar conta
+POST /api/verify-email - Verificar e-mail com token
+POST /api/resend-verification - Reenviar e-mail de verificação
+```
+
+### Passo 4: Escrever os Testes
+
+```markdown
+@tdd-coach Ajude-me a escrever testes para o UserRegistrationService
+
+Casos de teste:
+1. Registro bem-sucedido cria o usuário
+2. E-mail duplicado retorna erro
+3. Senha fraca retorna erro
+4. E-mail de verificação é enviado
+5. Token de verificação ativa a conta
+6. Token expirado retorna erro
+```
+
+### Passo 5: Gerar Código
+
+```bash
+/symfony:generate-crud User --with-api
+/symfony:generate-command SendVerificationEmailCommand
+```
+
+### Passo 6: Implementar
+
+Faça os testes passarem um por um:
+
+```php
+// Fazer o teste 1 passar
+public function register(string $email, string $password): User
+{
+    $user = User::create($email, $password);
+    $this->repository->save($user);
+    return $user;
+}
+
+// Fazer o teste 2 passar
+public function register(string $email, string $password): User
+{
+    if ($this->repository->findByEmail($email)) {
+        throw new DuplicateEmailException($email);
+    }
+    // ...
+}
+
+// Continuar para cada teste...
+```
+
+### Passo 7: Refatorar
+
+```bash
+/symfony:check-code-quality
+```
+
+Corrija todos os problemas identificados.
+
+### Passo 8: Revisar
+
+```markdown
+@symfony-reviewer Revise minha implementação de registro de usuário
+
+Implementação completa incluindo:
+- Domain: Entidade User, ValueObjects
+- Application: RegistrationService
+- Infrastructure: DoctrineUserRepository
+- API: RegisterController
+- Tests: Unitários, Integração, API
+```
+
+### Passo 9: Verificação Final
+
+```bash
+/symfony:check-compliance
+```
+
+Meta: Pontuação 90+/100
+
+---
+
+## Recursos Disponíveis
+
+### Resumo dos Agentes
+
+| Agente | Para Usar |
+|--------|-----------|
+| `@api-designer` | Design de endpoints de API |
+| `@database-architect` | Design de esquema de banco de dados |
+| `@tdd-coach` | Orientação para escrita de testes |
 | `@refactoring-specialist` | Melhoria de código |
 | `@{tech}-reviewer` | Revisão de código |
+| `@devops-engineer` | Revisão de infraestrutura |
+| `@research-assistant` | Pesquisa de melhores práticas |
+
+### Resumo dos Comandos
+
+| Fase | Comandos |
+|------|----------|
+| Análise | `/common:analyze-feature` |
+| Design | `/common:architecture-decision` |
+| Testes | `/{tech}:check-testing` |
+| Geração | `/{tech}:generate-*` |
+| Qualidade | `/{tech}:check-code-quality` |
+| Revisão | `/{tech}:check-compliance` |
+| Segurança | `/common:security-audit` |
+
+### Localização dos Templates
+
+```bash
+ls .claude/templates/
+```
+
+### Localização das Listas de Verificação
+
+```bash
+ls .claude/checklists/
+```
+
+---
+
+## Dicas para o Sucesso
+
+1. **Não pule os testes**: Eles são a sua rede de segurança
+2. **Use os agentes**: Eles fornecem orientação especializada
+3. **Execute as verificações de conformidade com frequência**: Identifique problemas cedo
+4. **Siga o fluxo de trabalho**: Cada fase tem um propósito
+5. **Documente as decisões**: Use ADRs para escolhas importantes
+6. **Gerencie o contexto**: Use `/context` para verificar sugestões de otimização, `/clear` entre fases
+7. **Ajuste o esforço**: Use `/effort high` para análise/design, `/effort low` para geração de código
 
 ---
 

--- a/docs/guides/pt/04-bug-fixing.md
+++ b/docs/guides/pt/04-bug-fixing.md
@@ -1,67 +1,264 @@
 # Guia de Correção de Bugs
 
-Abordagem sistemática para corrigir bugs com Claude-Craft.
+Este guia cobre a abordagem sistemática para corrigir bugs usando o Claude-Craft, desde o diagnóstico até a validação.
 
 ---
 
-## Fluxo de Correção
+## Índice
+
+1. [Fluxo de Correção de Bugs](#fluxo-de-correção-de-bugs)
+2. [Fase 1: Reproduzir](#fase-1-reproduzir)
+3. [Fase 2: Diagnosticar](#fase-2-diagnosticar)
+4. [Fase 3: Escrever Teste de Regressão](#fase-3-escrever-teste-de-regressão)
+5. [Fase 4: Corrigir](#fase-4-corrigir)
+6. [Fase 5: Validar](#fase-5-validar)
+7. [Fase 6: Documentar](#fase-6-documentar)
+8. [Procedimentos de Hotfix](#procedimentos-de-hotfix)
+9. [Exemplo Completo](#exemplo-completo)
+
+---
+
+## Fluxo de Correção de Bugs
+
+A abordagem sistemática para corrigir bugs:
 
 ```
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ 1. Reproduzir│ -->│2. Diagnosticar│ --> │  3. Teste   │
+│ 1. Reproduzir│ --> │2. Diagnosticar│ --> │  3. Teste   │
 └─────────────┘     └─────────────┘     └─────────────┘
                                               │
                                               v
 ┌─────────────┐     ┌─────────────┐     ┌─────────────┐
-│ 6. Documentar│ <--│  5. Validar │ <-- │ 4. Corrigir │
+│ 6. Documentar│ <-- │  5. Validar │ <-- │ 4. Corrigir │
 └─────────────┘     └─────────────┘     └─────────────┘
 ```
+
+### Por Que Esta Abordagem?
+
+1. **Reproduzir primeiro**: Não é possível corrigir o que não se consegue ver
+2. **Testar antes de corrigir**: Prova que o bug existe e foi corrigido
+3. **Validar completamente**: Garante que não há regressão
+4. **Documentar**: Ajuda a prevenir bugs semelhantes no futuro
 
 ---
 
 ## Fase 1: Reproduzir
 
-- Coletar informações do relatório de bug
-- Criar ambiente de reprodução
-- Verificar que o bug é consistente
+Antes de corrigir, reproduza o bug de forma consistente.
+
+### Coletar Informações
+
+Obtenha do relatório de bug:
+- Passos para reproduzir
+- Comportamento esperado
+- Comportamento real
+- Ambiente (versão, SO, etc.)
+- Mensagens de erro/logs
+- Capturas de tela, se aplicável
+
+### Criar Ambiente de Reprodução
+
+```bash
+# Fazer checkout da versão problemática
+git checkout <commit-ou-tag>
+
+# Configurar ambiente idêntico
+make docker-up
+
+# Reproduzir com os passos exatos
+```
+
+### Verificar a Reprodução
+
+Você consegue acionar o bug de forma consistente?
+
+- [ ] Bug ocorre com os passos relatados
+- [ ] Bug ocorre no mesmo ambiente
+- [ ] Bug é determinístico (não aleatório)
+
+### Se Você Não Conseguir Reproduzir
+
+```markdown
+@research-assistant Ajude-me a entender por que este bug pode ser específico do ambiente
+
+Relatório de bug:
+- Usuário vê erro X ao fazer Y
+- Não consigo reproduzir localmente
+- Usuário está no ambiente Z
+
+Possíveis causas?
+```
 
 ---
 
 ## Fase 2: Diagnosticar
 
+Encontre a causa raiz do bug.
+
+### Usando o Comando de Análise
+
 ```bash
-/common:analyze-bug "Os usuários não conseguem fazer login após redefinir a senha"
+/common:analyze-bug "Os usuários não conseguem fazer login com credenciais corretas após redefinição de senha"
 ```
+
+Este comando irá:
+1. Sugerir áreas para investigar
+2. Identificar causas potenciais
+3. Recomendar passos de depuração
+4. Listar áreas de código relacionadas
+
+### Usando o TDD Coach para Diagnóstico
 
 ```markdown
 @tdd-coach Ajude-me a diagnosticar este bug de autenticação
+
+Sintomas:
+- O usuário redefine a senha com sucesso
+- A nova senha é salva (confirmado no banco de dados)
+- O login falha com "credenciais inválidas"
+- A senha antiga também não funciona
+
+O que devo investigar?
 ```
+
+### Técnicas de Depuração
+
+#### Adicionar Logging
+
+```php
+// Log de depuração temporário
+$this->logger->debug('Password verification', [
+    'user_id' => $user->getId(),
+    'stored_hash' => substr($user->getPasswordHash(), 0, 20) . '...',
+    'verification_result' => $result,
+]);
+```
+
+#### Inspecionar o Estado do Banco de Dados
+
+```sql
+-- Verificar estado do usuário após redefinição de senha
+SELECT id, email, password_hash, updated_at
+FROM users
+WHERE email = 'user@example.com';
+```
+
+#### Rastrear o Caminho de Execução
+
+```php
+// Adicionar stack trace em pontos suspeitos
+debug_print_backtrace(DEBUG_BACKTRACE_IGNORE_ARGS);
+```
+
+### Identificar a Causa Raiz
+
+Categorias comuns:
+- **Erro de lógica**: Condição ou cálculo incorreto
+- **Erro de estado**: Estado de dados incorreto
+- **Condição de corrida**: Comportamento dependente de temporização
+- **Erro de integração**: Problema com serviço externo
+- **Erro de configuração**: Configurações erradas
+
+### Checklist de Diagnóstico
+
+- [ ] Bug reproduzido de forma consistente
+- [ ] Localização do erro identificada
+- [ ] Causa raiz compreendida
+- [ ] Áreas de código relacionadas identificadas
+- [ ] Abordagem de correção determinada
 
 ---
 
-## Fase 3: Teste de Regressão
+## Fase 3: Escrever Teste de Regressão
+
+Escreva um teste que FALHE ANTES da correção e PASSE DEPOIS.
+
+### Por Que Testar Primeiro?
+
+1. **Prova que o bug existe**: O teste falha com o código atual
+2. **Prova que a correção funciona**: O teste passa após a correção
+3. **Previne regressão**: O teste detecta quebras futuras
+4. **Documenta o comportamento**: O teste descreve o comportamento esperado
+
+### Usando o TDD Coach
+
+```markdown
+@tdd-coach Ajude-me a escrever um teste de regressão para este bug
+
+Bug: A redefinição de senha não atualiza o hash de senha corretamente
+
+Comportamento esperado:
+- O usuário solicita a redefinição de senha
+- O usuário define uma nova senha
+- O usuário consegue fazer login com a nova senha
+
+Comportamento real:
+- O login falha após a redefinição de senha
+```
+
+### Exemplo de Teste de Regressão
 
 ```php
 /**
  * @test
  * @see https://github.com/company/project/issues/123
  *
- * Bug: Os usuários não conseguiam fazer login após redefinição
+ * Bug: Os usuários não conseguiam fazer login após a redefinição de senha
+ * Causa raiz: O hash de senha não era persistido corretamente
  */
 public function test_user_can_login_after_password_reset(): void
 {
+    // Arrange: Criar usuário com senha conhecida
     $user = $this->createUser('user@example.com', 'old-password');
+
+    // Act: Redefinir senha
     $this->passwordResetService->resetPassword($user, 'new-password');
 
+    // Assert: Consegue fazer login com a nova senha
     $result = $this->authService->authenticate('user@example.com', 'new-password');
 
     $this->assertTrue($result->isSuccess());
+    $this->assertNotNull($result->getToken());
+}
+
+/**
+ * @test
+ * Relacionado: Garantir que a senha antiga não funciona mais
+ */
+public function test_old_password_fails_after_reset(): void
+{
+    $user = $this->createUser('user@example.com', 'old-password');
+
+    $this->passwordResetService->resetPassword($user, 'new-password');
+
+    $result = $this->authService->authenticate('user@example.com', 'old-password');
+
+    $this->assertFalse($result->isSuccess());
 }
 ```
+
+### Checklist de Escrita de Testes
+
+- [ ] O teste reproduz o bug (falha antes da correção)
+- [ ] O teste tem nome descritivo
+- [ ] O teste referencia o número do issue
+- [ ] O teste documenta a causa raiz no comentário
+- [ ] Casos extremos relacionados testados
 
 ---
 
 ## Fase 4: Corrigir
+
+Implemente a correção mínima para o bug.
+
+### Diretrizes de Correção
+
+1. **Mudança mínima**: Corrija apenas o bug, não refatore
+2. **Intenção clara**: O código deve mostrar o que estava errado
+3. **Sem efeitos colaterais**: Não altere comportamento não relacionado
+4. **Manter estilo**: Corresponder aos padrões do código existente
+
+### Exemplo de Correção
 
 ```php
 // ANTES (com bug)
@@ -82,66 +279,380 @@ public function resetPassword(User $user, string $newPassword): void
 }
 ```
 
+### Executar o Teste de Regressão
+
+```bash
+# O teste deve passar agora
+make test-unit TEST=tests/Unit/PasswordResetTest.php
+
+# Ou executar teste específico
+./vendor/bin/phpunit --filter test_user_can_login_after_password_reset
+```
+
+### Checklist de Correção
+
+- [ ] O teste de regressão agora passa
+- [ ] A correção é mínima e focada
+- [ ] Nenhuma alteração não relacionada incluída
+- [ ] Estilo do código mantido
+
 ---
 
 ## Fase 5: Validar
 
+Certifique-se de que a correção não quebre nada mais.
+
+### Executar a Suite Completa de Testes
+
 ```bash
+# Todos os testes unitários
+make test-unit
+
+# Todos os testes de integração
+make test-integration
+
+# Suite completa de testes
 make test
+```
+
+### Verificações de Qualidade
+
+```bash
+# Qualidade do código (por tecnologia)
+/symfony:check-code-quality
+/flutter:check-code-quality
+/python:check-code-quality
+
+# Segurança (se a correção toca código sensível)
+/common:security-audit
+
+# Conformidade completa
 /symfony:check-compliance
 ```
 
+### Testes Manuais
+
+Mesmo com testes automatizados, verifique manualmente:
+
+1. Seguir os passos originais de reprodução do bug
+2. Verificar que o bug não ocorre mais
+3. Testar funcionalidades relacionadas
+4. Verificar casos extremos
+
+### Usando o Agente Revisor
+
 ```markdown
 @symfony-reviewer Revise minha correção para o issue #123
+
+Bug: Os usuários não conseguiam fazer login após a redefinição de senha
+Correção: Adicionados persist/flush ausentes em resetPassword()
+
+Arquivos alterados:
+- src/Application/Service/PasswordResetService.php
+- tests/Unit/PasswordResetTest.php
+
+Por favor, verifique:
+1. A correção está correta e completa
+2. Ausência de efeitos colaterais
+3. Cobertura de teste adequada
 ```
+
+### Checklist de Validação
+
+- [ ] O teste de regressão passa
+- [ ] Todos os testes existentes passam
+- [ ] A análise estática passa
+- [ ] Os testes manuais confirmam a correção
+- [ ] Revisão de código concluída
 
 ---
 
 ## Fase 6: Documentar
 
-```bash
-git commit -m "fix(auth): resolver falha de login após redefinição de senha
+Documente a correção para referência futura.
 
-Bug: Os usuários não conseguiam fazer login após redefinir senha
-Causa raiz: O hash não era persistido no banco de dados
-Correção: Adicionados persist() e flush() em PasswordResetService
+### Formato da Mensagem de Commit
 
-Closes #123"
 ```
+fix(auth): resolver falha de login após redefinição de senha
+
+Bug: Os usuários não conseguiam fazer login após redefinir a senha
+Causa raiz: A alteração do hash de senha não era persistida no banco de dados
+Correção: Adicionadas chamadas a persist() e flush() em PasswordResetService
+
+Closes #123
+
+Test: test_user_can_login_after_password_reset
+```
+
+### Atualizar o Rastreador de Issues
+
+```markdown
+## Resolução
+
+**Causa Raiz:**
+O método `resetPassword()` em `PasswordResetService` estava atualizando o hash
+de senha do usuário na memória, mas não persistia a alteração no banco de dados.
+
+**Correção:**
+Adicionadas chamadas a `persist()` e `flush()` após definir o novo hash de senha.
+
+**Testes:**
+- Teste de regressão adicionado: `test_user_can_login_after_password_reset`
+- Teste de caso extremo adicionado: `test_old_password_fails_after_reset`
+
+**Prevenção:**
+Considere adicionar um item de verificação na lista de revisão de código para operações de persistência.
+```
+
+### Entrada na Base de Conhecimento (se for um padrão recorrente)
+
+```markdown
+# Bug Comum: Alterações de Entidade Não Persistidas
+
+## Sintomas
+- As alterações de dados parecem funcionar (sem erros)
+- As alterações não aparecem no banco de dados
+- As alterações são perdidas após atualização da página
+
+## Causa Raiz
+Chamadas a `persist()` e/ou `flush()` ausentes no Doctrine.
+
+## Padrão de Correção
+```php
+$entity->setSomething($value);
+$this->entityManager->persist($entity); // Não esqueça!
+$this->entityManager->flush();
+```
+
+## Prevenção
+- Adicionar verificação de persistência ao checklist de revisão de código
+- Considerar auto-flush na classe base do serviço
+```
+
+### Checklist de Documentação
+
+- [ ] A mensagem de commit descreve o bug e a correção
+- [ ] O rastreador de issues atualizado com a resolução
+- [ ] Documentação relacionada atualizada
+- [ ] Entrada na base de conhecimento se for um padrão
 
 ---
 
-## Procedimento Hotfix
+## Procedimentos de Hotfix
+
+Para bugs críticos em produção.
+
+### Fluxo de Hotfix
+
+```
+1. Criar branch de hotfix a partir de produção
+2. Aplicar correção mínima
+3. Testar completamente
+4. Implantar em produção
+5. Mesclar de volta em main
+```
+
+### Passo a Passo
 
 ```bash
-# 1. Criar branch hotfix
+# 1. Criar branch de hotfix
 git checkout production
-git checkout -b hotfix/issue-123
+git checkout -b hotfix/issue-123-login-failure
 
-# 2. Aplicar correção e teste
+# 2. Aplicar correção
+# ... fazer as alterações ...
 
-# 3. Verificar
+# 3. Escrever teste de regressão
+# ... adicionar teste ...
+
+# 4. Verificar
 make test
 /symfony:check-compliance
 
-# 4. Criar PR
-gh pr create --base production --title "HOTFIX: Falha de login"
+# 5. Commitar com mensagem clara
+git commit -m "fix(auth): resolver falha crítica de login após redefinição de senha
 
-# 5. Após merge, mergear em main
+HOTFIX para issue de produção.
+Causa raiz: Hash de senha não persistido após redefinição.
+
+Closes #123"
+
+# 6. Criar PR para revisão
+gh pr create --base production --title "HOTFIX: Falha de login após redefinição de senha"
+
+# 7. Após merge, implantar
+# ... processo de implantação ...
+
+# 8. Mesclar de volta em main
 git checkout main
-git merge hotfix/issue-123
+git merge hotfix/issue-123-login-failure
+git push origin main
+```
+
+### Checklist de Hotfix
+
+- [ ] Branch de hotfix criada a partir de produção
+- [ ] Correção mínima e focada apenas
+- [ ] Teste de regressão adicionado
+- [ ] Todos os testes passando
+- [ ] PR revisado e aprovado
+- [ ] Implantado em produção
+- [ ] Verificado em produção
+- [ ] Mesclado de volta em main
+
+---
+
+## Exemplo Completo
+
+Vamos percorrer a correção de um bug real.
+
+### Relatório de Bug
+
+```
+Issue #456: Total do pedido calculado incorretamente
+
+Passos para reproduzir:
+1. Adicionar item com preço $10.00, quantidade 3
+2. Adicionar item com preço $5.50, quantidade 2
+3. Visualizar o carrinho
+
+Esperado: Total = $41.00 (30 + 11)
+Real: Total = $36.00
+
+Ambiente: Produção v2.3.1
+Reportado por: Suporte ao cliente
+Prioridade: Alta
+```
+
+### Passo 1: Reproduzir
+
+```php
+// Teste local rápido
+$order = new Order();
+$order->addItem(new Item('A', 10.00), 3);  // $30
+$order->addItem(new Item('B', 5.50), 2);   // $11
+echo $order->getTotal(); // Mostra 36.00 - confirmado!
+```
+
+### Passo 2: Diagnosticar
+
+```markdown
+@tdd-coach Ajude-me a encontrar o bug no cálculo do total do pedido
+
+O total deveria ser 41.00, mas mostra 36.00
+A diferença é 5.00, que é exatamente o preço de um item B
+
+Hipótese: a quantidade do segundo item não está sendo contada?
+```
+
+A investigação revela:
+
+```php
+// Bug encontrado em Order::calculateTotal()
+public function calculateTotal(): Money
+{
+    $total = Money::zero();
+    foreach ($this->items as $item) {
+        // BUG: Usando 1 em vez da quantidade do item!
+        $total = $total->add($item->getPrice()->multiply(1));
+    }
+    return $total;
+}
+```
+
+### Passo 3: Escrever Teste de Regressão
+
+```php
+/**
+ * @test
+ * @see https://github.com/company/shop/issues/456
+ *
+ * Bug: O total do pedido ignorava as quantidades dos itens
+ */
+public function test_order_total_includes_all_quantities(): void
+{
+    $order = new Order();
+    $order->addItem($this->createItem(10.00), 3);  // $30
+    $order->addItem($this->createItem(5.50), 2);   // $11
+
+    $total = $order->calculateTotal();
+
+    $this->assertEquals(41.00, $total->getAmount());
+}
+
+/**
+ * @test
+ * Caso extremo: item único com quantidade > 1
+ */
+public function test_single_item_quantity_multiplied(): void
+{
+    $order = new Order();
+    $order->addItem($this->createItem(10.00), 5);
+
+    $this->assertEquals(50.00, $order->calculateTotal()->getAmount());
+}
+```
+
+Executar o teste — confirma que falha.
+
+### Passo 4: Corrigir
+
+```php
+public function calculateTotal(): Money
+{
+    $total = Money::zero();
+    foreach ($this->items as $item) {
+        // Corrigido: Usar a quantidade real do item do pedido
+        $total = $total->add(
+            $item->getPrice()->multiply($item->getQuantity())
+        );
+    }
+    return $total;
+}
+```
+
+### Passo 5: Validar
+
+```bash
+# Teste de regressão passa
+./vendor/bin/phpunit --filter test_order_total
+
+# Todos os testes passam
+make test
+
+# Verificação de qualidade
+/symfony:check-compliance
+# Pontuação: 94/100 ✓
+```
+
+### Passo 6: Documentar
+
+```bash
+git commit -m "fix(order): corrigir cálculo do total para incluir as quantidades
+
+Bug: O total do pedido ignorava as quantidades dos itens, sempre usando 1
+Causa raiz: multiply(1) codificado em vez de multiply(quantity)
+Correção: Usar getQuantity() do item do pedido no cálculo
+
+Closes #456
+
+Testes de regressão adicionados:
+- test_order_total_includes_all_quantities
+- test_single_item_quantity_multiplied"
 ```
 
 ---
 
-## Checklist de Correção
+## Dicas de Prevenção de Bugs
 
-- [ ] Bug reproduzido localmente
-- [ ] Teste de regressão escrito (falha)
-- [ ] Código corrigido
-- [ ] Teste passa
-- [ ] Sem regressões
-- [ ] Commit com referência ao issue
+1. **Escreva os testes primeiro**: TDD previne muitos bugs
+2. **Revisão de código**: Outros olhos detectam problemas
+3. **Análise estática**: Ferramentas encontram erros comuns
+4. **Testes de integração**: Capturam bugs de interação
+5. **Monitorar produção**: Detectar problemas mais cedo
+6. **Use `/loop`**: Configure verificações de qualidade recorrentes (ex.: `/loop 5m /common:pre-commit-check`)
+7. **Salve aprendizados**: Use `/memory` para persistir padrões de bugs entre sessões
 
 ---
 

--- a/docs/guides/pt/05-tools-reference.md
+++ b/docs/guides/pt/05-tools-reference.md
@@ -1,41 +1,370 @@
-# Referência de Ferramentas
+# Guia de Referência de Ferramentas
 
-Guia das ferramentas utilitárias incluídas com Claude-Craft.
+Este guia cobre as ferramentas utilitárias incluídas no Claude-Craft para gerenciar perfis, exibição de status, configuração de projetos e comandos e funcionalidades do Claude Code (v8.7).
 
 ---
 
-## Gestor MultiAccount
+## Índice
 
-Gerencia múltiplos perfis de Claude Code.
+1. [Comandos do Claude Code](#comandos-do-claude-code)
+2. [Eventos de Hook](#eventos-de-hook)
+3. [Frontmatter de Agentes](#frontmatter-de-agentes)
+4. [Pesquisa de Ferramentas MCP](#pesquisa-de-ferramentas-mcp)
+5. [Modo Automático](#modo-automático)
+6. [Templates de Hook](#templates-de-hook)
+7. [Configurações Gerenciadas](#configurações-gerenciadas)
+8. [Gerenciador MultiConta](#gerenciador-multiconta)
+9. [StatusLine](#statusline)
+10. [Gerenciador ProjectConfig](#gerenciador-projectconfig)
+11. [Instalação](#instalação)
+
+---
+
+## Comandos do Claude Code
+
+O Claude Code fornece comandos integrados para gerenciamento de contexto e sessão. Esses comandos estão disponíveis em qualquer sessão do Claude Code (v2.1.47+).
+
+### Comandos de Gerenciamento de Contexto
+
+| Comando | Versão | Descrição |
+|---------|--------|-----------|
+| `/clear` | Todos | Limpa o contexto entre tarefas não relacionadas |
+| `/compact` | Todos | Compacta o contexto proativamente (executar em ~70% de uso) |
+| `/context` | v2.1.74+ | Obtém sugestões acionáveis para otimização de contexto |
+| `/effort low\|medium\|high` | v2.1.72+ | Ajusta o esforço de raciocínio do modelo por complexidade da tarefa |
+| `/memory` | v2.1.59+ | Salva aprendizados persistentes entre sessões e compactações |
+| `/model haiku\|sonnet\|opus` | v2.1.72+ | Alterna o modelo durante a sessão com base na complexidade da tarefa |
+
+### Comandos de Sessão
+
+| Comando | Versão | Descrição |
+|---------|--------|-----------|
+| `/loop [interval] [command]` | v2.1.71+ | Executa tarefas recorrentes (ex.: `/loop 5m /common:pre-commit-check`) |
+| `/proactive` | v2.1.105+ | Alias para `/loop` |
+| `/color` | v2.1.94+ | Altera o esquema de cores do terminal |
+| `/rename` | v2.1.94+ | Renomeia a sessão atual |
+| `/powerup` | v2.1.94+ | Ativa funcionalidades avançadas |
+
+### Exemplos de Uso
+
+```bash
+# Ajustar esforço para uma consulta simples
+/effort low
+
+# Alternar para um modelo mais econômico para exploração
+/model sonnet
+
+# Configurar monitoramento recorrente de CI
+/loop 5m "Check if CI pipeline passed"
+
+# Salvar contexto importante antes da compactação
+/memory "Authentication uses JWT with RS256, refresh tokens in HttpOnly cookies"
+```
+
+---
+
+## Eventos de Hook
+
+O Claude Code suporta 24 eventos de hook (8 adicionados nas versões recentes do Claude Code) para automatizar fluxos de trabalho:
+
+### Todos os Eventos de Hook
+
+| Evento | Momento | Caso de Uso |
+|--------|---------|-------------|
+| **PreToolUse** | Antes da execução da ferramenta | Bloquear comandos perigosos, reescrever com RTK |
+| **PostToolUse** | Após a execução da ferramenta | Filtrar saída verbosa, resumir resultados |
+| **PreCompact** | Antes da compactação de contexto | Salvar contexto crítico; código de saída 2 bloqueia a compactação (v2.1.105+) |
+| **PostCompact** | Após a compactação de contexto | Reinjetar contexto essencial |
+| **SessionStart** | No início da sessão | Carregar essenciais de contexto, configurar ambiente |
+| **StopFailure** | Em parada inesperada | Salvar estado, alertar sobre falhas |
+| **Notification** | Em eventos de notificação | Alertas customizados |
+| **TaskCreated** | Quando tarefa de subagente é criada | Rastrear trabalho de subagente |
+| **CwdChanged** | Mudança de diretório de trabalho | Atualizar ambiente por diretório |
+| **FileChanged** | Modificação de arquivo detectada | Disparar rebuilds, linting |
+| **PermissionDenied** | Falha na verificação de permissão | Registrar eventos de segurança |
+| **Elicitation** | Antes do prompt do usuário | Personalizar fluxo de elicitação |
+| **ElicitationResult** | Após resposta do usuário | Processar resultados de elicitação |
+| **Stop** | No encerramento da sessão | Limpeza |
+
+### Melhorias de Hook (v8.7)
+
+| Funcionalidade | Descrição |
+|----------------|-----------|
+| **`if` condicional** | Executar hooks apenas quando a condição corresponder |
+| **`defer`** | Adiar execução do hook para não bloquear |
+| **Bloqueio de PreCompact** | Código de saída 2 no hook PreCompact bloqueia a compactação (v2.1.105+) |
+
+### Exemplo: Filtro de Saída PostToolUse
+
+```json
+{
+  "hooks": {
+    "PostToolUse": [{
+      "matcher": "Bash",
+      "hooks": [{
+        "type": "command",
+        "command": "echo '$TOOL_OUTPUT' | head -100"
+      }]
+    }]
+  }
+}
+```
+
+---
+
+## Frontmatter de Agentes
+
+Agentes customizados (v2.1.78+) suportam campos de frontmatter para controlar comportamento e custo:
+
+```yaml
+---
+effort: low          # Esforço de raciocínio (low/medium/high)
+maxTurns: 10         # Número máximo de turnos de conversa
+disallowedTools:     # Ferramentas que o agente não pode usar
+  - Edit
+  - Write
+---
+```
+
+| Campo | Tipo | Descrição |
+|-------|------|-----------|
+| `effort` | string | Esforço de raciocínio `low`, `medium` ou `high` |
+| `maxTurns` | número | Número máximo de turnos antes de parar |
+| `disallowedTools` | lista | Ferramentas que o agente não tem permissão de usar |
+
+Isso é útil para criar agentes de exploração econômicos que podem ler, mas não modificar o código.
+
+---
+
+## Pesquisa de Ferramentas MCP
+
+A Pesquisa de Ferramentas MCP (v2.1.80+) permite o carregamento preguiçoso (lazy loading) de ferramentas MCP, reduzindo o consumo de contexto em 95%:
+
+| Abordagem | Custo de Contexto |
+|-----------|-------------------|
+| MCP clássico (todas as ferramentas carregadas) | ~500-2000 tokens/ferramenta/turno |
+| MCP com Pesquisa de Ferramentas (lazy) | ~50 tokens no total |
+
+### Uso
+
+```bash
+# Carregar uma ferramenta específica sob demanda
+ToolSearch with query: "select:tool_name"
+
+# Pesquisar por palavra-chave
+ToolSearch with query: "slack send"
+```
+
+Em vez de carregar todas as ferramentas do servidor MCP na inicialização, a Pesquisa de Ferramentas as carrega apenas quando necessário.
+
+---
+
+## Modo Automático
+
+O Modo Automático (v2.1.94+) é um classificador de permissões baseado em IA que substitui `--dangerously-skip-permissions` de forma mais segura:
+
+| Modo | Proteção | Velocidade | Caso de Uso |
+|------|----------|-----------|-------------|
+| Manual | Máxima | Lenta | Fluxos auditados, alta segurança |
+| Modo Automático | Alta | Rápida | Fluxos de desenvolvimento confiáveis |
+| Pular Permissões | Mínima | Máxima | Somente projetos locais/pessoais |
+
+**Funcionalidades de segurança:**
+- Um modelo de segurança em segundo plano avalia cada chamada de ferramenta
+- Operações seguras (leituras, testes) são aprovadas automaticamente
+- Ações arriscadas (exclusão em massa, exfiltração) são bloqueadas
+- 3 bloqueios consecutivos revertem para o modo manual
+- 20+ bloqueios em uma sessão revertem para o modo manual completo
+
+Disponível para planos Team com aprovação do administrador.
+
+---
+
+## Templates de Hook
+
+O Claude-Craft fornece templates de hook prontos para uso em `.claude/templates/hooks/`:
+
+| Template | Finalidade |
+|----------|-----------|
+| `output-filter.json` | Filtro PostToolUse para saídas grandes de CLI |
+| `pre-compact.json` | Hook PreCompact para preservar contexto crítico |
+| `context-reinject.json` | Hook SessionStart para reinjeção de contexto após compactação |
 
 ### Instalação
+
+Copie os templates para o `.claude/settings.json` do seu projeto ou mescle na sua configuração de hooks:
+
 ```bash
+# Ver templates disponíveis
+ls .claude/templates/hooks/
+
+# Aplicar ao seu projeto (mesclar manualmente no settings.json)
+cat .claude/templates/hooks/output-filter.json
+```
+
+---
+
+## Configurações Gerenciadas
+
+O diretório `managed-settings.d/` (v2.1.83+) permite configuração modular via mesclagem alfabética:
+
+```
+.claude/
+  managed-settings.d/
+    00-base.json          # Configuração base
+    10-security.json      # Regras de segurança
+    20-team.json          # Preferências da equipe
+```
+
+Os arquivos são mesclados em ordem alfabética, permitindo que as equipes componham configurações em camadas sem conflitos.
+
+---
+
+## Gerenciador MultiConta
+
+Gerencie múltiplos perfis do Claude Code para diferentes contas ou contextos.
+
+### Finalidade
+
+- Alternar entre contas Claude (pessoal, trabalho, cliente)
+- Gerenciar limites de uso alternando perfis
+- Manter contextos de projeto isolados
+- Compartilhar ou isolar configurações
+
+### Instalação
+
+```bash
+# Via Makefile
 make install-multiaccount
+
+# Ou manualmente
+cp Tools/MultiAccount/claude-accounts.sh ~/.local/bin/
+chmod +x ~/.local/bin/claude-accounts.sh
 ```
 
-### Uso Interativo
+### Uso
+
+#### Modo Interativo
+
 ```bash
+# Iniciar menu interativo
 ./claude-accounts.sh
+# Ou se instalado globalmente
+claude-accounts.sh
 ```
 
-### Modo CLI
+Opções do menu:
+```
+1. List profiles
+2. Add a profile
+3. Delete a profile
+4. Authenticate a profile
+5. Launch Claude Code
+6. Install ccsp() function
+7. Migrate legacy profile
+8. Help
+9. Exit
+```
+
+#### Modo CLI
+
 ```bash
-./claude-accounts.sh list              # Listar perfis
-./claude-accounts.sh add <nome>        # Adicionar perfil
-./claude-accounts.sh remove <nome>     # Remover perfil
-./claude-accounts.sh auth <nome>       # Autenticar perfil
-./claude-accounts.sh launch <nome>     # Lançar Claude com perfil
+# Listar todos os perfis
+./claude-accounts.sh list
+
+# Adicionar novo perfil
+./claude-accounts.sh add <profile-name>
+
+# Remover perfil
+./claude-accounts.sh remove <profile-name>
+
+# Autenticar perfil
+./claude-accounts.sh auth <profile-name>
+
+# Iniciar Claude Code com perfil
+./claude-accounts.sh launch <profile-name>
+
+# Exibir ajuda
+./claude-accounts.sh --help
 ```
 
 ### Modos de Perfil
-- **shared**: Compartilha configuração com `~/.claude`
-- **isolated**: Configuração independente
 
-### Função ccsp()
+#### Modo Compartilhado (Padrão)
+
+O perfil compartilha configuração com o `~/.claude` principal:
+
 ```bash
-ccsp           # Listar perfis
-ccsp trabalho  # Mudar para perfil "trabalho"
-claude         # Lançar com perfil atual
+./claude-accounts.sh add work --mode=shared
+```
+
+- Configurações vinculadas simbolicamente a `~/.claude`
+- Indicado para: alternar entre contas mantendo as configurações
+- Caso de uso: gerenciamento de limites de uso
+
+#### Modo Isolado
+
+O perfil possui configuração completamente independente:
+
+```bash
+./claude-accounts.sh add client-a --mode=isolated
+```
+
+- Cópia independente das configurações
+- Indicado para: trabalho com clientes com regras separadas
+- Caso de uso: configurações de projeto distintas
+
+### Troca Rápida de Perfil
+
+Instale a função shell `ccsp()`:
+
+```bash
+# Adicionar via opção 6 do menu
+# Ou adicionar manualmente a ~/.bashrc ou ~/.zshrc:
+
+ccsp() {
+    if [ -z "$1" ]; then
+        claude-accounts.sh list
+    else
+        export CLAUDE_CONFIG_DIR="$HOME/.claude-profiles/$1"
+        echo "Switched to profile: $1"
+    fi
+}
+```
+
+Uso:
+```bash
+# Listar perfis
+ccsp
+
+# Alternar para um perfil
+ccsp work
+
+# Iniciar Claude Code (usa o perfil atual)
+claude
+```
+
+### Estrutura de Perfis
+
+```
+~/.claude-profiles/
+├── work/
+│   ├── .mode              # "shared" ou "isolated"
+│   ├── config/            # Configuração do Claude
+│   └── settings.json      # Configurações do perfil
+├── client-a/
+│   └── ...
+└── personal/
+    └── ...
+```
+
+### Suporte a Idiomas
+
+```bash
+# Usar em idioma específico
+./claude-accounts.sh --lang=fr list
+./claude-accounts.sh --lang=es add trabajo
+./claude-accounts.sh --lang=de --help
 ```
 
 ---
@@ -44,86 +373,390 @@ claude         # Lançar com perfil atual
 
 Exibe informações contextuais na barra de status do Claude Code.
 
+### Finalidade
+
+- Mostrar o perfil atual
+- Exibir o modelo em uso
+- Mostrar branch e status do Git
+- Rastrear percentual de uso do contexto
+- Monitorar custos da sessão e semanais
+- Exibir limites de uso
+
 ### Instalação
+
 ```bash
+# Via Makefile
 make install-statusline
+
+# Ou manualmente
+cp Tools/StatusLine/statusline.sh ~/.claude/statusline.sh
+cp Tools/StatusLine/statusline.conf.example ~/.claude/statusline.conf
+chmod +x ~/.claude/statusline.sh
 ```
 
-### Formato
-```
-🔑 pro | 🧠 Opus | 🌿 main +2~1 | 📁 projeto | 📊 45% | ⏱️ 5h: 23% | 📅 Sem: 45% | 💰 $0.42 | 🕐 14:32
+### Configurar o Claude Code
+
+Adicione ao `~/.claude/settings.json`:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "~/.claude/statusline.sh"
+  }
+}
 ```
 
-### Configuração (`~/.claude/statusline.conf`)
+### Formato da Linha de Status
+
+```
+🔑 pro | 🧠 Opus | 🌿 main +2~1 | 📁 my-project | 📊 45% | ⏱️ 5h: 23% | 📅 Sem: 45% | 💰 $0.42 | 🕐 14:32
+```
+
+| Elemento | Descrição |
+|----------|-----------|
+| 🔑 pro | Nome do perfil ativo |
+| 🧠 Opus | Modelo atual (🧠 Opus, 🎵 Sonnet, 🍃 Haiku) |
+| 🌿 main +2~1 | Branch Git + status (+staged ~modificados ?não rastreados) |
+| 📁 my-project | Nome do diretório do projeto |
+| 📊 45% | Uso da janela de contexto |
+| ⏱️ 5h: 23% | Percentual de uso da sessão (5h) |
+| 📅 Sem: 45% | Percentual de uso semanal |
+| 💰 $0.42 | Custo da sessão |
+| 🕐 14:32 | Hora atual |
+
+### Codificação de Cores
+
+Os indicadores de uso mudam de cor com base em limites:
+
+| Cor | Significado | Limite |
+|-----|-------------|--------|
+| Verde | Uso baixo | < 60% |
+| Amarelo | Uso moderado | 60-80% |
+| Vermelho | Uso alto | > 80% |
+
+### Configuração
+
+Edite `~/.claude/statusline.conf`:
+
 ```bash
-SESSION_COST_LIMIT=500.00    # Limite sessão (Max 20x)
-WEEKLY_COST_LIMIT=3000.00    # Limite semanal
-USAGE_WARN_THRESHOLD=60      # Amarelo a 60%
-USAGE_CRIT_THRESHOLD=80      # Vermelho a 80%
+# =============================================================================
+# LIMITES DE USO
+# =============================================================================
+# Valores recomendados por plano:
+#   - Pro ($20/mês)      : SESSION=25,   WEEKLY=150
+#   - Max 5x ($100/mês)  : SESSION=125,  WEEKLY=750
+#   - Max 20x ($200/mês) : SESSION=500,  WEEKLY=3000
+
+SESSION_COST_LIMIT=500.00
+WEEKLY_COST_LIMIT=3000.00
+
+# =============================================================================
+# LIMITES DE ALERTA (percentual)
+# =============================================================================
+USAGE_WARN_THRESHOLD=60    # Amarelo em 60%
+USAGE_CRIT_THRESHOLD=80    # Vermelho em 80%
+
+# =============================================================================
+# CACHE (desempenho)
+# =============================================================================
+SESSION_CACHE_TTL=60       # Atualização da sessão a cada 60s
+WEEKLY_CACHE_TTL=300       # Atualização semanal a cada 5min
+
+# =============================================================================
+# OPÇÕES DE EXIBIÇÃO
+# =============================================================================
+SHOW_SESSION_LIMIT=true
+SHOW_WEEKLY_LIMIT=true
+
+# Rótulos personalizados
+SESSION_LABEL="⏱️ 5h"
+WEEKLY_LABEL="📅 Sem"
 ```
 
 ### Dependências
+
 ```bash
-brew install jq   # Obrigatório
-npm install -g ccusage  # Opcional
+# Obrigatório: jq (processador JSON)
+# macOS
+brew install jq
+
+# Linux
+sudo apt install jq
+
+# Opcional: ccusage (rastreamento de custos)
+npm install -g ccusage
+```
+
+### Solução de Problemas
+
+**Linha de status não aparece:**
+```bash
+# Verificar se o script é executável
+ls -la ~/.claude/statusline.sh
+
+# Testar manualmente
+echo '{"model":{"display_name":"Test"}}' | ~/.claude/statusline.sh
+```
+
+**Custo mostra $0.00:**
+```bash
+# Verificar se ccusage funciona
+npx ccusage daily --json
+```
+
+**Percentuais de uso não aparecem:**
+```bash
+# Verificar arquivos de cache
+ls -la /tmp/.ccusage_*
+
+# Limpar cache para atualizar
+rm /tmp/.ccusage_*
 ```
 
 ---
 
-## Gestor ProjectConfig
+## Gerenciador ProjectConfig
 
-Gerencia configurações de projeto Claude-Craft via YAML.
+Gerencie configurações de projetos do Claude-Craft via YAML.
+
+### Finalidade
+
+- Definir configurações de projeto em YAML
+- Gerenciar múltiplos projetos
+- Lidar com configurações de monorepo
+- Validar configurações
+- Instalar regras a partir da configuração
 
 ### Instalação
-```bash
-make install-projectconfig
-```
 
-### Modo CLI
 ```bash
-./claude-projects.sh list                  # Listar projetos
-./claude-projects.sh validate              # Validar config
-./claude-projects.sh install <nome>        # Instalar projeto
-./claude-projects.sh install-all           # Instalar todos
+# Via Makefile
+make install-projectconfig
+
+# Ou manualmente
+cp Tools/ProjectConfig/claude-projects.sh ~/.local/bin/
+chmod +x ~/.local/bin/claude-projects.sh
 ```
 
 ### Dependências
+
 ```bash
-brew install yq  # Obrigatório
+# Obrigatório: yq (processador YAML)
+# macOS
+brew install yq
+
+# Linux (snap)
+sudo snap install yq
+
+# Linux (binário)
+wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+chmod +x /usr/local/bin/yq
+```
+
+### Uso
+
+#### Modo Interativo
+
+```bash
+./claude-projects.sh
+```
+
+Opções do menu:
+```
+1. List projects
+2. Add a project
+3. Edit a project
+4. Add a module
+5. Delete a project
+6. Validate configuration
+7. Install project
+8. Help
+9. Exit
+```
+
+#### Modo CLI
+
+```bash
+# Listar projetos configurados
+./claude-projects.sh list
+
+# Validar arquivo de configuração
+./claude-projects.sh validate [config-file]
+
+# Instalar projeto específico
+./claude-projects.sh install <project-name>
+
+# Instalar todos os projetos
+./claude-projects.sh install-all
+
+# Exibir detalhes do projeto
+./claude-projects.sh show <project-name>
+
+# Adicionar novo projeto
+./claude-projects.sh add <project-name> <path>
+
+# Remover projeto
+./claude-projects.sh remove <project-name>
+```
+
+### Arquivo de Configuração
+
+Localização padrão: `./claude-projects.yaml`
+
+```yaml
+settings:
+  default_lang: "fr"
+
+projects:
+  - name: "my-saas"
+    description: "SaaS platform"
+    path: "~/Projects/my-saas"
+    modules:
+      - name: "api"
+        path: "backend"
+        technologies: ["symfony"]
+      - name: "web"
+        path: "frontend"
+        technologies: ["react"]
+      - name: "mobile"
+        path: "app"
+        technologies: ["flutter"]
+
+  - name: "internal-tool"
+    path: "~/Projects/internal"
+    technologies: ["python"]
+    lang: "en"
+```
+
+### Validação
+
+```bash
+# Validar configuração
+./claude-projects.sh validate
+
+# Ou via Makefile
+make config-validate CONFIG=claude-projects.yaml
+```
+
+Verificações de validação:
+- Sintaxe YAML válida
+- Campos obrigatórios presentes
+- Caminhos existem
+- Tecnologias válidas
+- Idiomas válidos
+
+### Instalação a partir da Configuração
+
+```bash
+# Instalar projeto único
+./claude-projects.sh install my-saas
+
+# Ou via Makefile
+make config-install CONFIG=claude-projects.yaml PROJECT=my-saas
+
+# Instalar todos os projetos
+make config-install-all CONFIG=claude-projects.yaml
+
+# Simulação (dry run)
+make config-install CONFIG=claude-projects.yaml PROJECT=my-saas OPTIONS="--dry-run"
+```
+
+### Suporte a Idiomas
+
+```bash
+# Usar em idioma específico
+./claude-projects.sh --lang=fr list
+./claude-projects.sh --lang=de validate
 ```
 
 ---
 
-## Instalar Todas as Ferramentas
+## Instalação
+
+### Instalar Todas as Ferramentas
 
 ```bash
 make install-tools
+```
+
+Isso instala:
+- Gerenciador MultiConta
+- StatusLine
+- Gerenciador ProjectConfig
+
+### Instalar Ferramentas Individualmente
+
+```bash
+# Apenas MultiConta
+make install-multiaccount
+
+# Apenas StatusLine
+make install-statusline
+
+# Apenas ProjectConfig
+make install-projectconfig
+```
+
+### Verificar Instalação
+
+```bash
+# Verificar MultiConta
+which claude-accounts.sh
+claude-accounts.sh --version
+
+# Verificar StatusLine
+ls ~/.claude/statusline.sh
+cat ~/.claude/settings.json | jq '.statusLine'
+
+# Verificar ProjectConfig
+which claude-projects.sh
+claude-projects.sh --version
 ```
 
 ---
 
 ## Referência Rápida
 
-### Comandos MultiAccount
+### Comandos MultiConta
+
 | Comando | Descrição |
 |---------|-----------|
-| `list` | Mostrar perfis |
-| `add <nome>` | Criar perfil |
-| `remove <nome>` | Excluir perfil |
-| `launch <nome>` | Iniciar Claude |
+| `list` | Mostrar todos os perfis |
+| `add <name>` | Criar novo perfil |
+| `remove <name>` | Excluir perfil |
+| `auth <name>` | Autenticar perfil |
+| `launch <name>` | Iniciar Claude com o perfil |
+| `migrate` | Converter perfil legado |
 
-### Elementos StatusLine
+### Elementos da StatusLine
+
 | Emoji | Significado |
 |-------|-------------|
 | 🔑 | Perfil |
-| 🧠/🎵/🍃 | Modelo (Opus/Sonnet/Haiku) |
+| 🧠 | Modelo Opus |
+| 🎵 | Modelo Sonnet |
+| 🍃 | Modelo Haiku |
 | 🌿 | Branch Git |
 | 📁 | Projeto |
-| 📊 | Contexto % |
-| ⏱️ | Uso sessão |
+| 📊 | % de Contexto |
+| ⏱️ | Uso da sessão |
 | 📅 | Uso semanal |
 | 💰 | Custo |
+| 🕐 | Hora |
+
+### Comandos ProjectConfig
+
+| Comando | Descrição |
+|---------|-----------|
+| `list` | Mostrar todos os projetos |
+| `validate` | Verificar validade da configuração |
+| `install <name>` | Instalar regras do projeto |
+| `install-all` | Instalar todos os projetos |
+| `show <name>` | Mostrar detalhes do projeto |
+| `add <name> <path>` | Adicionar novo projeto |
+| `remove <name>` | Excluir projeto |
 
 ---
 
-[&larr; Correção de Bugs](04-bug-fixing.md) | [Resolução de Problemas &rarr;](06-troubleshooting.md)
+[&larr; Correção de Bugs](04-bug-fixing.md) | [Solução de Problemas &rarr;](06-troubleshooting.md)

--- a/docs/guides/pt/06-troubleshooting.md
+++ b/docs/guides/pt/06-troubleshooting.md
@@ -1,138 +1,695 @@
-# Guia de Resolução de Problemas
+# Guia de Solução de Problemas
 
-Problemas comuns e suas soluções ao usar Claude-Craft.
+Este guia cobre os problemas mais comuns e suas soluções ao usar o Claude-Craft.
+
+---
+
+## Índice
+
+1. [Problemas de Instalação](#problemas-de-instalação)
+2. [Problemas de Agentes](#problemas-de-agentes)
+3. [Problemas de Comandos](#problemas-de-comandos)
+4. [Problemas de Configuração](#problemas-de-configuração)
+5. [Problemas de Ferramentas](#problemas-de-ferramentas)
+6. [Problemas de Desempenho](#problemas-de-desempenho)
+7. [Obtendo Ajuda](#obtendo-ajuda)
 
 ---
 
 ## Problemas de Instalação
 
-### Comandos Não Reconhecidos
-**Soluções:**
-1. Reiniciar Claude Code (`exit` + `claude`)
-2. Verificar instalação: `ls -la .claude/commands/`
-3. Verificar formato dos arquivos de comandos
+### Comandos Não Reconhecidos Após a Instalação
 
-### Arquivos Não Encontrados
-**Soluções:**
-1. Verificar caminho do Claude-Craft: `pwd && ls Dev/scripts/`
-2. Verificar arquivos de idioma: `ls Dev/i18n/pt/`
-3. Usar caminho TARGET absoluto
+**Sintomas:**
+- Comandos slash como `/symfony:check-compliance` não funcionam
+- Claude não reconhece os comandos instalados
 
-### Erros de Permissão
-```bash
-chmod +x Dev/scripts/*.sh
-chmod +x Tools/*/*.sh
-```
+**Soluções:**
+
+1. **Reiniciar o Claude Code**
+   ```bash
+   # Sair completamente do Claude Code
+   exit
+
+   # Iniciar novamente
+   claude
+   ```
+
+2. **Verificar a instalação**
+   ```bash
+   ls -la .claude/commands/
+   # Deve mostrar os diretórios de comandos
+   ```
+
+3. **Verificar o formato do arquivo de comando**
+   ```bash
+   head -5 .claude/commands/symfony/check-compliance.md
+   # Deve começar com o cabeçalho markdown correto
+   ```
+
+### Arquivos Não Encontrados Durante a Instalação
+
+**Sintomas:**
+- Erros de "Source file not found"
+- Regras ou templates ausentes
+
+**Soluções:**
+
+1. **Verificar o caminho do Claude-Craft**
+   ```bash
+   # Certifique-se de estar executando do diretório claude-craft
+   pwd
+   ls -la Dev/scripts/
+   ```
+
+2. **Verificar se os arquivos de idioma existem**
+   ```bash
+   ls -la Dev/i18n/en/Symfony/rules/
+   ```
+
+3. **Usar o caminho TARGET absoluto**
+   ```bash
+   # Em vez de
+   make install-symfony TARGET=./backend
+
+   # Use
+   make install-symfony TARGET=/caminho/completo/para/backend
+   ```
+
+### Erros de Permissão Negada
+
+**Sintomas:**
+- Não é possível executar os scripts de instalação
+- Não é possível gravar no diretório alvo
+
+**Soluções:**
+
+1. **Tornar os scripts executáveis**
+   ```bash
+   chmod +x Dev/scripts/*.sh
+   chmod +x Project/*.sh
+   chmod +x Infra/*.sh
+   chmod +x Tools/*/*.sh
+   ```
+
+2. **Verificar permissões do diretório alvo**
+   ```bash
+   ls -la ~/my-project/
+   # Certifique-se de ter permissões de escrita
+   ```
+
+3. **Executar com o usuário adequado**
+   ```bash
+   # Não use sudo, a menos que seja necessário
+   # Verifique a propriedade do diretório
+   ls -la ~/my-project
+   ```
+
+### Instalação Cria Diretório Vazio
+
+**Sintomas:**
+- Diretório `.claude/` criado, mas vazio ou com arquivos faltando
+
+**Soluções:**
+
+1. **Verificar erros na saída**
+   ```bash
+   # Executar com saída detalhada
+   make install-symfony TARGET=./backend 2>&1 | tee install.log
+   ```
+
+2. **Verificar se a fonte existe**
+   ```bash
+   ls -la Dev/i18n/en/Symfony/
+   ```
+
+3. **Tentar execução direta do script**
+   ```bash
+   ./Dev/scripts/install-symfony-rules.sh --lang=en ./backend
+   ```
 
 ---
 
 ## Problemas de Agentes
 
 ### Agente Não Disponível
-1. Verificar arquivos: `ls .claude/agents/`
-2. Verificar formato do frontmatter
-3. Reinstalar: `make install-common TARGET=. OPTIONS="--force"`
 
-### Respostas Irrelevantes
-1. Fornecer mais contexto na solicitação
-2. Ser específico no pedido
-3. Verificar `00-project-context.md`
+**Sintomas:**
+- `@api-designer` ou outros agentes não respondem
+- Erros do tipo "Unknown agent"
+
+**Soluções:**
+
+1. **Verificar se os arquivos do agente existem**
+   ```bash
+   ls -la .claude/agents/
+   # Deve listar os arquivos .md dos agentes
+   ```
+
+2. **Verificar o formato do arquivo do agente**
+   ```bash
+   head -20 .claude/agents/api-designer.md
+   # Deve ter frontmatter correto com nome e descrição
+   ```
+
+3. **Reinstalar os agentes**
+   ```bash
+   make install-common TARGET=. OPTIONS="--force"
+   ```
+
+### Agente Dá Respostas Irrelevantes
+
+**Sintomas:**
+- O agente não segue suas instruções especializadas
+- Respostas genéricas em vez de conselhos especializados
+
+**Soluções:**
+
+1. **Fornecer mais contexto**
+   ```markdown
+   @symfony-reviewer Revise minha implementação do UserService
+
+   Contexto:
+   - Symfony 7 com API Platform
+   - Clean Architecture
+   - Abordagem DDD
+
+   Código para revisar:
+   [cole o código aqui]
+   ```
+
+2. **Ser específico na sua solicitação**
+   ```markdown
+   # Em vez de
+   @database-architect Ajude com meu banco de dados
+
+   # Use
+   @database-architect Projete o schema para o agregado User com:
+   - Entidade User (id, email, password_hash)
+   - Entidade Role (muitos-para-muitos com User)
+   - Entidade Permission (muitos-para-muitos com Role)
+   - Trilha de auditoria para alterações de usuário
+   ```
+
+3. **Verificar o arquivo de contexto do projeto**
+   ```bash
+   cat .claude/rules/00-project-context.md
+   # Certifique-se de que descreve seu projeto com precisão
+   ```
+
+### Conflito do Agente com as Regras do Projeto
+
+**Sintomas:**
+- As sugestões do agente contradizem as convenções do projeto
+- Conselhos inconsistentes
+
+**Soluções:**
+
+1. **Atualizar o contexto do projeto**
+   - Adicionar convenções específicas ao `00-project-context.md`
+   - Incluir preferências e restrições da equipe
+
+2. **Ser explícito nas solicitações**
+   ```markdown
+   @api-designer Projete o endpoint seguindo nossas convenções RESTful
+   (veja 00-project-context.md para nossos padrões de API)
+   ```
 
 ---
 
 ## Problemas de Comandos
 
 ### Comando Não Encontrado
-1. Verificar diretório: `ls .claude/commands/symfony/`
-2. Verificar namespace correto
-3. Listar comandos: `/help`
 
-### Erros de Execução
-1. Verificar pré-requisitos
-2. Revisar arquivo de comando
-3. Fornecer parâmetros obrigatórios
+**Sintomas:**
+- `/symfony:generate-crud` retorna "unknown command"
+- Sugestões de comandos não aparecem
+
+**Soluções:**
+
+1. **Verificar o diretório de comandos**
+   ```bash
+   ls .claude/commands/symfony/
+   # Deve incluir generate-crud.md
+   ```
+
+2. **Verificar o namespace**
+   ```bash
+   # Os comandos estão no formato: /{namespace}:{command}
+   # Namespaces disponíveis:
+   ls .claude/commands/
+   # common/, symfony/, flutter/, python/, react/, reactnative/, docker/
+   ```
+
+3. **Listar os comandos disponíveis**
+   ```bash
+   # No Claude Code, digite:
+   /help
+   ```
+
+### Erros de Execução de Comandos
+
+**Sintomas:**
+- O comando inicia mas falha
+- Saída inesperada ou erros
+
+**Soluções:**
+
+1. **Verificar os pré-requisitos**
+   - Alguns comandos exigem ferramentas específicas
+   - Verificar se as dependências necessárias estão instaladas
+
+2. **Revisar o arquivo de comando**
+   ```bash
+   cat .claude/commands/symfony/generate-crud.md
+   # Entender o que o comando espera
+   ```
+
+3. **Fornecer os parâmetros obrigatórios**
+   ```bash
+   # Em vez de
+   /symfony:generate-crud
+
+   # Use
+   /symfony:generate-crud User --with-api --with-tests
+   ```
+
+### Saída do Comando Incorreta
+
+**Sintomas:**
+- O código gerado não corresponde ao estilo do projeto
+- Padrões de tecnologia errados utilizados
+
+**Soluções:**
+
+1. **Atualizar o contexto do projeto**
+   ```bash
+   # Editar .claude/rules/00-project-context.md
+   # Adicionar padrões e convenções específicos
+   ```
+
+2. **Personalizar os templates**
+   ```bash
+   # Editar templates em .claude/templates/
+   # Ajustar para corresponder ao estilo do seu projeto
+   ```
 
 ---
 
 ## Problemas de Configuração
 
-### YAML Inválido
-```bash
-yq e '.' claude-projects.yaml  # Validar sintaxe
-make config-validate CONFIG=claude-projects.yaml
-```
+### Configuração YAML Inválida
 
-### Projeto Não Encontrado
-1. Verificar ortografia do nome (sensível a maiúsculas)
-2. Verificar caminho do arquivo de configuração
+**Sintomas:**
+- `make config-validate` falha
+- Erros de sintaxe na configuração
+
+**Soluções:**
+
+1. **Verificar a sintaxe YAML**
+   ```bash
+   # Validar YAML
+   yq e '.' claude-projects.yaml
+   ```
+
+2. **Erros comuns de YAML:**
+   ```yaml
+   # Errado: indentação inconsistente
+   projects:
+     - name: "project"
+       path: "/path"  # 2 espaços
+        technologies: ["symfony"]  # 3 espaços - ERRO!
+
+   # Correto: indentação consistente
+   projects:
+     - name: "project"
+       path: "/path"
+       technologies: ["symfony"]
+   ```
+
+3. **Validar com a ferramenta**
+   ```bash
+   make config-validate CONFIG=claude-projects.yaml
+   ```
+
+### Projeto Não Encontrado na Configuração
+
+**Sintomas:**
+- "Project not found" ao instalar
+- Projeto não listado
+
+**Soluções:**
+
+1. **Verificar a ortografia do nome do projeto**
+   ```bash
+   # Listar projetos
+   make config-list CONFIG=claude-projects.yaml
+
+   # Os nomes diferenciam maiúsculas de minúsculas
+   ```
+
+2. **Verificar o caminho do arquivo de configuração**
+   ```bash
+   # Por padrão, busca claude-projects.yaml no diretório atual
+   # Especificar explicitamente:
+   make config-install CONFIG=/caminho/para/config.yaml PROJECT=myprojeto
+   ```
+
+### Configuração Não Aplicada
+
+**Sintomas:**
+- Alterações na configuração não têm efeito
+- Configurações antigas persistem
+
+**Soluções:**
+
+1. **Reinstalar com força**
+   ```bash
+   make config-install CONFIG=claude-projects.yaml PROJECT=myprojeto OPTIONS="--force"
+   ```
+
+2. **Verificar conflitos**
+   ```bash
+   # Remover instalação existente
+   rm -rf /caminho/para/projeto/.claude
+
+   # Reinstalar
+   make config-install CONFIG=claude-projects.yaml PROJECT=myprojeto
+   ```
 
 ---
 
 ## Problemas de Ferramentas
 
-### StatusLine Não Aparece
+### StatusLine Não Está Sendo Exibida
+
+**Sintomas:**
+- Barra de status vazia ou padrão
+- Linha de status personalizada não aparece
+
+**Soluções:**
+
+1. **Verificar se o script está instalado**
+   ```bash
+   ls -la ~/.claude/statusline.sh
+   # Deve existir e ser executável
+   ```
+
+2. **Verificar o settings.json**
+   ```bash
+   cat ~/.claude/settings.json | jq '.statusLine'
+   # Deve mostrar:
+   # {
+   #   "type": "command",
+   #   "command": "~/.claude/statusline.sh"
+   # }
+   ```
+
+3. **Testar o script manualmente**
+   ```bash
+   echo '{"model":{"display_name":"Test","id":"claude-opus"}}' | ~/.claude/statusline.sh
+   # Deve exibir a linha de status formatada
+   ```
+
+4. **Verificar o jq**
+   ```bash
+   which jq
+   # Instalar se ausente: brew install jq / apt install jq
+   ```
+
+### Problemas de Perfil MultiConta
+
+**Sintomas:**
+- Não é possível alternar perfis
+- Perfil não reconhecido
+
+**Soluções:**
+
+1. **Listar os perfis**
+   ```bash
+   ./claude-accounts.sh list
+   ```
+
+2. **Verificar o diretório de perfis**
+   ```bash
+   ls -la ~/.claude-profiles/
+   # Deve conter os diretórios de perfil
+   ```
+
+3. **Verificar o arquivo de modo do perfil**
+   ```bash
+   cat ~/.claude-profiles/meuperfil/.mode
+   # Deve conter "shared" ou "isolated"
+   ```
+
+4. **Recriar o perfil com problema**
+   ```bash
+   ./claude-accounts.sh remove meuperfil
+   ./claude-accounts.sh add meuperfil --mode=shared
+   ```
+
+### Erros de yq no ProjectConfig
+
+**Sintomas:**
+- "yq: command not found"
+- Erros de análise de YAML
+
+**Soluções:**
+
+1. **Instalar yq**
+   ```bash
+   # macOS
+   brew install yq
+
+   # Linux
+   sudo snap install yq
+   # ou
+   sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+   sudo chmod +x /usr/local/bin/yq
+   ```
+
+2. **Verificar a versão do yq**
+   ```bash
+   yq --version
+   # Deve ser v4.x (mikefarah/yq, não kislyuk/yq)
+   ```
+
+---
+
+## Problemas de Hook
+
+### Hook Não Está Disparando
+
+**Sintomas:**
+- Hooks PreToolUse/PostToolUse não executam
+- Nenhuma saída dos comandos de hook
+
+**Soluções:**
+
+1. **Verificar a configuração de hook no settings.json**
+   ```bash
+   cat .claude/settings.json | jq '.hooks'
+   ```
+
+2. **Verificar a sintaxe do matcher**
+   ```json
+   {
+     "hooks": {
+       "PreToolUse": [{
+         "matcher": "Bash",
+         "hooks": [{"type": "command", "command": "echo test"}]
+       }]
+     }
+   }
+   ```
+   O `matcher` deve corresponder exatamente ao nome da ferramenta (ex.: `Bash`, `Edit`, `Write`).
+
+3. **Testar o comando do hook de forma independente**
+   ```bash
+   # Executar o comando do hook manualmente para verificar se funciona
+   bash -c 'echo test'
+   ```
+
+### Bloqueio do Hook PreCompact
+
+**Sintomas:**
+- A compactação de contexto não acontece quando esperado
+- Compactação parece travada
+
+**Solução:** Os hooks PreCompact (v2.1.105+) podem bloquear a compactação com código de saída 2. Verifique seus hooks:
 ```bash
-ls -la ~/.claude/statusline.sh  # Verificar instalação
-echo '{"model":{"display_name":"Test"}}' | ~/.claude/statusline.sh  # Teste
+cat .claude/settings.json | jq '.hooks.PreCompact'
+# Certifique-se de que os scripts de hook não retornem acidentalmente o código de saída 2
 ```
 
-### Problemas de Perfil MultiAccount
-```bash
-./claude-accounts.sh list
-ls -la ~/.claude-profiles/
-```
+### Erros de Sandbox
 
-### Erros yq
-```bash
-# Instalar yq v4.x (mikefarah/yq)
-brew install yq  # macOS
-sudo snap install yq  # Linux
-yq --version  # Verificar versão
-```
+**Sintomas:**
+- Erros de "Sandbox unavailable"
+- Problemas de permissão em subprocessos
+
+**Soluções:**
+
+1. **Verificar a versão do Claude Code** (sandbox exige v2.1.98+)
+   ```bash
+   claude --version
+   ```
+
+2. **No Linux, verificar suporte a namespaces PID**
+   ```bash
+   # Verificar se unshare está disponível
+   which unshare
+   ```
+
+3. **Desativar sandbox estrita se necessário** (não recomendado por segurança)
+   - Remover `sandbox.failIfUnavailable` das configurações, se tiver sido adicionado
+
+### Falhas de Hook Relacionadas à Segurança
+
+Se estiver usando servidores MCP com hooks, certifique-se de que o Claude Code seja v2.1.97+ para evitar CVEs conhecidas:
+- CVE-2025-59536: Injeção de comandos via entradas MCP no pipeline de hook
+- CVE-2026-35020: Bypass de comando composto
+- CVE-2026-35022: Injeção de prefixo via variável de ambiente
 
 ---
 
 ## Problemas de Desempenho
 
-### Execução Lenta
-1. Ajustar TTL de cache em `statusline.conf`
-2. Limpar caches: `rm /tmp/.ccusage_*`
-3. Verificar conexão de rede
+### Execução Lenta de Comandos
 
-### Alto Uso de Contexto
-1. Usar `/compact` para compactar o contexto proativamente
-2. Usar `/clear` entre tarefas não relacionadas
-3. Usar `/effort low` para tarefas simples (reduz consumo de tokens)
-4. Usar `/context` para obter sugestões de otimização
-5. Configurar RTK para economia de tokens de 60-90% (`/common:setup-rtk`)
-6. Delegar investigações a sub-agentes
+**Sintomas:**
+- Comandos demoram muito para responder
+- StatusLine atualiza lentamente
+
+**Soluções:**
+
+1. **Verificar as configurações de cache**
+   ```bash
+   # Em ~/.claude/statusline.conf
+   SESSION_CACHE_TTL=60   # Reduzir se estiver muito lento
+   WEEKLY_CACHE_TTL=300   # Reduzir se estiver muito lento
+   ```
+
+2. **Limpar caches**
+   ```bash
+   rm /tmp/.ccusage_*
+   ```
+
+3. **Verificar a rede**
+   - Algumas funcionalidades exigem rede (ccusage)
+   - Rede lenta = atualizações lentas
+
+### Alto Uso da Janela de Contexto
+
+**Sintomas:**
+- Indicador de contexto mostra percentual alto rapidamente
+- Avisos de "Context limit"
+
+**Soluções:**
+
+1. **Usar `/context` para sugestões de otimização** (v2.1.74+)
+   ```bash
+   /context
+   ```
+
+2. **Ajustar o nível de esforço** para tarefas simples (v2.1.72+)
+   ```bash
+   /effort low    # Consultas simples
+   /effort medium # Trabalho padrão
+   ```
+
+3. **Compactar proativamente** em ~70% de uso
+   ```bash
+   /compact
+   ```
+
+4. **Usar `/clear` entre tarefas não relacionadas**
+
+5. **Salvar aprendizados importantes** antes da compactação
+   ```bash
+   /memory "Important: auth uses JWT RS256 with 15min expiry"
+   ```
+
+6. **Configurar RTK** para economia de 55-65% de tokens
+   ```bash
+   /common:setup-rtk
+   ```
+
+7. **Usar agentes para tarefas complexas**
+   ```markdown
+   # Em vez de colar toda a base de código
+   @research-assistant Find all authentication-related files in src/
+   ```
 
 ---
 
-## Obter Ajuda
+## Obtendo Ajuda
 
-### Documentação
-- `docs/AGENTS.md` - Referência de agentes
-- `docs/COMMANDS.md` - Referência de comandos
-- `docs/TECHNOLOGIES.md` - Guia de tecnologias
+### Verificar a Documentação
 
-### Versões
+1. **Docs principais**: diretório `docs/`
+2. **Referência de agentes**: `docs/AGENTS.md`
+3. **Referência de comandos**: `docs/COMMANDS.md`
+4. **Guia de tecnologias**: `docs/TECHNOLOGIES.md`
+
+### Obter Informações de Versão
+
 ```bash
+# Scripts de instalação
 ./Dev/scripts/install-symfony-rules.sh --version
+
+# Ferramentas
 ./Tools/MultiAccount/claude-accounts.sh --version
+./Tools/ProjectConfig/claude-projects.sh --version
+```
+
+### Reportar Problemas
+
+Se encontrar bugs:
+
+1. Coletar informações:
+   - Versão do Claude-Craft
+   - Sistema operacional
+   - Passos para reproduzir
+   - Mensagens de erro
+
+2. Verificar os problemas existentes no GitHub
+
+3. Criar um novo issue com os detalhes
+
+### Pedir Ajuda
+
+```markdown
+@research-assistant Estou com problema em [descrever o problema]
+
+Ambiente:
+- SO: [seu SO]
+- Versão do Claude-Craft: [versão]
+- Tecnologia: [symfony/flutter/etc.]
+
+O que tentei:
+1. [passo 1]
+2. [passo 2]
+
+Mensagem de erro:
+[colar o erro]
 ```
 
 ---
 
 ## Checklist de Correções Rápidas
 
-- [ ] Reiniciar Claude Code
-- [ ] Verificar instalação (`ls .claude/`)
-- [ ] Verificar permissões de arquivos
-- [ ] Validar configuração
+Quando algo não funcionar:
+
+- [ ] Reiniciar o Claude Code
+- [ ] Verificar a instalação (`ls .claude/`)
+- [ ] Verificar as permissões de arquivos
+- [ ] Validar a configuração
 - [ ] Limpar caches
-- [ ] Verificar dependências (jq, yq)
-- [ ] Tentar reinstalação com `--force`
+- [ ] Verificar as dependências (jq, yq)
+- [ ] Tentar reinstalar com `--force`
+- [ ] Verificar a documentação
+- [ ] Pedir ajuda
 
 ---
 

--- a/docs/guides/pt/07-backlog-management.md
+++ b/docs/guides/pt/07-backlog-management.md
@@ -1,24 +1,35 @@
-# Guia de Gestao do Backlog
+# Guia de Gestão do Backlog
 
-Fluxo de trabalho completo para criar e gerenciar um backlog SCRUM com Claude-Craft.
+Fluxo de trabalho completo para criar e gerenciar um backlog SCRUM com o Claude-Craft.
 
 ---
 
-## Visao Geral
+## Visão Geral
 
-Claude-Craft fornece um conjunto completo de comandos para gerenciar seu product backlog seguindo a metodologia SCRUM:
+O Claude-Craft fornece um conjunto completo de comandos para gerenciar seu product backlog seguindo a metodologia SCRUM:
 
-- **15 comandos slash** para operacoes de backlog
+- **15 comandos slash** para operações de backlog
 - **5 templates** para estrutura consistente
-- **Vertical slicing** obrigatorio em todas as camadas
-- **Validacao INVEST** para User Stories
+- **Vertical slicing** obrigatório em todas as camadas tecnológicas
+- **Validação do modelo INVEST** para User Stories
+
+### Filosofia
+
+Baseada em:
+- Princípios do Manifesto Ágil
+- 12 Princípios Ágeis
+- Fundamentos do SCRUM
+- Vertical slicing (cada US atravessa todas as camadas)
 
 ---
 
-## Geracao Inicial do Backlog
+## Geração Inicial do Backlog
+
+### A Partir de Especificações
+
+Coloque as especificações do seu projeto em `./docs/` e execute:
 
 ```bash
-# A partir das especificacoes em ./docs/
 /project:generate-backlog symfony+flutter
 ```
 
@@ -26,175 +37,299 @@ Claude-Craft fornece um conjunto completo de comandos para gerenciar seu product
 
 ```
 project-management/
-├── README.md                    # Visao geral do projeto
-├── personas.md                  # Personas (min. 3)
-├── definition-of-done.md        # Niveis DoD progressivos
+├── README.md                    # Visão geral do projeto
+├── personas.md                  # Personas (mín. 3)
+├── definition-of-done.md        # Níveis de DoD progressivos
+├── dependencies-matrix.md       # Dependências entre Epics e US
 ├── backlog/
-│   ├── epics/                   # EPIC-XXX-nome.md
-│   └── user-stories/            # US-XXX-nome.md
+│   ├── epics/                   # Arquivos EPIC-XXX-nome.md
+│   └── user-stories/            # Arquivos US-XXX-nome.md
 └── sprints/
-    └── sprint-XXX-objetivo/
+    └── sprint-XXX-objetivo/     # Planos de sprint
 ```
 
 ---
 
 ## Estrutura SCRUM
 
-### Personas (minimo 3)
-- Identidade, objetivos, frustracoes
-- Formato: P-001, P-002...
+### Personas
+
+Mínimo de 3 personas exigidas, cada uma contendo:
+- **Identidade**: Nome, função, dados demográficos
+- **Objetivos**: O que desejam alcançar
+- **Frustrações**: Problemas que precisam ser resolvidos
+
+Formato: `P-001`, `P-002`, `P-003`...
 
 ### EPICs
-- ID unico (EPIC-XXX)
-- MMF (Minimum Marketable Feature)
-- Objetivos de negocio e criterios de sucesso
 
-### User Stories (modelo INVEST)
+Grandes funcionalidades que contêm múltiplas User Stories:
 
-| Letra | Significado |
-|-------|-------------|
-| **I** | Independent - Sem dependencias |
-| **N** | Negotiable - Detalhes negociaveis |
-| **V** | Valuable - Valor para o usuario |
-| **E** | Estimable - Pode ser estimada |
-| **S** | Sized - Max 8 pontos |
-| **T** | Testable - Criterios claros |
+| Campo | Descrição |
+|-------|-----------|
+| ID | Identificador único (EPIC-001, EPIC-002...) |
+| MMF | Minimum Marketable Feature |
+| Status | Draft, Ready, In Progress, Done |
+| Objetivos de Negócio | Por que este EPIC é relevante |
+| Critérios de Sucesso | Como medir o êxito |
 
-#### Criterios de Aceitacao (Gherkin)
-- 1 cenario nominal
-- 2 cenarios alternativos
-- 2 cenarios de erro
+### User Stories
 
-### Tasks (Tarefas)
+Seguem o modelo **INVEST**:
 
-| Tipo | Descricao |
-|------|-----------|
-| `[DB]` | Banco de dados |
-| `[BE]` | Backend |
-| `[FE-WEB]` | Frontend Web |
-| `[FE-MOB]` | Frontend Mobile |
-| `[TEST]` | Testes |
-| `[DOC]` | Documentacao |
-| `[OPS]` | DevOps |
-| `[REV]` | Code review |
+| Letra | Significado | Validação |
+|-------|-------------|-----------|
+| **I** | Independent (Independente) | Sem dependências de outras US |
+| **N** | Negotiable (Negociável) | Detalhes podem ser discutidos |
+| **V** | Valuable (Valiosa) | Entrega valor ao usuário |
+| **E** | Estimable (Estimável) | Pode ser dimensionada em pontos |
+| **S** | Sized (Dimensionada) | Máx. 8 story points |
+| **T** | Testable (Testável) | Possui critérios de aceitação claros |
+
+#### Os 3 Cs
+
+1. **Card (Cartão)**: Descrição resumida
+2. **Conversation (Conversa)**: Detalhes da discussão
+3. **Confirmation (Confirmação)**: Critérios de aceitação
+
+#### Critérios de Aceitação (Gherkin)
+
+Cada US exige:
+- 1 cenário nominal (caminho feliz)
+- 2 cenários alternativos
+- 2 cenários de erro
+
+```gherkin
+Scenario: Usuário faz login com sucesso
+  Given um usuário cadastrado com credenciais válidas
+  When ele submete o formulário de login
+  Then ele deve visualizar seu painel
+  And uma sessão deve ser criada
+```
+
+### Tarefas (Tasks)
+
+Itens de trabalho técnico dentro de uma User Story:
+
+| Tipo | Descrição | Duração Típica |
+|------|-----------|----------------|
+| `[DB]` | Banco de dados (entidades, migrações) | 1–3h |
+| `[BE]` | Backend (serviços, APIs) | 2–4h |
+| `[FE-WEB]` | Frontend Web (controllers, templates) | 2–4h |
+| `[FE-MOB]` | Frontend Mobile (telas, blocs) | 3–5h |
+| `[TEST]` | Testes (unitário, integração, E2E) | 2–4h |
+| `[DOC]` | Documentação | 0,5–1h |
+| `[OPS]` | DevOps (CI/CD, deploy) | 1–2h |
+| `[REV]` | Revisão de código | 1–2h |
+
+**Regras de estimativa:**
+- Duração da tarefa: 0,5h – 8h máximo
+- Story points (Fibonacci): 1, 2, 3, 5, 8, 13, 21
+- Tamanho máximo de uma US: 8 pontos (dividir se maior)
 
 ---
 
 ## Fluxo de Trabalho
 
+### Fluxo de Status
+
 ```
-To Do ──→ In Progress ──→ Done
-   │            │
-   └────→ Blocked ←────┘
+┌─────────┐     ┌─────────────┐     ┌──────┐
+│  To Do  │ ──→ │ In Progress │ ──→ │ Done │
+└─────────┘     └─────────────┘     └──────┘
+     │                │
+     │                ↓
+     └────────→ ┌─────────┐
+                │ Blocked │
+                └─────────┘
+                     │
+                     ↓
+              ┌─────────────┐
+              │ In Progress │
+              └─────────────┘
 ```
+
+**Transições proibidas:**
+- To Do → Done (deve passar por In Progress)
+- Qualquer estado → To Do (exceto reabertura manual)
 
 ---
 
-## Referencia de Comandos
+## Referência de Comandos
 
-### Comandos de Criacao
+### Comandos de Criação
 
-| Comando | Descricao |
+| Comando | Descrição |
 |---------|-----------|
-| `/project:generate-backlog [stack]` | Gerar backlog das specs |
-| `/project:add-epic` | Criar novo EPIC |
-| `/project:add-story` | Adicionar User Story |
-| `/project:add-task` | Criar tarefa tecnica |
+| `/project:generate-backlog [stack]` | Gerar backlog completo a partir das specs |
+| `/project:add-epic` | Criar um novo EPIC |
+| `/project:add-story` | Adicionar uma User Story a um EPIC |
+| `/project:add-task` | Criar uma tarefa técnica para uma US |
 
-### Comandos de Visualizacao
+### Comandos de Visualização
 
-| Comando | Descricao |
+| Comando | Descrição |
 |---------|-----------|
-| `/project:list-epics` | Listar EPICs |
-| `/project:list-stories` | Listar User Stories |
-| `/project:list-tasks` | Listar tarefas |
-| `/project:board` | Quadro Kanban |
-| `/sprint:status` | Status do sprint |
+| `/project:list-epics` | Exibir todos os EPICs com status |
+| `/project:list-stories [filtro]` | Listar User Stories (por EPIC, Sprint, Status) |
+| `/project:list-tasks [filtro]` | Listar tarefas (por US, Sprint, Tipo, Status) |
+| `/project:board [sprint]` | Exibir quadro Kanban |
+| `/sprint:status [sprint]` | Relatório detalhado de progresso do sprint |
 
-### Comandos de Atualizacao
+### Comandos de Atualização
 
-| Comando | Descricao |
+| Comando | Descrição |
 |---------|-----------|
-| `/sprint:transition` | Alterar status/sprint da US |
-| `/project:move-task` | Alterar status da tarefa |
-| `/project:update-epic` | Modificar EPIC |
-| `/project:update-story` | Modificar User Story |
+| `/sprint:transition [id] [status/sprint]` | Alterar status da US ou atribuir ao sprint |
+| `/project:move-task [id] [status]` | Alterar status de uma tarefa |
+| `/project:update-epic [id]` | Modificar um EPIC existente |
+| `/project:update-story [id]` | Modificar uma User Story existente |
 
-### Comandos Avancados
+### Comandos Avançados
 
-| Comando | Descricao |
+| Comando | Descrição |
 |---------|-----------|
-| `/project:decompose-tasks` | Decompor US em tarefas |
-| `/gate:validate-backlog` | Auditar qualidade SCRUM |
+| `/project:decompose-tasks [sprint]` | Decompor as US do sprint em tarefas |
+| `/gate:validate-backlog` | Auditar a qualidade do backlog (conformidade SCRUM) |
 
 ---
 
-## Exemplo Completo
+## Exemplo Completo: Novo Projeto
 
-```markdown
-## Passo 1: Gerar backlog inicial
+### Passo 1: Gerar o Backlog Inicial
+
+```bash
+# Certifique-se de que as specs estão em ./docs/
 /project:generate-backlog symfony+flutter
-
-## Passo 2: Validar qualidade
-/gate:validate-backlog
-
-## Passo 3: Visualizar Sprint 1
-/project:board 1
-
-## Passo 4: Decompor em tarefas
-/project:decompose-tasks 1
-
-## Passo 5: Comecar trabalho
-/project:move-task TASK-001 in-progress
 ```
 
+### Passo 2: Validar a Qualidade
+
+```bash
+/gate:validate-backlog
+```
+
+Isso gera `scrum-validation-report.md` com:
+- Pontuação de conformidade INVEST
+- Verificação dos 3 Cs
+- Análise dos critérios SMART
+- Consistência das estimativas
+
+### Passo 3: Revisar o Sprint 1
+
+```bash
+/project:board 1
+```
+
+Exibe o quadro Kanban com as colunas:
+- To Do | In Progress | In Review | Done | Blocked
+
+### Passo 4: Decompor em Tarefas
+
+```bash
+/project:decompose-tasks 1
+```
+
+Cria o detalhamento das tarefas:
+- Tarefas agrupadas por US
+- Grafo de dependências (Mermaid)
+- Estimativas de tempo por camada
+
+### Passo 5: Iniciar o Trabalho
+
+```bash
+# Mover primeira tarefa para em andamento
+/project:move-task TASK-001 in-progress
+
+# Depois, marcar como concluída
+/project:move-task TASK-001 done
+
+# Se bloqueada
+/project:move-task TASK-002 blocked "Aguardando specs da API"
+```
+
+### Passo 6: Acompanhar o Progresso
+
+```bash
+/sprint:status 1
+```
+
+### Passo 7: Configurar Monitoramento Recorrente (Opcional)
+
+Use `/loop` (v2.1.71+) para monitorar automaticamente o progresso do sprint:
+
+```bash
+# Verificar status do sprint a cada 30 minutos
+/loop 30m /sprint:status 1
+
+# Executar verificações pré-commit a cada 5 minutos durante o desenvolvimento
+/loop 5m /common:pre-commit-check
+```
+
+Alias: `/proactive` (v2.1.105+).
+
+Exibe:
+- Progresso geral e burndown
+- Métricas por User Story
+- Bloqueios e riscos
+- Ações recomendadas
+
 ---
 
-## Templates Disponiveis
+## Templates
 
-| Template | Proposito |
+O Claude-Craft fornece 5 templates para estrutura consistente do backlog:
+
+| Template | Finalidade |
 |----------|-----------|
-| `epic.md` | Estrutura de EPIC |
-| `user-story.md` | Estrutura de User Story |
-| `task.md` | Estrutura de tarefa |
-| `board.md` | Quadro Kanban |
-| `index.md` | Indice do backlog |
+| `epic.md` | Estrutura do arquivo EPIC com metadados, objetivos e lista de US |
+| `user-story.md` | Estrutura de US com critérios Gherkin e tabela de tarefas |
+| `task.md` | Estrutura de tarefa com checklist de DoD |
+| `board.md` | Quadro Kanban com cálculo de métricas |
+| `index.md` | Índice do backlog com resumo global |
 
 ---
 
-## Regras SCRUM
+## Regras SCRUM Aplicadas
 
 | Regra | Valor |
 |-------|-------|
-| Duracao sprint | 2 semanas |
-| Velocidade | 20-40 pontos/sprint |
-| Max US | 8 pontos |
-| Estimativa | Fibonacci (1,2,3,5,8,13,21) |
-| Duracao tarefa | 0.5h - 8h max |
+| Duração do sprint | 2 semanas (fixo) |
+| Velocidade | 20–40 pontos/sprint |
+| Tamanho máximo de US | 8 pontos (dividir se maior) |
+| Escala de estimativa | Fibonacci (1, 2, 3, 5, 8, 13, 21) |
+| Duração da tarefa | 0,5h – 8h máximo |
 
-### Sprint 1 = Walking Skeleton
-- Infraestrutura completa
-- 1 feature end-to-end
-- Testavel em Web e Mobile
+### Sprint 1: Walking Skeleton
+
+O primeiro sprint deve incluir:
+- Configuração completa da infraestrutura
+- 1 funcionalidade end-to-end (não apenas configuração)
+- Testável tanto em Web quanto em Mobile
 
 ### Vertical Slicing
-Cada US deve atravessar todas as camadas:
+
+**Cada User Story DEVE atravessar todas as camadas:**
+
 ```
-UI → API → Logica de Negocio → Banco de Dados
+UI (Web/Mobile) → API → Lógica de Negócio → Banco de Dados
 ```
+
+Não são permitidas User Stories "somente Backend", "somente Frontend" ou "somente Mobile".
 
 ---
 
-## Checklist
+## Checklist: Backlog Pronto
 
-- [ ] Minimo 3 personas definidas
-- [ ] EPICs com MMF e criterios de sucesso
-- [ ] User Stories seguem INVEST
-- [ ] Criterios no formato Gherkin
-- [ ] Estimativa em Fibonacci
+- [ ] Mínimo de 3 personas definidas
+- [ ] EPICs com MMF e critérios de sucesso
+- [ ] User Stories seguem o modelo INVEST
+- [ ] Critérios de aceitação no formato Gherkin
+- [ ] Stories estimadas em pontos Fibonacci
 - [ ] Sprint 1 = Walking Skeleton
-- [ ] Backlog validado
+- [ ] Definition of Done documentada
+- [ ] Backlog validado (`/gate:validate-backlog`)
 
 ---
 
-[&larr; Resolucao de Problemas](06-troubleshooting.md) | [Proximo: Configurar Novo Projeto &rarr;](08-setup-new-project.md)
+[&larr; Resolução de Problemas](06-troubleshooting.md) | [Próximo: Configurar Novo Projeto &rarr;](08-setup-new-project.md)

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -17,7 +17,7 @@ Este guia acompanha você ao longo de todo o ciclo de desenvolvimento:
 7. **Deploy** - Entregar em produção
 
 **Pré-requisitos:**
-- Claude Craft v8.8.1 instalado no seu projeto
+- Claude Craft v8.8.2 instalado no seu projeto
 - Claude Code v2.1.159 (recomendado) ou v2.1.97+ (mínimo, CVE-2025-59536 corrigido)
 - Conhecimento básico da stack de tecnologia escolhida
 

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -1,14 +1,14 @@
 # Guia de Fluxo de Trabalho Completo: Da Ideia à Produção
 
-Guia completo passo a passo para construir uma aplicação completa com Claude Craft, da ideia inicial ao deploy em produção.
+Um guia completo passo a passo para construir uma aplicação inteira usando o Claude Craft, da ideia inicial ao deploy em produção.
 
 ---
 
 ## Visão Geral
 
-Este guia acompanha você através do ciclo de desenvolvimento completo:
+Este guia acompanha você ao longo de todo o ciclo de desenvolvimento:
 
-1. **Ideação** - Definir sua visão do produto
+1. **Ideação** - Definir a visão do seu produto
 2. **Requisitos** - Documentar o que você está construindo
 3. **Arquitetura** - Projetar a solução técnica
 4. **Planejamento** - Criar sprints acionáveis
@@ -16,9 +16,26 @@ Este guia acompanha você através do ciclo de desenvolvimento completo:
 6. **Qualidade** - Validar e testar
 7. **Deploy** - Entregar em produção
 
+**Pré-requisitos:**
+- Claude Craft v8.8.1 instalado no seu projeto
+- Claude Code v2.1.159 (recomendado) ou v2.1.97+ (mínimo, CVE-2025-59536 corrigido)
+- Conhecimento básico da stack de tecnologia escolhida
+
 ---
 
 ## Fase 1: Ideação (5-10 minutos)
+
+### Configurar sua Sessão
+
+Antes de começar, configure a sua sessão para desempenho otimizado:
+
+```bash
+# Ajustar o nível de raciocínio para planejamento (alto para tarefas complexas)
+/effort high
+
+# Opcionalmente, configurar a otimização de tokens
+/common:setup-rtk
+```
 
 ### Iniciar com BMAD
 
@@ -32,6 +49,8 @@ Este guia acompanha você através do ciclo de desenvolvimento completo:
 
 ### Definir a Visão
 
+Trabalhe com o agente de Product Manager:
+
 ```
 @pm Quero construir uma plataforma e-commerce para vender produtos artesanais.
 Funcionalidades principais:
@@ -41,111 +60,452 @@ Funcionalidades principais:
 - Gestão de pedidos
 ```
 
+O PM irá ajudá-lo a:
+- Clarificar o problema que você está resolvendo
+- Identificar os usuários-alvo
+- Definir métricas de sucesso
+
+### Criar o Documento de Visão Inicial
+
+```
+@pm Crie um documento de visão para este projeto
+```
+
+Saída: `docs/vision.md`
+
 ---
 
 ## Fase 2: Requisitos (15-30 minutos)
 
-### Criar PRD
+### Analisar os Requisitos
+
+Trabalhe com o Analista de Negócios:
+
+```
+@ba Analise os requisitos da plataforma e-commerce com base na visão
+```
+
+O BA irá:
+- Decompor as funcionalidades em histórias de usuário
+- Identificar dependências
+- Criar um mapa de histórias de usuário
+
+### Criar o PRD
 
 ```
 @pm Crie um Product Requirements Document
+```
+
+### Validar o PRD
+
+```
 /gate:validate-prd docs/prd.md
 ```
+
+Certifique-se de passar no PRD Gate (≥80%):
+- [ ] Declaração do problema definida
+- [ ] Usuários-alvo identificados
+- [ ] Objetivos claros
+- [ ] Métricas de sucesso definidas
+- [ ] Limites de escopo estabelecidos
 
 ---
 
 ## Fase 3: Arquitetura (20-45 minutos)
 
-### Projetar Arquitetura
+### Projetar a Arquitetura
+
+Trabalhe com o Arquiteto:
 
 ```
 @architect Projete a arquitetura do sistema para a plataforma e-commerce
+Considere:
+- Backend Symfony com API Platform
+- Banco de dados PostgreSQL
+- Cache Redis
+- Deploy com Docker
 ```
 
-### Validar Especificação Técnica
+O Arquiteto criará:
+- Diagrama de arquitetura do sistema
+- Design dos componentes
+- Modelo de dados
+- Contratos de API
+
+### Criar a Especificação Técnica
+
+```
+@architect Crie a especificação técnica a partir do PRD
+```
+
+Saída: `docs/tech-spec.md`
+
+### Documentar as Decisões
+
+Para escolhas importantes:
+
+```
+@architect Crie um ADR para a escolha de JWT em vez de autenticação baseada em sessão
+```
+
+Saída: `docs/adr/001-jwt-authentication.md`
+
+### Validar a Especificação Técnica
 
 ```
 /gate:validate-techspec docs/tech-spec.md
 ```
+
+Certifique-se de passar no Tech Spec Gate (≥90%):
+- [ ] Arquitetura documentada
+- [ ] Contratos de API definidos
+- [ ] Segurança abordada
+- [ ] Requisitos de desempenho estabelecidos
+- [ ] Estratégia de testes definida
+- [ ] Plano de deploy criado
 
 ---
 
 ## Fase 4: Planejamento (15-30 minutos)
 
-### Criar Backlog
+### Criar o Backlog
+
+Trabalhe com o Product Owner:
 
 ```
-@po Crie user stories a partir da especificação técnica
-@sm Planeje o sprint 1
+@po Crie histórias de usuário a partir da especificação técnica
+Priorize usando o método MoSCoW
+```
+
+O PO criará histórias como:
+```
+EPIC-001: Autenticação de Usuário
+├── US-001: Registro de usuário
+├── US-002: Login de usuário
+├── US-003: Redefinição de senha
+└── US-004: Login social
+
+EPIC-002: Catálogo de Produtos
+├── US-005: Navegar pelos produtos
+├── US-006: Busca de produtos
+├── US-007: Filtragem por categoria
+└── US-008: Detalhes do produto
+```
+
+### Validar o Backlog
+
+```
+/gate:validate-backlog
+```
+
+Cada história deve passar no critério INVEST:
+- **I**ndependente
+- **N**egociável
+- **V**aliosa
+- **E**stimável
+- **S**mall (pequena)
+- **T**estável
+
+### Planejar o Primeiro Sprint
+
+Trabalhe com o Scrum Master:
+
+```
+@sm Planeje o sprint 1 com as histórias de maior prioridade
+Inclua:
+- US-001: Registro de usuário
+- US-002: Login de usuário
+- US-005: Navegar pelos produtos
+```
+
+### Validar o Sprint
+
+```
 /gate:validate-sprint
 ```
 
 ---
 
-## Fase 5: Desenvolvimento
+## Fase 5: Desenvolvimento (Variável)
 
-### Ciclo TDD
+### Iniciar o Desenvolvimento do Sprint
 
-```bash
-# Obter próxima história
+```
+/sprint:dev 1
+```
+
+Ou trabalhe história por história:
+
+### 5.1 Obter a Próxima História
+
+```
 /sprint:next-story --claim
+```
 
-# Implementar com TDD
-@dev Implemente US-001 usando TDD
+Exemplo: US-001 (Registro de Usuário)
 
-# 🔴 Vermelho - Escrever teste falhando
-# 🟢 Verde - Implementar
-# 🔵 Refatorar
+### 5.2 Transicionar para Em Andamento
 
-# Validar
+```
+/sprint:transition US-001 in-progress
+```
+
+### 5.3 Fase Vermelha do TDD (Escrever Teste que Falha)
+
+Trabalhe com o agente Desenvolvedor:
+
+```
+@dev Inicie o TDD para US-001 (Registro de Usuário)
+Comece com a fase 🔴 Vermelho - escreva testes que falham
+```
+
+Crie os testes primeiro:
+```php
+// tests/Feature/UserRegistrationTest.php
+class UserRegistrationTest extends TestCase
+{
+    public function test_user_can_register_with_valid_data(): void
+    {
+        $response = $this->post('/api/register', [
+            'email' => 'test@example.com',
+            'password' => 'SecurePass123!',
+            'name' => 'Test User'
+        ]);
+
+        $response->assertStatus(201);
+        $this->assertDatabaseHas('users', ['email' => 'test@example.com']);
+    }
+}
+```
+
+### 5.4 Fase Verde do TDD (Implementar)
+
+```
+@dev Agora implemente a fase 🟢 Verde - faça os testes passarem
+```
+
+Gere o código:
+```
+/symfony:generate-crud User
+```
+
+### 5.5 Fase de Refatoração do TDD
+
+```
+@dev 🔵 Refatorar - limpe a implementação
+```
+
+### 5.6 Revisão de Código
+
+```
+@symfony-reviewer Revise a implementação do registro de usuário
+```
+
+### 5.7 Validar a DoD da História
+
+```
 /gate:validate-story US-001
+```
+
+### 5.8 Transicionar para Revisão
+
+```
+/sprint:transition US-001 review
+```
+
+### 5.9 Validação pelo QA
+
+```
+@qa Valide os critérios de aceitação para US-001
+```
+
+### 5.10 Concluir a História
+
+```
 /sprint:transition US-001 done
 ```
 
+### 5.11 Repetir
+
+Continue com a próxima história até o sprint estar completo.
+
 ---
 
-## Fase 6: Qualidade
+## Fase 6: Qualidade (Contínua)
+
+### Gerenciamento de Contexto
+
+Durante o desenvolvimento, gerencie a janela de contexto de forma eficiente:
 
 ```bash
+# Verificar sugestões de otimização do contexto
+/context
+
+# Mudar para menor esforço em tarefas simples
+/effort low
+
+# Limpar o contexto entre tarefas não relacionadas
+/clear
+
+# Salvar aprendizados importantes que persistem entre sessões
+/memory "Decisão arquitetural-chave: usando CQRS para o módulo de pedidos"
+```
+
+### Verificações de Qualidade Contínuas
+
+Execute regularmente durante o desenvolvimento:
+
+```bash
+# Configurar monitoramento de qualidade recorrente
+/loop 5m /common:pre-commit-check
+
+# Verificação de arquitetura
 /symfony:check-architecture
+
+# Qualidade do código
+/symfony:check-code-quality
+
+# Auditoria de segurança
+/symfony:check-security
+
+# Cobertura de testes
+/symfony:check-testing
+```
+
+### Auditoria Completa Antes do Lançamento
+
+```
 /team:audit --sequential
+```
+
+### Validação Pré-Commit
+
+Sempre antes de fazer commit:
+
+```
 /common:pre-commit-check
 ```
 
+### Revisão do Sprint
+
+Ao final do sprint:
+
+```
+@sm Execute a revisão do sprint 1
+```
+
+### Retrospectiva
+
+```
+@sm Execute a retrospectiva do sprint
+```
+
 ---
 
-## Fase 7: Deploy
+## Fase 7: Deploy (30-60 minutos)
 
-```bash
+### Preparar a Configuração Docker
+
+```
+@docker-architect Projete a arquitetura Docker para produção
+```
+
+### Criar os Arquivos Docker
+
+```
 /docker:compose-setup symfony postgresql redis
+```
+
+### Criar o Pipeline de CI/CD
+
+```
 /docker:cicd-pipeline github-actions
+```
+
+### Verificação de Segurança
+
+```
+/docker:security-scan
+```
+
+### Lista de Verificação Pré-Lançamento
+
+```
 /common:release-checklist
 ```
 
----
-
-## Usando Ralph para Automação
+### Deploy
 
 ```bash
-/common:ralph-run "Implementar autenticação de usuário com TDD"
+# Build e teste
+docker compose -f docker-compose.prod.yml build
+docker compose -f docker-compose.prod.yml up -d
+
+# Executar migrações
+docker compose exec app php bin/console doctrine:migrations:migrate
+
+# Verificar saúde
+curl https://your-app.com/health
 ```
 
 ---
 
-## Sequência de Comandos Completa
+## Usando o Ralph para Automação
+
+Para ciclos de desenvolvimento automatizados, use o Ralph Wiggum:
 
 ```bash
+# Implementar uma funcionalidade automaticamente
+/common:ralph-run "Implementar registro de usuário com TDD"
+
+# Com verificações completas de DoD
+/common:ralph-run --full "Adicionar funcionalidade de redefinição de senha"
+```
+
+O Ralph irá iterar até que:
+- Todos os testes passem
+- O lint passe
+- Os validadores de DoD passem
+
+---
+
+## Sequência Completa de Comandos
+
+Aqui está uma sequência condensada para uma funcionalidade típica:
+
+```bash
+# 0. Configuração da sessão
+/effort high                    # Planejamento complexo
+/common:setup-rtk               # Otimização de tokens (apenas na primeira vez)
+
+# 1. Inicializar
 /bmad:init
-@pm Crie o PRD
+
+# 2. Definir (PM)
+@pm Crie o PRD para a funcionalidade
 /gate:validate-prd docs/prd.md
+
+# 3. Projetar (Arquiteto)
 @architect Crie a especificação técnica
 /gate:validate-techspec docs/tech-spec.md
-@po Crie as user stories
+
+# 4. Planejar (PO + SM)
+@po Crie as histórias de usuário
 @sm Planeje o sprint 1
+/gate:validate-sprint
+
+# 5. Desenvolver (Dev)
 /sprint:next-story --claim
-@dev Implemente com TDD
+@dev Implementar com TDD
 /gate:validate-story US-001
+/sprint:transition US-001 done
+
+# 6. Revisar (QA)
+@qa Validar os critérios de aceitação
 /team:audit --sequential
+
+# 7. Deploy
+/docker:cicd-pipeline github-actions
 /common:release-checklist
 ```
 
@@ -153,22 +513,78 @@ Funcionalidades principais:
 
 ## Dicas para o Sucesso
 
-1. **Não pule os Quality Gates**
-2. **Use os agentes colaborativamente** - Claude-Craft inclui **70 agentes** especializados
-3. **TDD é não negociável**: 🔴 → 🟢 → 🔵
-4. **Documente as decisões** com ADRs
-5. **Revisões regulares**: `/common:daily-standup`, `@{tech}-reviewer`
-6. **Gerencie seu contexto**:
-   - `/effort high` para tarefas complexas, `/effort low` para lookups
-   - `/context` para sugestões de otimização do contexto
-   - `/compact` proativamente quando o contexto ultrapassar 70%
-   - `/clear` entre tarefas não relacionadas
-   - `/loop` para tarefas recorrentes (ex: `/loop 5m /common:pre-commit-check`)
+### 0. Gerencie sua Janela de Contexto
+
+A janela de contexto é o seu recurso mais crítico:
+- Use `/effort low` para tarefas simples, `/effort high` para tarefas complexas
+- Use `/context` regularmente para verificar sugestões de otimização
+- Execute `/clear` entre tarefas não relacionadas
+- Use `/memory` para persistir decisões-chave entre sessões
+- Configure `/loop` para verificações recorrentes em vez de execuções manuais
+
+### 1. Não Pule os Quality Gates
+
+Cada gate detecta problemas diferentes:
+- PRD Gate → Evita construir a coisa errada
+- Tech Spec Gate → Evita problemas arquiteturais
+- Backlog Gate → Garante que as histórias são implementáveis
+- Story DoD → Garante código de qualidade
+
+### 2. Use os Agentes de Forma Colaborativa
+
+Deixe os agentes se passarem o trabalho uns para os outros:
+```
+@bmad-master Direcione isto para o agente adequado
+```
+
+### 3. TDD é Inegociável
+
+Sempre siga 🔴 Vermelho → 🟢 Verde → 🔵 Refatorar.
+
+### 4. Documente as Decisões
+
+Use ADRs para escolhas importantes:
+```
+@architect Crie um ADR para a escolha de X em vez de Y
+```
+
+### 5. Revisões Regulares
+
+- Diariamente: `/common:daily-standup`
+- Final do Sprint: `@sm Execute a revisão do sprint`
+- Contínuo: `@{tech}-reviewer Revise este código`
 
 ---
 
-## Veja Também
+## Solução de Problemas
 
-- [Guia Prático BMAD](../BMAD-PRACTICAL-GUIDE.md)
-- [Guia Ralph Wiggum](../RALPH-GUIDE.md)
-- [Referência de Comandos](../COMMANDS.md)
+### Falha no Quality Gate
+
+```
+/gate:report
+```
+
+Verifique quais critérios estão faltando.
+
+### História Bloqueada
+
+```
+/sprint:transition US-001 blocked --reason="Aguardando API"
+```
+
+### Necessidade de Reverter
+
+Se estiver usando o Ralph com checkpointing Git:
+```bash
+git log --oneline --grep="[ralph]"
+git reset --hard HEAD~3
+```
+
+---
+
+## Próximos Passos
+
+- [Guia Prático BMAD](../BMAD-PRACTICAL-GUIDE.md) - Mergulho profundo no BMAD
+- [Guia Ralph Wiggum](../RALPH-GUIDE.md) - Desenvolvimento automatizado
+- [Referência de Comandos](../COMMANDS.md) - Todos os comandos disponíveis
+- [Referência de Agentes](../AGENTS.md) - Todos os agentes disponíveis

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-bearded-bear/claude-craft",
-      "version": "8.8.1",
+      "version": "8.8.2",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.8.1",
+  "version": "8.8.2",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",

--- a/scripts/verify-i18n-parity.sh
+++ b/scripts/verify-i18n-parity.sh
@@ -19,16 +19,18 @@ ERRORS=0
 # Size parity threshold: target language file must be >= SIZE_THRESHOLD * en_size
 # Overridable via env var; 0.80 means 80% parity required
 SIZE_THRESHOLD="${I18N_SIZE_THRESHOLD:-0.80}"
-# Set STRICT_SIZE=1 to fail on size gaps (default: warn only)
-STRICT_SIZE="${STRICT_SIZE:-0}"
+# Set STRICT_SIZE=0 to downgrade size gaps to warnings (default: fail on gaps).
+# Flipped to 1 in v8.8.2: the i18n translation debt (101 files < 0.80) is fully
+# resorbed, so any new sub-threshold file is now a regression and must block.
+STRICT_SIZE="${STRICT_SIZE:-1}"
 # Hard blocking threshold: files > BLOCK_SIZE_BYTES with ratio < BLOCK_RATIO trigger exit 1
 # regardless of SIZE_THRESHOLD, unless I18N_PARITY_STRICT=0 is set.
 BLOCK_SIZE_BYTES="${I18N_BLOCK_SIZE_BYTES:-5000}"
 BLOCK_RATIO="${I18N_BLOCK_RATIO:-0.40}"
-# Set I18N_PARITY_STRICT=1 to enable hard blocking (default: 0, opt-in until Phase 4)
-# Rationale: 164 i18n files inherited from pre-v8.6.0 are below the 0.40 ratio.
-# Once the i18n cleanup session (P0 #26) lands, flip default to 1.
-I18N_PARITY_STRICT="${I18N_PARITY_STRICT:-0}"
+# Set I18N_PARITY_STRICT=0 to allow transitional PRs (default: hard blocking on).
+# Flipped to 1 in v8.8.2: the inherited i18n debt is fully resorbed (gap report
+# empty), so a large file dropping below BLOCK_RATIO is now a regression to block.
+I18N_PARITY_STRICT="${I18N_PARITY_STRICT:-1}"
 SIZE_WARNINGS=0
 BLOCK_FAILURES=()
 # CSV output file for gap report

--- a/website/.vitepress/theme/LandingPage.vue
+++ b/website/.vitepress/theme/LandingPage.vue
@@ -17,7 +17,7 @@ const translations = {
     nav_tools: "Tools",
     nav_install: "Install",
     nav_tech: "Tech Stack",
-    hero_badge: "v8.8.1 - Claude Code 2.1.159",
+    hero_badge: "v8.8.2 - Claude Code 2.1.159",
     hero_title_1: "Supercharge",
     hero_title_2: "with Expert Knowledge",
     hero_desc: "A comprehensive framework for AI-assisted development. Install standardized rules, agents, and commands for your projects across multiple technology stacks.",
@@ -73,7 +73,7 @@ const translations = {
     nav_tools: "Outils",
     nav_install: "Installation",
     nav_tech: "Technologies",
-    hero_badge: "v8.8.1 - Claude Code 2.1.159",
+    hero_badge: "v8.8.2 - Claude Code 2.1.159",
     hero_title_1: "Superchargez",
     hero_title_2: "d'une Expertise Technique",
     hero_desc: "Un framework complet pour le d\u00e9veloppement assist\u00e9 par IA. Installez des r\u00e8gles, agents et commandes standardis\u00e9s pour vos projets.",
@@ -126,7 +126,7 @@ const translations = {
   },
   es: {
     nav_features: "Caracter\u00edsticas", nav_tools: "Herramientas", nav_install: "Instalaci\u00f3n", nav_tech: "Tecnolog\u00edas",
-    hero_badge: "v8.8.1 - Claude Code 2.1.159", hero_title_1: "Potencia", hero_title_2: "con Conocimiento Experto",
+    hero_badge: "v8.8.2 - Claude Code 2.1.159", hero_title_1: "Potencia", hero_title_2: "con Conocimiento Experto",
     hero_desc: "Un marco integral para el desarrollo asistido por IA.", cta_get_started: "Empezar", cta_docs: "Documentaci\u00f3n",
     feat_main_title: "Todo lo que necesitas para escalar", feat_main_desc: "Equipa a Claude con herramientas conscientes del contexto.",
     feat_bmad_title: "Framework BMAD v6", feat_bmad_desc: "9 agentes Agent-as-Code, 5 Quality Gates.",
@@ -154,7 +154,7 @@ const translations = {
   },
   de: {
     nav_features: "Funktionen", nav_tools: "Werkzeuge", nav_install: "Installation", nav_tech: "Technologien",
-    hero_badge: "v8.8.1 - Claude Code 2.1.159", hero_title_1: "Laden Sie", hero_title_2: "mit Expertenwissen auf",
+    hero_badge: "v8.8.2 - Claude Code 2.1.159", hero_title_1: "Laden Sie", hero_title_2: "mit Expertenwissen auf",
     hero_desc: "Ein umfassendes Framework f\u00fcr KI-gest\u00fctzte Entwicklung.", cta_get_started: "Loslegen", cta_docs: "Dokumentation",
     feat_main_title: "Alles f\u00fcr skalierbare KI-Entwicklung", feat_main_desc: "Statten Sie Claude mit kontextbezogenen Tools aus.",
     feat_bmad_title: "BMAD v6 Framework", feat_bmad_desc: "9 Agent-as-Code Personas, 5 Quality Gates.",
@@ -182,7 +182,7 @@ const translations = {
   },
   pt: {
     nav_features: "Funcionalidades", nav_tools: "Ferramentas", nav_install: "Instala\u00e7\u00e3o", nav_tech: "Tecnologias",
-    hero_badge: "v8.8.1 - Claude Code 2.1.159", hero_title_1: "Turbine o", hero_title_2: "com Conhecimento Especializado",
+    hero_badge: "v8.8.2 - Claude Code 2.1.159", hero_title_1: "Turbine o", hero_title_2: "com Conhecimento Especializado",
     hero_desc: "Um framework abrangente para desenvolvimento assistido por IA.", cta_get_started: "Come\u00e7ar", cta_docs: "Documenta\u00e7\u00e3o",
     feat_main_title: "Tudo para escalar", feat_main_desc: "Equipe o Claude com ferramentas conscientes do contexto.",
     feat_bmad_title: "Framework BMAD v6", feat_bmad_desc: "9 agentes Agent-as-Code, 5 Quality Gates.",
@@ -344,8 +344,8 @@ onMounted(() => {
           <p style="margin-top: 1rem; font-size: 1.25rem; color: #94a3b8;">{{ t('feat_main_desc') }}</p>
         </div>
         <div class="grid-3col" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 2rem;">
-          <FeatureCard icon="git-branch" color="cyan" :badge="'v8.8.1'" :title="t('feat_bmad_title')" :desc="t('feat_bmad_desc')" />
-          <FeatureCard icon="repeat" color="orange" :badge="'v8.8.1'" :title="t('feat_ralph_title')" :desc="t('feat_ralph_desc')" />
+          <FeatureCard icon="git-branch" color="cyan" :badge="'v8.8.2'" :title="t('feat_bmad_title')" :desc="t('feat_bmad_desc')" />
+          <FeatureCard icon="repeat" color="orange" :badge="'v8.8.2'" :title="t('feat_ralph_title')" :desc="t('feat_ralph_desc')" />
           <FeatureCard icon="globe" color="brand" :title="t('feat_1_title')" :desc="t('feat_1_desc')" />
           <FeatureCard icon="bot" color="blue" :title="t('feat_2_title')" :desc="t('feat_2_desc')" />
           <FeatureCard icon="sparkles" color="emerald" :title="t('feat_skills_title')" :desc="t('feat_skills_desc')" />

--- a/website/.vitepress/theme/components/AgentShowcase.vue
+++ b/website/.vitepress/theme/components/AgentShowcase.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 const agents = [
   { name: 'bmad-master', desc: 'BMAD orchestrator: routing, gates enforcement, sprint lifecycle, batch processing.', color: '#22d3ee', badge: 'BMAD v6', badgeBg: 'rgba(6,182,212,0.2)', borderColor: 'rgba(6,182,212,0.3)' },
-  { name: 'ralph-conductor', desc: 'v2.0: Adaptive profiles, hooks integration, health monitoring, and DoD templates.', color: '#fb923c', badge: 'v8.8.1', badgeBg: 'rgba(249,115,22,0.2)', borderColor: 'rgba(249,115,22,0.3)' },
+  { name: 'ralph-conductor', desc: 'v2.0: Adaptive profiles, hooks integration, health monitoring, and DoD templates.', color: '#fb923c', badge: 'v8.8.2', badgeBg: 'rgba(249,115,22,0.2)', borderColor: 'rgba(249,115,22,0.3)' },
   { name: 'uiux-orchestrator', desc: 'Coordinates UI, UX, and Accessibility experts for holistic design solutions.', color: '#f472b6', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },
   { name: 'product-owner', desc: 'Helps with user stories, backlog prioritization, and sprint planning.', color: '#fbbf24', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },
   { name: 'accessibility-expert', desc: 'Ensures WCAG 2.2 AAA compliance and ARIA best practices.', color: '#2dd4bf', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },


### PR DESCRIPTION
## Contexte

Traite le backlog résiduel de l'audit **2026-06-01** (`RESTE-A-FAIRE.md`, section 1), dont le cœur est la **dette de traduction i18n** : 101 fichiers étaient sous le seuil de parité de taille 0.80 (pt le plus dégradé, ratios ~0.10 sur les commandes Flutter), ce qui dégradait l'expérience des utilisateurs non anglophones.

## Changements

### i18n — dette résorbée (101 → 0)
- Les **101 fichiers** sous le seuil sont désormais traduits **intégralement** depuis la référence `Dev/i18n/en/<...>` (frontmatter conservé, accents/caractères natifs respectés).
- Répartition : **pt** (48), **de** (23), **es** (21), **fr** (9) — commandes, règles, agents (`Dev/i18n` + `Project/i18n`) et guides utilisateur (`docs/guides`).
- Vérifié via `scripts/verify-i18n-parity.sh` : **0 fichier sous 0.80**.

### CI — parité de taille désormais bloquante
- La dette historique étant résorbée, les défauts du script passent en mode strict (`STRICT_SIZE=1`, `I18N_PARITY_STRICT=1`).
- Le job `parity` bloque maintenant sur le **count** ET la **taille** (< 0.80) ; toute régression future échoue la CI.
- Doc mise à jour : `.claude/rules/16-i18n.md`.

### Release 8.8.2 (PATCH)
- Contenu uniquement (aucun nouveau fichier/feature) → compteurs commandes/agents **inchangés**.
- Bump version : `package.json`, `package-lock.json`, `.claude/{CLAUDE,COMPATIBILITY,context-essentials}.md`, `.claude-plugin/plugin.json`, `CHANGELOG.md`, guides + website.

## Tests
- `npm test` : **958 tests** ✓
- `make test-bats` ✓ (skips `jq` locaux, exécutés en CI)
- `npm run lint:i18n` (mode strict) : **All languages at parity** ✓

## Hors périmètre (audit §2, action humaine)
PR awesome-claude-code, Discord, pricing, showcases, bus factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)