### PR TITLE
feat(ecosystem): catalogue d'outils token/contexte tiers + release 8.9.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.8.2",
+  "version": "8.9.0",
   "description": "Multi-stack framework for Claude Code teams: 19 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.8.2 | **Languages:** en, fr, es, de, pt
+**Version:** 8.9.0 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 
@@ -112,7 +112,7 @@ docker compose exec app ./vendor/bin/phpunit
 
 ## Skills
 
-`/solid-principles`, `/testing`, `/security`, `/git-workflow`, `/documentation`, `/kiss-dry-yagni`, `/workflow-analysis`, `/parallel-worktrees`, `/atomic-tasks`, `/design-md-convention`, `/architect`, `/debug-methodical`, `/socratic-brainstorm` — loaded on demand from `.claude/skills/`
+`/solid-principles`, `/testing`, `/security`, `/git-workflow`, `/documentation`, `/kiss-dry-yagni`, `/workflow-analysis`, `/parallel-worktrees`, `/atomic-tasks`, `/design-md-convention`, `/architect`, `/debug-methodical`, `/socratic-brainstorm`, `/ecosystem-tools` — loaded on demand from `.claude/skills/`
 
 ## AI-First Development (Karpathy)
 
@@ -135,6 +135,7 @@ Projects with UI should include a root `DESIGN.md` file (template: `.claude/temp
 | [Agents](../docs/AGENTS.md) | All agents |
 | [FAQ](../docs/FAQ.md) | Common questions |
 | [Troubleshooting](../docs/TROUBLESHOOTING.md) | Problem solving |
+| [Ecosystem](../docs/ECOSYSTEM.md) | Third-party token/context/review tools |
 
 ---
 

--- a/.claude/COMPATIBILITY.md
+++ b/.claude/COMPATIBILITY.md
@@ -1,4 +1,4 @@
-# Claude Code Compatibility — Claude Craft v8.8.2
+# Claude Code Compatibility — Claude Craft v8.9.0
 
 **Minimum Version:** 2.1.97 (elevated from 2.1.47 — see [rationale](#why-we-elevated-minimum-from-2147-to-2197))
 **Recommended Version:** 2.1.159 (Opus 4.8 + Dynamic Workflows, May 31, 2026)
@@ -352,7 +352,7 @@ Features available in Claude Code 2.1.119–2.1.145 and their adoption status in
 
 ---
 
-### Adoption Roadmap for v8.8.2
+### Adoption Roadmap for v8.9.0
 
 | Priorité | Feature | Fichier à modifier | Effort |
 |----------|---------|-------------------|--------|

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.8.2
+- **Version:** 8.9.0
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/.claude/rules/12-context-management.md
+++ b/.claude/rules/12-context-management.md
@@ -354,6 +354,23 @@ Templates disponibles dans `.claude/templates/hooks/`: `output-filter.json`, `pr
 
 ---
 
+## Outils tiers de l'écosystème (tokens & contexte)
+
+En complément de RTK et des hooks natifs, l'écosystème Claude Code fournit des outils couvrant des angles non traités nativement. Aucun n'est embarqué dans Claude Craft : ils sont documentés et recommandés.
+
+| Outil | Licence | Angle | Reco |
+|-------|---------|-------|------|
+| **caveman** | MIT | Compression des réponses (output) ~65 % | ✅ Intégrer |
+| **code-review-graph** | MIT | Graphe AST, lecture du blast radius (−38× à −528×) | ✅ Intégrer |
+| **token-savior** | MIT | Index symbolique + compaction Bash (−80 %) | ✅ Intégrer |
+| **claude-token-efficient** | MIT | Règles CLAUDE.md anti-verbosité (~63 % output) | ✅ Intégrer |
+| **context-mode** | ELv2 | Sandbox des outputs, continuité post-compaction | 🔶 Référencer (licence) |
+| **claude-context** | MIT | Recherche sémantique (vector DB requise) | 🔶 Référencer (infra) |
+
+> Catalogue complet, licences et recettes d'activation : `@docs/ECOSYSTEM.md`. Auditer et pinner tout outil tiers avant installation (règle 11).
+
+---
+
 ## Ressources
 
 - **Anthropic Best Practices:** [code.claude.com](https://code.claude.com/docs/en/overview)

--- a/.claude/skills/ecosystem-tools/SKILL.md
+++ b/.claude/skills/ecosystem-tools/SKILL.md
@@ -1,0 +1,29 @@
+---
+name: ecosystem-tools
+description: Third-party Claude Code token/context/code-review tools. Use when choosing or recommending an external tool to reduce token usage, manage context, or review large codebases (caveman, code-review-graph, token-savior, context-mode...).
+triggers:
+  keywords: ["token optimization", "reduce tokens", "context management", "code review tool", "caveman", "code-review-graph", "token-savior", "context-mode", "claude-context", "MCP server", "RTK alternative"]
+auto_suggest: true
+---
+
+# Ecosystem Tools
+
+Curated third-party Claude Code tools that complement Claude Craft's native token/context stack (RTK,
+`context: fork` skills, compaction hooks). None are bundled — they are documented with activation
+recipes and license caveats.
+
+See `@docs/ECOSYSTEM.md` for the full catalogue, licenses, and `.mcp.json` snippets.
+
+## Quick reference
+
+| Tool | License | Use it for | Rec |
+|------|---------|-----------|-----|
+| **caveman** | MIT | Compress agent **output** ~65% | ✅ Integrate |
+| **code-review-graph** | MIT | AST graph → read only the blast radius on review | ✅ Integrate |
+| **token-savior** | MIT | Symbol index + Bash output compaction (−80%), RTK alternative | ✅ Integrate |
+| **claude-token-efficient** | MIT | Anti-verbosity CLAUDE.md drop-in | ✅ Integrate |
+| **context-mode** | ELv2 | Output sandboxing — license blocks commercial redistribution | 🔶 Reference |
+| **claude-context** | MIT | Semantic search; needs a Milvus/Zilliz vector DB | 🔶 Reference |
+
+> Audit the source and pin a version before enabling any third-party MCP server or skill — see
+> `@.claude/rules/11-security.md` and `@docs/MCP.md#security`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.9.0] - 2026-06-02
+
+Intégration curatoriale de l'écosystème d'outils tiers Claude Code (optimisation de tokens, gestion de contexte, code review). MINOR release. Backwards compatible. Aucun code tiers n'est embarqué : les outils sont documentés, recommandés et accompagnés de leurs recettes d'activation et de leurs contraintes de licence.
+
+### Added
+
+- **Catalogue `docs/ECOSYSTEM.md`** : évaluation de 9 dépôts + 1 roundup (camilleroux.com 2026) avec recommandation INTÉGRER / RÉFÉRENCER / IGNORER, licences, type (skill/MCP/CLI/CLAUDE.md) et recettes d'activation. Retenus (MIT) : **caveman** (compression output ~65 %), **code-review-graph** (graphe AST, lecture du blast radius), **token-savior** (index symbolique + compaction Bash, alternative RTK), **claude-token-efficient** (CLAUDE.md anti-verbosité). Référencés avec disclaimer de licence : **context-mode** (ELv2), **token-optimizer**/alexgreensh (PolyForm Noncommercial), **claude-context**/zilliztech (MIT mais dépendance Milvus/Zilliz). Écartés : **claude-token-optimizer**/nadimtuhin, **token-optimizer-mcp**/ooples.
+- **`docs/MCP.md` — section « Token-Optimization MCP Servers »** : configuration `.mcp.json` prête à l'emploi pour `code-review-graph` et `token-savior`, avec rappel d'audit/pinning (lien vers la section Security).
+- **Skill `ecosystem-tools`** : skill commun (`.claude/skills/` + distribution `Dev/i18n/base/Common/skills/`) pointant vers le catalogue, déclenché lors du choix d'un outil tiers token/contexte/review.
+- **Règle 12 (`context-management`) — section « Outils tiers de l'écosystème »** : mini-tableau + pointeur vers `docs/ECOSYSTEM.md`, distribué dans les 5 langues (`.claude/rules/` + `Dev/i18n/{en,fr,es,de,pt}`).
+- **Liens de découverte** : `README.md`, `.claude/CLAUDE.md` (table Documentation) et `docs/RTK-ANALYSIS.md` (« Voir aussi ») pointent désormais vers le catalogue.
+
 ## [8.8.2] - 2026-06-02
 
 Résorption complète de la dette de traduction i18n résiduelle de l'audit 2026-06-01. PATCH release. Backwards compatible.

