### PR TITLE
fix(branding): migrate domain to the-bearded-bear.com + normalize GitHub org (v8.10.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -4,18 +4,18 @@
   "owner": {
     "name": "The Bearded CTO",
     "email": "flavien.metivier@gmail.com",
-    "url": "https://thebeardedcto.com"
+    "url": "https://the-bearded-bear.com"
   },
   "metadata": {
     "description": "Claude Craft — multi-stack framework for Claude Code teams (11 stacks, BMAD v6, QA Recette, Kanban, RTK token optimization).",
-    "homepage": "https://thebeardedcto.com/claude-craft"
+    "homepage": "https://the-bearded-bear.com/claude-craft"
   },
   "plugins": [
     {
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.10.0",
+      "version": "8.10.1",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,18 +2,18 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.10.0",
+  "version": "8.10.1",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",
     "email": "flavien.metivier@gmail.com",
-    "url": "https://thebeardedcto.com"
+    "url": "https://the-bearded-bear.com"
   },
   "repository": {
     "type": "git",
     "url": "https://github.com/TheBeardedBearSAS/claude-craft"
   },
-  "homepage": "https://thebeardedcto.com/claude-craft",
+  "homepage": "https://the-bearded-bear.com/claude-craft",
   "license": "MIT",
   "keywords": [
     "framework",
@@ -138,7 +138,7 @@
   "installation": {
     "npm": "@the-bearded-bear/claude-craft",
     "command": "npx @the-bearded-bear/claude-craft install",
-    "docs": "https://thebeardedcto.com/claude-craft/getting-started"
+    "docs": "https://the-bearded-bear.com/claude-craft/getting-started"
   },
   "features": {
     "bmad-v6": {

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.10.0 | **Languages:** en, fr, es, de, pt
+**Version:** 8.10.1 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/.claude/COMPATIBILITY.md
+++ b/.claude/COMPATIBILITY.md
@@ -1,4 +1,4 @@
-# Claude Code Compatibility — Claude Craft v8.10.0
+# Claude Code Compatibility — Claude Craft v8.10.1
 
 **Minimum Version:** 2.1.97 (elevated from 2.1.47 — see [rationale](#why-we-elevated-minimum-from-2147-to-2197))
 **Recommended Version:** 2.1.168 (Opus 4.8, `fallbackModel`, `ultracode` trigger, June 6, 2026)
@@ -384,7 +384,7 @@ Features available in Claude Code 2.1.119–2.1.145 and their adoption status in
 
 ---
 
-### Adoption Roadmap for v8.10.0
+### Adoption Roadmap for v8.10.1
 
 | Priorité | Feature | Fichier à modifier | Effort |
 |----------|---------|-------------------|--------|

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.10.0
+- **Version:** 8.10.1
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/.claude/templates/AGENTS.md.template
+++ b/.claude/templates/AGENTS.md.template
@@ -87,4 +87,4 @@ context: fork                # isoler le contexte (skills lourds)
 
 - Documentation complete : [docs/AGENTS.md](docs/AGENTS.md)
 - Standard AGENTS.md : https://agents.md
-- claude-craft : https://github.com/the-bearded-cto/claude-craft
+- claude-craft : https://github.com/TheBeardedBearSAS/claude-craft

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Default owners
-* @thebearded-cto
+* @flavien-metivier

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.10.1] - 2026-06-11
+
+### Fixed
+- Migration des références de domaine email/web vers `the-bearded-bear.com` (unification des variantes `thebeardedcto.com` et `thebearded-cto.com` dans plugin/marketplace, README, PRIVACY, CHARTER, SECURITY, CONTRIBUTING, CODE_OF_CONDUCT et les politiques de conformité).
+- Normalisation des URLs GitHub obsolètes (`the-bearded-cto`, `thebeardedcto`, `TheBeardedCTO`) vers `github.com/TheBeardedBearSAS/claude-craft`.
+- Correction du `CODEOWNERS` cassé (`@thebearded-cto` inexistant) vers le mainteneur `@flavien-metivier`.
+
 ## [8.10.0] - 2026-06-09
 
 Passage à un projet **100 % open-source MIT** (suppression de toute la structure de licence commerciale/enterprise) + lot d'audit de fraîcheur 2026-06-08. MINOR release. Backwards compatible.

--- a/CHARTER.md
+++ b/CHARTER.md
@@ -115,7 +115,7 @@ Les versions publiées de `claude-craft` sous MIT ne peuvent **jamais** être re
 
 ## 11. Contact et Transparence
 
-- **Gouvernance et questions légales :** governance@thebeardedcto.com
+- **Gouvernance et questions légales :** governance@the-bearded-bear.com
 - **Discussions communautaires :** GitHub Discussions, Discord #governance
 - **RFC :** `docs/rfc/` dans le dépôt principal
 

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -6,6 +6,6 @@ Please read the full text at the link above.
 
 ## Reporting
 
-If you experience or witness unacceptable behavior, please contact us at **conduct@thebearded-cto.com**.
+If you experience or witness unacceptable behavior, please contact us at **conduct@the-bearded-bear.com**.
 
 We will review and investigate all complaints and respond appropriately.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -559,7 +559,7 @@ When contributing to Claude Craft:
 1. **No secrets in commits**: Never commit API keys, tokens, or credentials
 2. **Dependency hygiene**: Only add well-maintained dependencies with active security patching
 3. **Audit new dependencies**: Check for known CVEs before adding new dependencies
-4. **Report security issues privately**: Email security@thebearded-cto.com instead of opening public issues
+4. **Report security issues privately**: Email security@the-bearded-bear.com instead of opening public issues
 5. **Supply chain awareness**: Understand SLSA provenance and SBOM generation (see SECURITY.md)
 
 ### Verifying Package Integrity

--- a/Dev/i18n/de/Paperclip/README.md
+++ b/Dev/i18n/de/Paperclip/README.md
@@ -76,4 +76,4 @@ make install-paperclip TARGET=/path/to/my/paperclip-project RULES_LANG=en
 
 - Paperclip docs: https://docs.paperclip.ing/
 - Paperclip repo: https://github.com/paperclipai/paperclip
-- Claude-Craft: https://github.com/the-bearded-cto/claude-craft
+- Claude-Craft: https://github.com/TheBeardedBearSAS/claude-craft

--- a/Dev/i18n/en/Paperclip/README.md
+++ b/Dev/i18n/en/Paperclip/README.md
@@ -76,4 +76,4 @@ make install-paperclip TARGET=/path/to/my/paperclip-project RULES_LANG=en
 
 - Paperclip docs: https://docs.paperclip.ing/
 - Paperclip repo: https://github.com/paperclipai/paperclip
-- Claude-Craft: https://github.com/the-bearded-cto/claude-craft
+- Claude-Craft: https://github.com/TheBeardedBearSAS/claude-craft

--- a/Dev/i18n/es/Paperclip/README.md
+++ b/Dev/i18n/es/Paperclip/README.md
@@ -76,4 +76,4 @@ make install-paperclip TARGET=/path/to/my/paperclip-project RULES_LANG=en
 
 - Documentación Paperclip: https://docs.paperclip.ing/
 - Repositorio Paperclip: https://github.com/paperclipai/paperclip
-- Claude-Craft: https://github.com/the-bearded-cto/claude-craft
+- Claude-Craft: https://github.com/TheBeardedBearSAS/claude-craft

--- a/Dev/i18n/fr/Paperclip/README.md
+++ b/Dev/i18n/fr/Paperclip/README.md
@@ -76,4 +76,4 @@ make install-paperclip TARGET=/chemin/vers/mon/projet-paperclip RULES_LANG=fr
 
 - Documentation Paperclip : https://docs.paperclip.ing/
 - Dépôt Paperclip : https://github.com/paperclipai/paperclip
-- Claude-Craft : https://github.com/the-bearded-cto/claude-craft
+- Claude-Craft : https://github.com/TheBeardedBearSAS/claude-craft

--- a/Dev/i18n/pt/Paperclip/README.md
+++ b/Dev/i18n/pt/Paperclip/README.md
@@ -76,4 +76,4 @@ make install-paperclip TARGET=/path/to/my/paperclip-project RULES_LANG=en
 
 - Documentação Paperclip: https://docs.paperclip.ing/
 - Repositório Paperclip: https://github.com/paperclipai/paperclip
-- Claude-Craft: https://github.com/the-bearded-cto/claude-craft
+- Claude-Craft: https://github.com/TheBeardedBearSAS/claude-craft

--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -8,7 +8,7 @@ This Privacy Policy describes how Claude Craft ("we", "us", or "the Project") co
 ## 1. Data Controller
 
 The Bearded Bear SAS  
-Contact: privacy@thebeardedcto.com (or open a GitHub issue at https://github.com/TheBeardedBearSAS/claude-craft/issues)
+Contact: privacy@the-bearded-bear.com (or open a GitHub issue at https://github.com/TheBeardedBearSAS/claude-craft/issues)
 
 ## 2. What Data We Collect
 
@@ -80,7 +80,7 @@ You have the following rights under GDPR:
 5. **Right to Object (Art. 21)**: Object to processing based on legitimate interest
 6. **Right to Restriction (Art. 18)**: Request limited processing of your data
 
-To exercise these rights, contact us at privacy@thebeardedcto.com or open a GitHub issue.
+To exercise these rights, contact us at privacy@the-bearded-bear.com or open a GitHub issue.
 
 ## 6. Third-Party Services
 
@@ -125,7 +125,7 @@ We implement industry-standard security measures:
 - Access controls to limit data access to authorized personnel only
 - Regular security audits
 
-However, no system is 100% secure. If you discover a security vulnerability, please report it responsibly via GitHub Security Advisories or privacy@thebeardedcto.com.
+However, no system is 100% secure. If you discover a security vulnerability, please report it responsibly via GitHub Security Advisories or privacy@the-bearded-bear.com.
 
 ## 10. Children's Privacy
 
@@ -145,9 +145,9 @@ Your continued use of Claude Craft after changes constitutes acceptance of the u
 
 For privacy-related questions or to exercise your rights:
 
-- **Email**: privacy@thebeardedcto.com
+- **Email**: privacy@the-bearded-bear.com
 - **GitHub Issues**: https://github.com/TheBeardedBearSAS/claude-craft/issues
-- **DPO (if applicable)**: Contact privacy@thebeardedcto.com to reach our Data Protection Officer
+- **DPO (if applicable)**: Contact privacy@the-bearded-bear.com to reach our Data Protection Officer
 
 ## 13. Supervisory Authority
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ Step-by-step tutorials available in 5 languages:
 
 ## Project Governance & Sustainability
 
-Claude Craft is maintained by [The Bearded CTO](https://thebeardedcto.com), a solo founder with deep involvement in the AFUP and Symfony French ecosystem.
+Claude Craft is maintained by [The Bearded CTO](https://the-bearded-bear.com), a solo founder with deep involvement in the AFUP and Symfony French ecosystem.
 
 | Item | Status |
 |------|--------|

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@
 
 If you discover a security vulnerability in Claude Craft, please report it responsibly.
 
-**Email:** security@thebearded-cto.com
+**Email:** security@the-bearded-bear.com
 
 ### What to include
 
@@ -180,7 +180,7 @@ Starting with version 8.1.0:
 
 If you discover a supply chain security issue (compromised dependency, malicious package, signature mismatch):
 
-**Email:** security@thebearded-cto.com
+**Email:** security@the-bearded-bear.com
 
 **Subject:** `[SUPPLY-CHAIN] <brief description>`
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -58,7 +58,7 @@ Replace `react` with your technology: `symfony`, `flutter`, `python`, `angular`,
 **What you should see:**
 
 ```
-  Claude Craft v8.10.0 - AI Development Framework
+  Claude Craft v8.10.1 - AI Development Framework
 
   Installing react rules to /home/user/my-project...
   [OK] Common rules installed

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -347,7 +347,7 @@ npm run lint:shell
 
 - **Maintainer:** The Bearded CTO
 - **Email:** flavien.metivier@gmail.com
-- **Security:** security@thebearded-cto.com
+- **Security:** security@the-bearded-bear.com
 
 ---
 

--- a/docs/SECURITY.md
+++ b/docs/SECURITY.md
@@ -4,7 +4,7 @@ La politique de sécurité officielle se trouve à la racine du dépôt : [SECUR
 
 Voir aussi :
 
-- **Rapport de vulnérabilité** : [processus documenté](../SECURITY.md#reporting-a-vulnerability) — email `security@thebearded-cto.com`, réponse sous 48h
+- **Rapport de vulnérabilité** : [processus documenté](../SECURITY.md#reporting-a-vulnerability) — email `security@the-bearded-bear.com`, réponse sous 48h
 - **CVE / hardening Claude Code** : [Known CVE Fixes](../SECURITY.md#known-cve-fixes-claude-code) — baseline minimale v2.1.97
 - **SLSA / SBOM / Sigstore** : [Software Supply Chain Security](../SECURITY.md#software-supply-chain-security) dans le SECURITY.md racine
 - **Subprocess sandboxing** : [Subprocess Sandboxing (v2.1.98+)](../SECURITY.md#subprocess-sandboxing-v2198)

--- a/docs/community/CHAMPIONS.md
+++ b/docs/community/CHAMPIONS.md
@@ -131,7 +131,7 @@ Champions are expected to:
 
 - **Discord:** #champions channel (invite after acceptance)
 - **Email:** champions@claude-craft.dev
-- **GitHub Discussions:** [Community](https://github.com/TheBeardedCTO/claude-craft/discussions)
+- **GitHub Discussions:** [Community](https://github.com/TheBeardedBearSAS/claude-craft/discussions)
 
 ---
 

--- a/docs/compliance/ISO27001-GAP-ANALYSIS-DETAILED.md
+++ b/docs/compliance/ISO27001-GAP-ANALYSIS-DETAILED.md
@@ -422,7 +422,7 @@ Disponible pour appel préliminaire (présentation Claude Craft, questions péri
 Cordialement,
 [CTO Name]
 The Bearded CTO
-cto@thebeardedcto.com
+cto@the-bearded-bear.com
 ```
 
 ---
@@ -663,6 +663,6 @@ Voir fichiers séparés :
 
 ---
 
-**Contact :** cto@thebeardedcto.com  
+**Contact :** cto@the-bearded-bear.com  
 **Dernière mise à jour :** 2026-04-15  
 **Confidentialité :** Internal — Ne pas diffuser hors équipe sans approbation CTO

--- a/docs/compliance/policies/access-control.md
+++ b/docs/compliance/policies/access-control.md
@@ -168,7 +168,7 @@ Cette Access Control Policy définit les principes et processus de gestion des a
 - IT crée ticket provisioning (checklist)
 
 **J-1 :**
-- Création compte Google Workspace (email @thebeardedcto.com)
+- Création compte Google Workspace (email @the-bearded-bear.com)
 - Envoi invitation 1Password vault approprié
 - Envoi hardware keys MFA (YubiKey si admin)
 
@@ -184,7 +184,7 @@ Cette Access Control Policy définit les principes et processus de gestion des a
 **Checklist provisioning :**
 
 ```markdown
-- [ ] Compte Google Workspace créé (email @thebeardedcto.com)
+- [ ] Compte Google Workspace créé (email @the-bearded-bear.com)
 - [ ] Invitation 1Password vault (Dev/Infra/Finance selon rôle)
 - [ ] MFA activé Google Workspace + 1Password
 - [ ] Hardware key envoyée (si admin)
@@ -413,7 +413,7 @@ Cette Access Control Policy définit les principes et processus de gestion des a
 **SLA :** 1h révocation tous accès, 24/7 (on-call IT Admin).
 
 **Process :**
-1. **Alerte :** Employé, manager, ou SIEM notifie IT Admin (#security-incidents Slack ou security@thebeardedcto.com)
+1. **Alerte :** Employé, manager, ou SIEM notifie IT Admin (#security-incidents Slack ou security@the-bearded-bear.com)
 2. **Triage :** IT Admin confirme urgence (15min)
 3. **Révocation :** IT exécute checklist offboarding urgence (section 6.2)
 4. **Notification :** CTO + Legal informés sous 30min
@@ -538,5 +538,5 @@ Cette Access Control Policy définit les principes et processus de gestion des a
 
 **FIN DU DOCUMENT — DRAFT v1.0.0**
 
-**Contact :** cto@thebeardedcto.com  
+**Contact :** cto@the-bearded-bear.com  
 **Confidentialité :** Internal — Diffusion équipe uniquement

--- a/docs/compliance/policies/business-continuity.md
+++ b/docs/compliance/policies/business-continuity.md
@@ -669,5 +669,5 @@ Co-founder & CTO, The Bearded CTO
 
 **FIN DU DOCUMENT — DRAFT v1.0.0**
 
-**Contact urgence :** CTO [MOBILE] | crisis@thebeardedcto.com  
+**Contact urgence :** CTO [MOBILE] | crisis@the-bearded-bear.com  
 **Confidentialité :** Internal — Management + CSIRT uniquement

--- a/docs/compliance/policies/incident-response.md
+++ b/docs/compliance/policies/incident-response.md
@@ -121,7 +121,7 @@ Preparation → Detection → Analysis → Containment → Eradication → Recov
 **Checklist préparation :**
 - [ ] CSIRT membres identifiés, formés, on-call rotation configurée
 - [ ] Playbooks Sev1/2 rédigés et accessibles (Google Drive CSIRT folder + 1Password emergency)
-- [ ] Canaux communication : Slack #security-incidents (privé, CSIRT only), email security@thebeardedcto.com, phone tree
+- [ ] Canaux communication : Slack #security-incidents (privé, CSIRT only), email security@the-bearded-bear.com, phone tree
 - [ ] Contacts externes : ANSSI CERT-FR (+33 1 71 75 84 68), CNIL (+33 1 53 73 22 22), cabinet forensics (TBD)
 - [ ] Backup outils : laptop CSIRT isolé (forensics, pas utilisé quotidiennement), clés USB bootable (Kali Linux, Tails)
 - [ ] Assurance cyber : contrat souscrit (montant couverture, SLA expertise externe)
@@ -139,7 +139,7 @@ Preparation → Detection → Analysis → Containment → Eradication → Recov
 | **Sentry** | Spike erreurs app (possible exploitation vulnérabilité) | Real-time alerting | Dev on-call |
 | **1Password Activity Log** | Accès vault anormal (IP géo, horaires) | Daily review | IT Admin |
 | **Employés** | Reporting phishing, device volé, activité suspecte | Immédiat (Slack #security-incidents) | Tous |
-| **External researcher** | Vulnerability disclosure (security@thebeardedcto.com) | Variable | CTO |
+| **External researcher** | Vulnerability disclosure (security@the-bearded-bear.com) | Variable | CTO |
 
 **Analysis (triage <15min Sev1, <1h Sev2) :**
 
@@ -543,14 +543,14 @@ Preparation → Detection → Analysis → Containment → Eradication → Recov
 
 | Rôle | Nom | Email | Mobile | Backup |
 |------|-----|-------|--------|--------|
-| **Incident Commander** | CTO | cto@thebeardedcto.com | [À compléter] | CEO |
-| **Tech Lead** | Dev Lead | devlead@thebeardedcto.com | [À compléter] | Senior Dev |
-| **Operations Lead** | IT Admin | it@thebeardedcto.com | [À compléter] | CTO |
-| **Communications Lead** | Legal Counsel | legal@thebeardedcto.com | [À compléter] | Product Manager |
+| **Incident Commander** | CTO | cto@the-bearded-bear.com | [À compléter] | CEO |
+| **Tech Lead** | Dev Lead | devlead@the-bearded-bear.com | [À compléter] | Senior Dev |
+| **Operations Lead** | IT Admin | it@the-bearded-bear.com | [À compléter] | CTO |
+| **Communications Lead** | Legal Counsel | legal@the-bearded-bear.com | [À compléter] | Product Manager |
 
 **Slack channel :** #security-incidents (privé, CSIRT only)
 
-**Email groupe :** security@thebeardedcto.com (forwardé CSIRT members)
+**Email groupe :** security@the-bearded-bear.com (forwardé CSIRT members)
 
 ### 7.2 Autorités et Partenaires Externes
 
@@ -652,7 +652,7 @@ Vos mots de passe et informations de paiement n'ont PAS été affectés (stocké
 
 **Plus d'informations :**
 Post-mortem détaillé (anonymisé) : [LIEN BLOG]
-Questions : security@thebeardedcto.com
+Questions : security@the-bearded-bear.com
 
 Nous sommes profondément désolés pour cet incident. La sécurité de vos données est notre 
 priorité absolue, et nous avons pris des mesures pour qu'un tel incident ne se reproduise pas.
@@ -688,7 +688,7 @@ Risque phishing ciblé (emails exposés), risque faible pour droits/libertés (p
 - Remediations : patch vulnérabilité, MFA renforcé, monitoring accrue
 
 **6. Contact DPO :**
-[NOM DPO], legal@thebeardedcto.com, +33 [TÉLÉPHONE]
+[NOM DPO], legal@the-bearded-bear.com, +33 [TÉLÉPHONE]
 ```
 
 ---
@@ -842,5 +842,5 @@ Chaque incident Sev1/2 → post-mortem obligatoire (section 5.7).
 
 **FIN DU DOCUMENT — DRAFT v1.0.0**
 
-**Contact urgence 24/7 :** security@thebeardedcto.com | Slack #security-incidents  
+**Contact urgence 24/7 :** security@the-bearded-bear.com | Slack #security-incidents  
 **Confidentialité :** Internal — CSIRT + Management uniquement

--- a/docs/compliance/policies/information-security.md
+++ b/docs/compliance/policies/information-security.md
@@ -24,7 +24,7 @@ L'ISP s'applique à tous les employés, contractors, partenaires et fournisseurs
 ### 2.1 Périmètre
 
 **Systèmes couverts :**
-- Repositories GitHub (github.com/the-bearded-cto/claude-craft)
+- Repositories GitHub (github.com/TheBeardedBearSAS/claude-craft)
 - Infrastructure cloud (Cloudflare, AWS/GCP si SaaS)
 - Services tiers (Anthropic API, Posthog, Sentry, Stripe)
 - Devices équipe (laptops, smartphones)
@@ -200,7 +200,7 @@ La sécurité de l'information repose sur trois piliers :
 - Respecter policies sécurité (ISP, Access Control, Acceptable Use)
 - Compléter formation sensibilisation 8h/an
 - Utiliser password manager (1Password) + MFA
-- Reporter incidents sécurité sous 1h (#security-incidents Slack ou security@thebeardedcto.com)
+- Reporter incidents sécurité sous 1h (#security-incidents Slack ou security@the-bearded-bear.com)
 - Protéger devices (antivirus, mises à jour, chiffrement disque)
 
 ---
@@ -436,5 +436,5 @@ La sécurité de l'information repose sur trois piliers :
 
 **FIN DU DOCUMENT — DRAFT v1.0.0**
 
-**Contact :** cto@thebeardedcto.com  
+**Contact :** cto@the-bearded-bear.com  
 **Confidentialité :** Internal — Diffusion équipe uniquement

--- a/docs/compliance/policies/supplier-management.md
+++ b/docs/compliance/policies/supplier-management.md
@@ -648,7 +648,7 @@ de vos pratiques de sécurité avec nos exigences internes (ISO 27001, RGPD).
 Cordialement,
 [CTO NAME]
 CTO, The Bearded CTO
-cto@thebeardedcto.com
+cto@the-bearded-bear.com
 ```
 
 ---
@@ -685,5 +685,5 @@ cto@thebeardedcto.com
 
 **FIN DU DOCUMENT — DRAFT v1.0.0**
 
-**Contact :** cto@thebeardedcto.com  
+**Contact :** cto@the-bearded-bear.com  
 **Confidentialité :** Internal — Management + Legal uniquement

--- a/docs/guides/MULTI-IDE.md
+++ b/docs/guides/MULTI-IDE.md
@@ -209,7 +209,7 @@ cp bundles/cursor/.cursorrules /path/to/your/project/
 Exported files include attribution to **The Bearded CTO / Claude Craft**.
 
 **License:** MIT  
-**Repository:** https://github.com/TheBeardedCTO/claude-craft
+**Repository:** https://github.com/TheBeardedBearSAS/claude-craft
 
 ---
 

--- a/docs/guides/de/01-getting-started.md
+++ b/docs/guides/de/01-getting-started.md
@@ -88,7 +88,7 @@ Alle Inhalte sind in 5 Sprachen verfügbar:
 
 ```bash
 # Claude-Craft klonen
-git clone https://github.com/thebeardedcto/claude-craft.git
+git clone https://github.com/TheBeardedBearSAS/claude-craft.git
 cd claude-craft
 
 # Für ein Symfony-Projekt installieren (auf Französisch)

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -17,7 +17,7 @@ Dieser Leitfaden führt Sie durch den vollständigen Entwicklungslebenszyklus:
 7. **Deployment** – In die Produktion deployen
 
 **Voraussetzungen:**
-- Claude Craft v8.10.0 in Ihrem Projekt installiert
+- Claude Craft v8.10.1 in Ihrem Projekt installiert
 - Claude Code v2.1.159 (empfohlen) oder v2.1.97+ (Minimum, CVE-2025-59536 gepatcht)
 - Grundlegendes Verständnis Ihres gewählten Technologie-Stacks
 

--- a/docs/guides/en/01-getting-started.md
+++ b/docs/guides/en/01-getting-started.md
@@ -88,7 +88,7 @@ All content is available in 5 languages:
 
 ```bash
 # Clone Claude-Craft
-git clone https://github.com/thebeardedcto/claude-craft.git
+git clone https://github.com/TheBeardedBearSAS/claude-craft.git
 cd claude-craft
 
 # Install for a Symfony project (in French)

--- a/docs/guides/en/10-complete-workflow.md
+++ b/docs/guides/en/10-complete-workflow.md
@@ -17,7 +17,7 @@ This guide walks you through the complete development lifecycle:
 7. **Deployment** - Ship to production
 
 **Prerequisites:**
-- Claude Craft v8.10.0 installed in your project
+- Claude Craft v8.10.1 installed in your project
 - Claude Code v2.1.159 (recommended) or v2.1.97+ (minimum, CVE-2025-59536 patched)
 - Basic understanding of your chosen technology stack
 

--- a/docs/guides/es/01-getting-started.md
+++ b/docs/guides/es/01-getting-started.md
@@ -88,7 +88,7 @@ Todo el contenido está disponible en 5 idiomas:
 
 ```bash
 # Clonar Claude-Craft
-git clone https://github.com/thebeardedcto/claude-craft.git
+git clone https://github.com/TheBeardedBearSAS/claude-craft.git
 cd claude-craft
 
 # Instalar para un proyecto Symfony (en francés)

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -17,7 +17,7 @@ Esta guía te lleva a través del ciclo de vida de desarrollo completo:
 7. **Despliegue** - Lanza a producción
 
 **Prerequisitos:**
-- Claude Craft v8.10.0 instalado en tu proyecto
+- Claude Craft v8.10.1 instalado en tu proyecto
 - Claude Code v2.1.159 (recomendado) o v2.1.97+ (mínimo, CVE-2025-59536 parcheado)
 - Comprensión básica de tu stack tecnológico elegido
 

--- a/docs/guides/fr/01-getting-started.md
+++ b/docs/guides/fr/01-getting-started.md
@@ -87,7 +87,7 @@ Tout le contenu est disponible en 5 langues :
 
 ```bash
 # Cloner Claude-Craft
-git clone https://github.com/thebeardedcto/claude-craft.git
+git clone https://github.com/TheBeardedBearSAS/claude-craft.git
 cd claude-craft
 
 # Installer pour un projet Symfony (en français)

--- a/docs/guides/pt/01-getting-started.md
+++ b/docs/guides/pt/01-getting-started.md
@@ -88,7 +88,7 @@ Todo o conteúdo está disponível em 5 idiomas:
 
 ```bash
 # Clonar o Claude-Craft
-git clone https://github.com/thebeardedcto/claude-craft.git
+git clone https://github.com/TheBeardedBearSAS/claude-craft.git
 cd claude-craft
 
 # Instalar para um projeto Symfony (em francês)

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -17,7 +17,7 @@ Este guia acompanha você ao longo de todo o ciclo de desenvolvimento:
 7. **Deploy** - Entregar em produção
 
 **Pré-requisitos:**
-- Claude Craft v8.10.0 instalado no seu projeto
+- Claude Craft v8.10.1 instalado no seu projeto
 - Claude Code v2.1.159 (recomendado) ou v2.1.97+ (mínimo, CVE-2025-59536 corrigido)
 - Conhecimento básico da stack de tecnologia escolhida
 

--- a/docs/marketing/POSITIONING.md
+++ b/docs/marketing/POSITIONING.md
@@ -166,7 +166,7 @@ Partial coverage, early adopters, evolving references.
 
 **Author:** The Bearded CTO  
 **License:** MIT  
-**Repository:** https://github.com/TheBeardedCTO/claude-craft  
+**Repository:** https://github.com/TheBeardedBearSAS/claude-craft  
 **Website:** https://claude-craft.dev
 
 ---

--- a/docs/plugins/README.md
+++ b/docs/plugins/README.md
@@ -86,6 +86,6 @@ Voir `examples/plugins/` :
 
 ## Contribuer
 
-- Discussion générale : [GitHub Discussions `plugins`](https://github.com/the-bearded-cto/claude-craft/discussions/categories/plugins)
-- Feedback API : commenter le [RFC v1.0](https://github.com/the-bearded-cto/claude-craft/discussions/plugin-rfc-v1)
+- Discussion générale : [GitHub Discussions `plugins`](https://github.com/TheBeardedBearSAS/claude-craft/discussions/categories/plugins)
+- Feedback API : commenter le [RFC v1.0](https://github.com/TheBeardedBearSAS/claude-craft/discussions/plugin-rfc-v1)
 - Bugs : issues GitHub avec label `plugins`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.10.0",
+  "version": "8.10.1",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",

--- a/scripts/export-multi-ide.sh
+++ b/scripts/export-multi-ide.sh
@@ -29,7 +29,7 @@ CURSOR_OUTPUT="$BUNDLES_DIR/cursor/.cursorrules"
 
 cat > "$CURSOR_OUTPUT" << 'EOF'
 # Claude Craft — AI-First TDD Framework for Cursor IDE
-# Generated from https://github.com/TheBeardedCTO/claude-craft
+# Generated from https://github.com/TheBeardedBearSAS/claude-craft
 # Version: 8.0.1 | Last updated: 2026-04-17
 
 ---
@@ -96,7 +96,7 @@ For full rules and references:
 
 **Attribution:** The Bearded CTO / Claude Craft
 **License:** MIT
-**Repository:** https://github.com/TheBeardedCTO/claude-craft
+**Repository:** https://github.com/TheBeardedBearSAS/claude-craft
 EOF
 
 echo -e "  ${YELLOW}→${NC} Created: $CURSOR_OUTPUT"

--- a/skills-marketplace/universal/README.md
+++ b/skills-marketplace/universal/README.md
@@ -64,7 +64,7 @@ All skills developed by **The Bearded CTO** as part of **Claude Craft** — the 
 
 - **Author:** The Bearded CTO
 - **License:** MIT
-- **Repository:** https://github.com/TheBeardedCTO/claude-craft
+- **Repository:** https://github.com/TheBeardedBearSAS/claude-craft
 - **Version:** 8.3.2
 - **Marketplace Status:** Ready for submission (2026-Q2)
 

--- a/skills-marketplace/universal/architect.md
+++ b/skills-marketplace/universal/architect.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [architecture, design, tdd, planning, boundaries, contracts, dependencies]
 category: design
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # Architect — Architecture Before TDD

--- a/skills-marketplace/universal/atomic-tasks.md
+++ b/skills-marketplace/universal/atomic-tasks.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [workflow, productivity, context-management, gsd, atomic, subagent]
 category: workflow
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # Atomic Tasks — GSD Pattern (Get Shit Done)

--- a/skills-marketplace/universal/debug-methodical.md
+++ b/skills-marketplace/universal/debug-methodical.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [debugging, troubleshooting, regression, bug-fix, methodical]
 category: quality
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # Debug-Methodical — 4-Phase Debugging

--- a/skills-marketplace/universal/documentation.md
+++ b/skills-marketplace/universal/documentation.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [documentation, adr, openapi, changelog, readme, markdown]
 category: quality
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # Documentation — Documentation as Code

--- a/skills-marketplace/universal/git-workflow.md
+++ b/skills-marketplace/universal/git-workflow.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [git, workflow, commits, pr, review, conventional-commits, github-flow]
 category: devops
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # Git Workflow — GitHub Flow + Conventional Commits

--- a/skills-marketplace/universal/kiss-dry-yagni.md
+++ b/skills-marketplace/universal/kiss-dry-yagni.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [simplicity, refactoring, yagni, clean-code, kiss, dry, cognitive-complexity]
 category: quality
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # KISS, DRY, YAGNI — Simplicity Principles

--- a/skills-marketplace/universal/security.md
+++ b/skills-marketplace/universal/security.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [security, owasp, auth, encryption, jwt, supply-chain, ssrf]
 category: security
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # Security — OWASP Top 10:2025 Essentials

--- a/skills-marketplace/universal/socratic-brainstorm.md
+++ b/skills-marketplace/universal/socratic-brainstorm.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [brainstorming, requirements, planning, socratic-method, clarification]
 category: planning
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # Socratic Brainstorm — Clarify Before Coding

--- a/skills-marketplace/universal/solid-principles.md
+++ b/skills-marketplace/universal/solid-principles.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [solid, oop, clean-code, architecture, srp, ocp, lsp, isp, dip]
 category: design
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # SOLID Principles — Clean OO Design

--- a/skills-marketplace/universal/testing.md
+++ b/skills-marketplace/universal/testing.md
@@ -6,7 +6,7 @@ version: 1.0.0
 tags: [testing, tdd, bdd, coverage, mutation, vitest, playwright, jest]
 category: quality
 license: MIT
-repository: https://github.com/TheBeardedCTO/claude-craft
+repository: https://github.com/TheBeardedBearSAS/claude-craft
 ---
 
 # Testing — TDD/BDD Principles (2026)


### PR DESCRIPTION
## Contexte

Le projet référençait un domaine email/web obsolète et incohérent (trois orthographes), et des URLs GitHub pointant vers des orgs périmées. Cette PR unifie tout vers le domaine officiel **`the-bearded-bear.com`** et le repo canonique **`TheBeardedBearSAS/claude-craft`**, puis bump en **v8.10.1**.

## Changements

### Domaine email/web → `the-bearded-bear.com`
- `thebeardedcto.com` (sans tiret) — URLs + emails (`privacy@`, `cto@`, `security@`, `legal@`, `governance@`, `crisis@`, `devlead@`, `it@`…)
- `thebearded-cto.com` (avec tiret) — emails `security@`, `conduct@`
- Fichiers : plugin/marketplace, README, PRIVACY, CHARTER, SECURITY, CONTRIBUTING, CODE_OF_CONDUCT, docs/RUNBOOK, docs/SECURITY, docs/compliance/**

### URLs GitHub → `github.com/TheBeardedBearSAS/claude-craft`
- Normalisation des variantes obsolètes `the-bearded-cto`, `thebeardedcto`, `TheBeardedCTO`

### CODEOWNERS
- `@thebearded-cto` (handle **inexistant**, 404 → review cassée) → `@flavien-metivier` (mainteneur, admin du repo)

### Release
- Bump `8.10.0` → `8.10.1` (13 occurrences trackées, FluentAssertions exclu)
- Entrée CHANGELOG `[8.10.1]`

## Hors-scope (signalé)
- `audit/` (gitignored), `website/en/*` non trackés
- `LandingPage.vue` figé à v8.8.2 (dette préexistante)
- Placeholders `your-org`/`YOUR_USERNAME` et lien Calendly historique conservés

## Vérifications
- ✅ `npm run lint:versions`
- ✅ `bash scripts/verify-i18n-parity.sh` (parité 5 langues OK)
- ✅ Aucune occurrence obsolète résiduelle (hors descriptions CHANGELOG)

🤖 Generated with [Claude Code](https://claude.com/claude-code)