### PR TITLE
ci(codeql): ignore scaffolding templates to fix parse-error warnings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,16 @@
+name: "Claude Craft CodeQL config"
+
+# Scaffolding templates contain Handlebars-style placeholders (e.g. `{{ComponentName}}`)
+# and are NOT valid standalone TypeScript/JavaScript. They are consumed by the CLI
+# generator, never executed. Excluding them removes ~180 spurious parse-error warnings
+# while keeping all real first-party code (cli/, scripts/, website/, tests/) under analysis.
+paths-ignore:
+  - '**/templates/**'
+  - '**/*.template.ts'
+  - '**/*.template.tsx'
+  - '**/*.template.js'
+  - '**/*.template.jsx'
+  - '**/*.template.mjs'
+  - '**/*.template.cjs'
+  - '**/*.template.vue'
+  - '**/*.template.svelte'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,6 +171,7 @@ jobs:
         uses: github/codeql-action/init@411bbbe57033eedfc1a82d68c01345aa96c737d7 # pinned: v4
         with:
           languages: javascript
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@411bbbe57033eedfc1a82d68c01345aa96c737d7 # pinned: v4


### PR DESCRIPTION
## Problème

Le scan CodeQL (`.github/workflows/ci.yml:codeql`) signalait **~183 warnings de parsing** :
> Could not process some files due to syntax errors — *A constructor, method, accessor, or property was expected.*

Cause : CodeQL analysait les **templates de scaffolding** `Dev/i18n/**/templates/*.template.ts` (+ 1 `.template.vue`) qui contiennent des placeholders Handlebars (`{{ComponentName}}`, `{{component-name}}`) — non valides en TypeScript/JavaScript. Ces fichiers sont consommés par le générateur du CLI, jamais exécutés.

## Correctif

- Ajout de `.github/codeql/codeql-config.yml` avec `paths-ignore` ciblant `**/templates/**` et `**/*.template.*`.
- Référencement via `config-file:` dans l'étape *Initialize CodeQL*.

Le vrai code first-party (`cli/`, `scripts/`, `website/`, `tests/`, kanban) reste intégralement analysé — aucune perte de couverture de sécurité.

## Vérification
- Les 16 fichiers `*.template.*` sont les seuls JS/TS de contenu distribué hors `cli/`/`scripts/`/`website/`/`tests/`.
- YAML validé localement.
- Le job CodeQL de cette PR doit passer sans warning de parsing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)