--- a/Dev/i18n/base/Common/skills/ecosystem-tools/SKILL.md
+++ b/Dev/i18n/base/Common/skills/ecosystem-tools/SKILL.md
@@ -1,0 +1,44 @@
+---
+name: ecosystem-tools
+description: Third-party Claude Code token/context/code-review tools. Use when choosing or recommending an external tool to reduce token usage, manage context, or review large codebases.
+allowed-tools:
+  - Read
+  - Glob
+  - Grep
+  - WebFetch
+model: haiku
+triggers:
+  keywords:
+    - token optimization
+    - reduce tokens
+    - context management
+    - code review tool
+    - caveman
+    - code-review-graph
+    - token-savior
+    - context-mode
+    - claude-context
+    - RTK alternative
+---
+
+# Ecosystem Tools
+
+Curated third-party Claude Code tools that complement Claude Craft's native token/context stack (RTK,
+`context: fork` skills, compaction hooks). None are bundled — they are documented with activation
+recipes and license caveats.
+
+See `../../../../docs/ECOSYSTEM.md` for the full catalogue, licenses, and `.mcp.json` snippets.
+
+## Quick reference
+
+| Tool | License | Use it for | Rec |
+|------|---------|-----------|-----|
+| **caveman** | MIT | Compress agent **output** ~65% | ✅ Integrate |
+| **code-review-graph** | MIT | AST graph → read only the blast radius on review | ✅ Integrate |
+| **token-savior** | MIT | Symbol index + Bash output compaction (−80%), RTK alternative | ✅ Integrate |
+| **claude-token-efficient** | MIT | Anti-verbosity CLAUDE.md drop-in | ✅ Integrate |
+| **context-mode** | ELv2 | Output sandboxing — license blocks commercial redistribution | 🔶 Reference |
+| **claude-context** | MIT | Semantic search; needs a Milvus/Zilliz vector DB | 🔶 Reference |
+
+> Audit the source and pin a version before enabling any third-party MCP server or skill — see
+> the security rule (11) and `docs/MCP.md#security`.

--- a/Dev/i18n/de/Common/rules/12-context-management.md
+++ b/Dev/i18n/de/Common/rules/12-context-management.md
@@ -734,6 +734,23 @@ Dateien werden in alphabetischer Reihenfolge zusammengefuehrt, sodass Teams Konf
 
 ---
 
+## Drittanbieter-Tools des Ökosystems (Tokens & Kontext)
+
+Ergänzend zu RTK und nativen Hooks bietet das Claude-Code-Ökosystem Tools, die nativ nicht abgedeckte Aspekte adressieren. Keines ist in Claude Craft eingebettet – sie werden dokumentiert und empfohlen.
+
+| Tool | Lizenz | Aspekt | Empf. |
+|------|--------|--------|-------|
+| **caveman** | MIT | Komprimierung der Antworten (Output) ~65 % | ✅ Integrieren |
+| **code-review-graph** | MIT | AST-Graph, Blast-Radius-Lesen (−38× bis −528×) | ✅ Integrieren |
+| **token-savior** | MIT | Symbolindex + Bash-Komprimierung (−80 %) | ✅ Integrieren |
+| **claude-token-efficient** | MIT | CLAUDE.md-Regeln gegen Geschwätzigkeit (~63 % Output) | ✅ Integrieren |
+| **context-mode** | ELv2 | Output-Sandbox, Kontinuität nach Kompaktierung | 🔶 Referenzieren (Lizenz) |
+| **claude-context** | MIT | Semantische Suche (Vektor-DB erforderlich) | 🔶 Referenzieren (Infra) |
+
+> Vollständiger Katalog, Lizenzen und Aktivierungsrezepte: `@docs/ECOSYSTEM.md`. Jedes Drittanbieter-Tool vor der Installation prüfen und auf eine Version pinnen (Regel 11).
+
+---
+
 ## Ressourcen
 
 - **Anthropic Best Practices:** [code.claude.com](https://code.claude.com/docs/en/overview)

--- a/Dev/i18n/en/Common/rules/12-context-management.md
+++ b/Dev/i18n/en/Common/rules/12-context-management.md
@@ -734,6 +734,23 @@ Files are merged in alphabetical order, allowing teams to layer configurations w
 
 ---
 
+## Third-Party Ecosystem Tools (tokens & context)
+
+Beyond RTK and native hooks, the Claude Code ecosystem offers tools that cover angles not handled natively. None are bundled into Claude Craft — they are documented and recommended.
+
+| Tool | License | Angle | Rec |
+|------|---------|-------|-----|
+| **caveman** | MIT | Output (response) compression ~65% | ✅ Integrate |
+| **code-review-graph** | MIT | AST graph, blast-radius reads (−38× to −528×) | ✅ Integrate |
+| **token-savior** | MIT | Symbol index + Bash compaction (−80%) | ✅ Integrate |
+| **claude-token-efficient** | MIT | Anti-verbosity CLAUDE.md rules (~63% output) | ✅ Integrate |
+| **context-mode** | ELv2 | Output sandbox, post-compaction continuity | 🔶 Reference (license) |
+| **claude-context** | MIT | Semantic search (vector DB required) | 🔶 Reference (infra) |
+
+> Full catalogue, licenses and activation recipes: `@docs/ECOSYSTEM.md`. Audit and pin any third-party tool before installing (rule 11).
+
+---
+
 ## Resources
 
 - **Anthropic Best Practices:** [code.claude.com](https://code.claude.com/docs/en/overview)

--- a/Dev/i18n/es/Common/rules/12-context-management.md
+++ b/Dev/i18n/es/Common/rules/12-context-management.md
@@ -734,6 +734,23 @@ Los archivos se fusionan en orden alfabetico, permitiendo a los equipos superpon
 
 ---
 
+## Herramientas de terceros del ecosistema (tokens y contexto)
+
+Además de RTK y los hooks nativos, el ecosistema de Claude Code ofrece herramientas que cubren ángulos no tratados de forma nativa. Ninguna se incluye en Claude Craft: se documentan y se recomiendan.
+
+| Herramienta | Licencia | Ángulo | Rec |
+|-------------|----------|--------|-----|
+| **caveman** | MIT | Compresión de respuestas (output) ~65 % | ✅ Integrar |
+| **code-review-graph** | MIT | Grafo AST, lectura del blast radius (−38× a −528×) | ✅ Integrar |
+| **token-savior** | MIT | Índice simbólico + compactación de Bash (−80 %) | ✅ Integrar |
+| **claude-token-efficient** | MIT | Reglas CLAUDE.md anti-verbosidad (~63 % output) | ✅ Integrar |
+| **context-mode** | ELv2 | Sandbox de outputs, continuidad tras compactación | 🔶 Referenciar (licencia) |
+| **claude-context** | MIT | Búsqueda semántica (requiere base vectorial) | 🔶 Referenciar (infra) |
+
+> Catálogo completo, licencias y recetas de activación: `@docs/ECOSYSTEM.md`. Auditar y fijar la versión de cualquier herramienta de terceros antes de instalarla (regla 11).
+
+---
+
 ## Recursos
 
 - **Anthropic Best Practices:** [code.claude.com](https://code.claude.com/docs/en/overview)

--- a/Dev/i18n/fr/Common/rules/12-context-management.md
+++ b/Dev/i18n/fr/Common/rules/12-context-management.md
@@ -734,6 +734,23 @@ Les fichiers sont fusionnes par ordre alphabetique, permettant aux equipes de su
 
 ---
 
+## Outils tiers de l'écosystème (tokens & contexte)
+
+En complément de RTK et des hooks natifs, l'écosystème Claude Code fournit des outils couvrant des angles non traités nativement. Aucun n'est embarqué dans Claude Craft : ils sont documentés et recommandés.
+
+| Outil | Licence | Angle | Reco |
+|-------|---------|-------|------|
+| **caveman** | MIT | Compression des réponses (output) ~65 % | ✅ Intégrer |
+| **code-review-graph** | MIT | Graphe AST, lecture du blast radius (−38× à −528×) | ✅ Intégrer |
+| **token-savior** | MIT | Index symbolique + compaction Bash (−80 %) | ✅ Intégrer |
+| **claude-token-efficient** | MIT | Règles CLAUDE.md anti-verbosité (~63 % output) | ✅ Intégrer |
+| **context-mode** | ELv2 | Sandbox des outputs, continuité post-compaction | 🔶 Référencer (licence) |
+| **claude-context** | MIT | Recherche sémantique (vector DB requise) | 🔶 Référencer (infra) |
+
+> Catalogue complet, licences et recettes d'activation : `@docs/ECOSYSTEM.md`. Auditer et pinner tout outil tiers avant installation (règle 11).
+
+---
+
 ## Ressources
 
 - **Anthropic Best Practices:** [code.claude.com](https://code.claude.com/docs/en/overview)

--- a/Dev/i18n/pt/Common/rules/12-context-management.md
+++ b/Dev/i18n/pt/Common/rules/12-context-management.md
@@ -734,6 +734,23 @@ Os arquivos sao fundidos em ordem alfabetica, permitindo que as equipes sobrepon
 
 ---
 
+## Ferramentas de terceiros do ecossistema (tokens e contexto)
+
+Além do RTK e dos hooks nativos, o ecossistema do Claude Code oferece ferramentas que cobrem ângulos não tratados nativamente. Nenhuma é incorporada ao Claude Craft: são documentadas e recomendadas.
+
+| Ferramenta | Licença | Ângulo | Rec |
+|------------|---------|--------|-----|
+| **caveman** | MIT | Compressão das respostas (output) ~65 % | ✅ Integrar |
+| **code-review-graph** | MIT | Grafo AST, leitura do blast radius (−38× a −528×) | ✅ Integrar |
+| **token-savior** | MIT | Índice simbólico + compactação do Bash (−80 %) | ✅ Integrar |
+| **claude-token-efficient** | MIT | Regras CLAUDE.md anti-verbosidade (~63 % output) | ✅ Integrar |
+| **context-mode** | ELv2 | Sandbox dos outputs, continuidade pós-compactação | 🔶 Referenciar (licença) |
+| **claude-context** | MIT | Busca semântica (requer banco vetorial) | 🔶 Referenciar (infra) |
+
+> Catálogo completo, licenças e receitas de ativação: `@docs/ECOSYSTEM.md`. Auditar e fixar a versão de qualquer ferramenta de terceiros antes de instalar (regra 11).
+
+---
+
 ## Recursos
 
 - **Anthropic Best Practices:** [code.claude.com](https://code.claude.com/docs/en/overview)

--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ Context usage is optimized: ~3,500 tokens always loaded vs ~70,000 if everything
 | [BMAD Guide](docs/BMAD-PRACTICAL-GUIDE.md) | Project management framework |
 | [Hooks](docs/HOOKS.md) | Pre/Post tool execution |
 | [MCP](docs/MCP.md) | Model Context Protocol integration |
+| [Ecosystem](docs/ECOSYSTEM.md) | Curated third-party token/context/review tools |
 | [Privacy Policy](PRIVACY.md) | Data protection and GDPR compliance |
 | [FAQ](docs/FAQ.md) | Common questions |
 | [Troubleshooting](docs/TROUBLESHOOTING.md) | Problem solving |

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -1,0 +1,149 @@
+# Ecosystem — Third-Party Token & Context Tools
+
+Claude Craft ships its own token-optimization stack (RTK, `context: fork` skills, sub-agent model
+routing, compaction hooks — see [`docs/RTK-ANALYSIS.md`](RTK-ANALYSIS.md) and
+[`.claude/rules/12-context-management.md`](../.claude/rules/12-context-management.md)). This page
+curates **complementary third-party tools** from the Claude Code ecosystem that extend — not
+replace — that stack.
+
+> **Curation, not bundling.** None of these tools are vendored into Claude Craft. Licenses are
+> heterogeneous and embedding third-party code would violate YAGNI and, in several cases, the tools'
+> own license terms. We document what each does, how it complements Claude Craft, and how to enable
+> it yourself. This mirrors how Claude Craft already treats RTK: documented, recommended, not embedded.
+
+**Evaluation date:** 2026-06-02 · **Sources:** the 9 repositories below + the
+[Top Skills/Plugins Claude Code 2026 (camilleroux.com)](https://www.camilleroux.com/top-skills-plugins-claude-code-2026-v3/)
+roundup.
+
+---
+
+## Summary table
+
+| Tool | ★ | License | Type | Recommendation | Note |
+|------|----|---------|------|----------------|------|
+| [caveman](https://github.com/juliusbrussee/caveman) | ~67.8k | MIT | Skill (+ optional MCP) | ✅ **Integrate** | Compresses agent **output** ~65% (telegraphic style, 4 levels). Covers the output side RTK doesn't. |
+| [code-review-graph](https://github.com/tirth8205/code-review-graph) | ~17.9k | MIT | MCP + CLI | ✅ **Integrate** | Tree-sitter/AST code graph → reads only the blast radius on review. 38×–528× token reduction on large repos. |
+| [token-savior](https://github.com/mibayy/token-savior) | ~0.9k | MIT | MCP + hooks | ✅ **Integrate** | Symbol-index + Bash output compaction (−80%). RTK alternative without a Rust binary. |
+| [claude-token-efficient](https://github.com/drona23/claude-token-efficient) | ~5.5k | MIT | CLAUDE.md drop-in | ✅ **Integrate** | Prompt rules cutting Claude verbosity ~63% output / 17–41% cost. Zero code. |
+| [context-mode](https://github.com/mksglu/context-mode) | ~16.3k | **ELv2** | MCP + hooks | 🔶 **Reference** | Sandboxes tool outputs (315 KB → 5.4 KB), SQLite session continuity. License blocks commercial redistribution. |
+| [token-optimizer](https://github.com/alexgreensh/token-optimizer) (alexgreensh) | ~1.2k | **PolyForm NC** | Plugin | 🔶 **Reference** | Real-time dashboard + quality scoring. Noncommercial license. |
+| [claude-context](https://github.com/zilliztech/claude-context) (zilliztech) | ~11.7k | MIT | MCP + VSCode ext | 🔶 **Reference** | Hybrid semantic search (BM25 + vectors) over the whole codebase. Requires a Milvus/Zilliz vector DB. |
+| [claude-token-optimizer](https://github.com/nadimtuhin/claude-token-optimizer) (nadimtuhin) | ~0.5k | MIT | CLI | ⚪ **Skip** | Essential/supplemental doc split — already native to Claude Craft (`.claude/rules/`, on-demand skills). |
+| [token-optimizer-mcp](https://github.com/ooples/token-optimizer-mcp) (ooples) | ~0.4k | MIT | MCP | ⚪ **Skip** | 95%+ claims unverified; inactive since Nov 2025. |
+
+Legend: ✅ Integrate (documented + activation recipe) · 🔶 Reference (documented, license/infra caveat) ·
+⚪ Skip (superseded or unverified).
+
+---
+
+## ✅ Recommended — Integrate
+
+These four are MIT-licensed, mature or trivially safe, and cover gaps in Claude Craft's stack.
+
+### caveman — output compression
+
+Compresses the agent's **responses** by ~65% using a fragmented/telegraphic dialect, with four levels
+(`lite`/`full`/`ultra`/`wenyan`) and ships `/caveman-commit`, `/caveman-review`, plus a memory-file
+compressor. Where RTK targets **input/tool** tokens, caveman targets **output** tokens — the two are
+orthogonal and stack cleanly.
+
+```bash
+# Install as a Claude Code skill (see the repo README for the current path)
+git clone https://github.com/juliusbrussee/caveman
+```
+
+Pairs with the verbosity rules already in [`.claude/rules/12-context-management.md`](../.claude/rules/12-context-management.md).
+
+### code-review-graph — blast-radius-aware review
+
+Builds a structural graph of the codebase (Tree-sitter + AST in SQLite) so the model reads only the
+code impacted by a change. Reported reductions of 38×–528× on large repos. Complements Claude Craft's
+review surface (`/qa:*`, `@security-auditor`, the `@{tech}-reviewer` agents).
+
+```jsonc
+// .mcp.json
+{
+  "mcpServers": {
+    "code-review-graph": {
+      "command": "npx",
+      "args": ["-y", "code-review-graph"]
+    }
+  }
+}
+```
+
+### token-savior — symbol index + Bash compaction
+
+Indexes the codebase by symbols (functions, classes, imports, call graph) and compacts Bash output up
+to −80% via `PreToolUse`/`PostToolUse` hooks. A good **RTK alternative** for teams that prefer an MCP
+server over installing a Rust binary. See [`docs/RTK-ANALYSIS.md`](RTK-ANALYSIS.md) for the RTK comparison.
+
+```jsonc
+// .mcp.json
+{
+  "mcpServers": {
+    "token-savior": {
+      "command": "npx",
+      "args": ["-y", "token-savior"]
+    }
+  }
+}
+```
+
+### claude-token-efficient — CLAUDE.md drop-in
+
+A single `CLAUDE.md` of prompt rules that reduce Claude's verbosity (~63% output / 17–41% cost). Most
+of its guidance overlaps Claude Craft's existing rules (12-context-management, 23-karpathy-principles);
+worth auditing to harvest any prompt rule not already covered.
+
+---
+
+## 🔶 Reference only — license or infrastructure caveat
+
+> **License compliance.** The tools below are **not** embedded in Claude Craft and **must not** be.
+> ELv2 and PolyForm Noncommercial restrict commercial redistribution; we link to them so you can adopt
+> them under your own terms.
+
+- **context-mode** ([repo](https://github.com/mksglu/context-mode)) — **Elastic License v2 (ELv2)**.
+  Excellent technically (output sandboxing, post-compaction continuity via native hooks) and closely
+  aligned with rule 12, but ELv2 forbids offering it as a managed service / redistributing commercially.
+  Evaluate for internal use under the ELv2 terms.
+- **token-optimizer** (alexgreensh) ([repo](https://github.com/alexgreensh/token-optimizer)) —
+  **PolyForm Noncommercial 1.0.0**. Real-time dashboard, checkpoint-based session continuity, quality
+  scoring. Free for teams under the noncommercial threshold; commercial use is paid.
+- **claude-context** (zilliztech) ([repo](https://github.com/zilliztech/claude-context)) — MIT, but
+  requires an external **Milvus / Zilliz Cloud** vector database. High setup friction; reserve it for
+  very large / enterprise codebases where hybrid semantic search pays for the infra.
+
+---
+
+## ⚪ Not recommended
+
+- **claude-token-optimizer** (nadimtuhin) — splits docs into essential vs. supplemental. Already native
+  to Claude Craft via modular `.claude/rules/` and on-demand skills; little marginal value.
+- **token-optimizer-mcp** (ooples) — aggressive "95%+ reduction" claims without recent validation;
+  no release since November 2025.
+
+---
+
+## Also worth watching (from the 2026 roundup)
+
+Not evaluated in depth here, but flagged for future integration assessment:
+**claude-health** (config health audit — could feed `/team:audit`), **claude-hud** (real-time
+context/agent/todo monitor — complements `rtk gain`), **claude-subconscious** (cross-session memory),
+**tech-debt-skill** (tech-debt audit — candidate for `/qa:*`).
+
+---
+
+## Security before you install
+
+Every third-party MCP server or skill runs with your permissions. Before enabling any tool on this page,
+apply [`.claude/rules/11-security.md`](../.claude/rules/11-security.md):
+
+- **Audit the source** and pin an exact version (no floating `latest`).
+- **Minimal permissions** — grant only the tools/paths the server needs.
+- Prefer Claude Code **v2.1.97+** when combining MCP servers with hooks.
+- See [`docs/MCP.md#security`](MCP.md#security) for the full MCP hardening checklist.
+
+> **Non-affiliation.** Claude Craft is not affiliated with any of the projects listed here. Stars,
+> licenses, and activity reflect the 2026-06-02 evaluation and may have changed since.

--- a/docs/MCP.md
+++ b/docs/MCP.md
@@ -8,6 +8,7 @@ MCP is an open standard that enables AI models to connect to external tools and 
 - [Configuration](#configuration)
 - [OAuth Client Credentials](#oauth-client-credentials)
 - [Popular MCP Servers](#popular-mcp-servers)
+- [Token-Optimization MCP Servers](#token-optimization-mcp-servers)
 - [Context7 - Documentation Server](#context7---documentation-server)
 - [Custom MCP Servers](#custom-mcp-servers)
 - [Tool Search — Lazy Loading](#tool-search--lazy-loading-v2180)
@@ -208,6 +209,49 @@ Browser automation and web scraping.
   }
 }
 ```
+
+---
+
+## Token-Optimization MCP Servers
+
+These community MCP servers reduce token usage on large codebases and reviews. They complement Claude
+Craft's native stack (RTK, `context: fork` skills) rather than replacing it. Full evaluation, licenses,
+and the rest of the ecosystem: [`docs/ECOSYSTEM.md`](ECOSYSTEM.md).
+
+### code-review-graph
+
+Tree-sitter/AST code graph (in SQLite) that lets the model read only the blast radius of a change —
+reported 38×–528× token reductions on large repos. Pairs with `/qa:*`, `@security-auditor` and the
+`@{tech}-reviewer` agents.
+
+```json
+{
+  "mcpServers": {
+    "code-review-graph": {
+      "command": "npx",
+      "args": ["-y", "code-review-graph"]
+    }
+  }
+}
+```
+
+### token-savior
+
+Symbol indexing (functions, classes, imports, call graph) plus Bash output compaction up to −80% via
+hooks. A good RTK alternative when you prefer an MCP server to a Rust binary (MIT-licensed).
+
+```json
+{
+  "mcpServers": {
+    "token-savior": {
+      "command": "npx",
+      "args": ["-y", "token-savior"]
+    }
+  }
+}
+```
+
+> Audit and pin any third-party MCP server before enabling it — see [Security](#security).
 
 ---
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -58,7 +58,7 @@ Replace `react` with your technology: `symfony`, `flutter`, `python`, `angular`,
 **What you should see:**
 
 ```
-  Claude Craft v8.8.2 - AI Development Framework
+  Claude Craft v8.9.0 - AI Development Framework
 
   Installing react rules to /home/user/my-project...
   [OK] Common rules installed

--- a/docs/RTK-ANALYSIS.md
+++ b/docs/RTK-ANALYSIS.md
@@ -9,6 +9,9 @@
 
 ---
 
+> **Voir aussi :** d'autres outils d'optimisation de tokens/contexte (caveman, code-review-graph,
+> token-savior…) sont catalogués dans [`docs/ECOSYSTEM.md`](ECOSYSTEM.md).
+
 ## 1. Qu'est-ce que RTK ?
 
 RTK est un **proxy CLI** ecrit en Rust qui reduit la consommation de tokens LLM de **60-90%** sur les commandes developpeur courantes. Il s'intercale entre l'assistant IA (Claude Code, Cursor, Aider, Gemini CLI...) et le terminal, filtrant/compressant les sorties avant qu'elles n'atteignent la fenetre de contexte du LLM.

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -17,7 +17,7 @@ Dieser Leitfaden führt Sie durch den vollständigen Entwicklungslebenszyklus:
 7. **Deployment** – In die Produktion deployen
 
 **Voraussetzungen:**
-- Claude Craft v8.8.2 in Ihrem Projekt installiert
+- Claude Craft v8.9.0 in Ihrem Projekt installiert
 - Claude Code v2.1.159 (empfohlen) oder v2.1.97+ (Minimum, CVE-2025-59536 gepatcht)
 - Grundlegendes Verständnis Ihres gewählten Technologie-Stacks
 

--- a/docs/guides/en/10-complete-workflow.md
+++ b/docs/guides/en/10-complete-workflow.md
@@ -17,7 +17,7 @@ This guide walks you through the complete development lifecycle:
 7. **Deployment** - Ship to production
 
 **Prerequisites:**
-- Claude Craft v8.8.2 installed in your project
+- Claude Craft v8.9.0 installed in your project
 - Claude Code v2.1.159 (recommended) or v2.1.97+ (minimum, CVE-2025-59536 patched)
 - Basic understanding of your chosen technology stack
 

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -17,7 +17,7 @@ Esta guía te lleva a través del ciclo de vida de desarrollo completo:
 7. **Despliegue** - Lanza a producción
 
 **Prerequisitos:**
-- Claude Craft v8.8.2 instalado en tu proyecto
+- Claude Craft v8.9.0 instalado en tu proyecto
 - Claude Code v2.1.159 (recomendado) o v2.1.97+ (mínimo, CVE-2025-59536 parcheado)
 - Comprensión básica de tu stack tecnológico elegido
 

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -17,7 +17,7 @@ Este guia acompanha você ao longo de todo o ciclo de desenvolvimento:
 7. **Deploy** - Entregar em produção
 
 **Pré-requisitos:**
-- Claude Craft v8.8.2 instalado no seu projeto
+- Claude Craft v8.9.0 instalado no seu projeto
 - Claude Code v2.1.159 (recomendado) ou v2.1.97+ (mínimo, CVE-2025-59536 corrigido)
 - Conhecimento básico da stack de tecnologia escolhida
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.8.2",
+  "version": "8.9.0",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
## Contexte

Analyse de 9 dépôts GitHub + 1 roundup (camilleroux.com 2026) d'outils Claude Code d'optimisation de tokens / context management / code review, évaluation de leur pertinence pour claude-craft, et intégration **curatoriale** des plus pertinents (documentation + recettes d'activation, aucun code tiers embarqué — licences hétérogènes + YAGNI). Aligné avec la façon dont RTK est déjà traité.

## Verdict d'évaluation

| Outil | Licence | Reco |
|---|---|---|
| caveman (67.8k★) | MIT | ✅ Intégrer (compression output ~65 %) |
| code-review-graph (17.9k★) | MIT | ✅ Intégrer (graphe AST, blast radius) |
| token-savior (929★) | MIT | ✅ Intégrer (index symbolique, alternative RTK) |
| claude-token-efficient (5.5k★) | MIT | ✅ Intégrer (CLAUDE.md anti-verbosité) |
| context-mode (16.3k★) | ELv2 | 🔶 Référencer (licence) |
| token-optimizer/alexgreensh (1.2k★) | PolyForm NC | 🔶 Référencer (licence) |
| claude-context/zilliztech (11.7k★) | MIT | 🔶 Référencer (dépend. Milvus/Zilliz) |
| claude-token-optimizer/nadimtuhin (450★) | MIT | ⚪ Ignorer (déjà couvert) |
| token-optimizer-mcp/ooples (404★) | MIT | ⚪ Ignorer (inactif) |

## Changements

- **`docs/ECOSYSTEM.md`** — catalogue noté, licences, types, recettes d'activation, encart sécurité (règle 11), non-affiliation.
- **`docs/MCP.md`** — section « Token-Optimization MCP Servers » (`.mcp.json` pour code-review-graph & token-savior).
- **Skill `ecosystem-tools`** — `.claude/skills/` + distribution `Dev/i18n/base/Common/skills/`.
- **Règle 12 (context-management)** — section écosystème distribuée dans les **5 langues** + `.claude/rules`.
- **Liens** — README, `.claude/CLAUDE.md`, `docs/RTK-ANALYSIS.md`.
- **Release 8.9.0** (MINOR) — bump dans package.json, plugin.json, CLAUDE.md, COMPATIBILITY, context-essentials, guides (5 langues), website + entrée CHANGELOG.

## Validation locale

- ✅ `vitest run` : **958 tests** (64/64 fichiers)
- ✅ `eslint cli/` propre
- ✅ `scripts/verify-i18n-parity.sh` : parité count **et** taille (seuil 0.80, strict) verte
- ✅ Cohérence version : seuls résiduels `8.8.2` = références historiques (CHANGELOG, règle 16, workflow i18n)

🤖 Generated with [Claude Code](https://claude.com/claude-code)