### PR TITLE
fix(kanban): build client UI in CI before publish + v8.10.2

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.10.1",
+      "version": "8.10.2",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.10.1",
+  "version": "8.10.2",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.10.1 | **Languages:** en, fr, es, de, pt
+**Version:** 8.10.2 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/.claude/COMPATIBILITY.md
+++ b/.claude/COMPATIBILITY.md
@@ -1,4 +1,4 @@
-# Claude Code Compatibility — Claude Craft v8.10.1
+# Claude Code Compatibility — Claude Craft v8.10.2
 
 **Minimum Version:** 2.1.97 (elevated from 2.1.47 — see [rationale](#why-we-elevated-minimum-from-2147-to-2197))
 **Recommended Version:** 2.1.168 (Opus 4.8, `fallbackModel`, `ultracode` trigger, June 6, 2026)

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.10.1
+- **Version:** 8.10.2
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -235,6 +235,15 @@ jobs:
           # Node 24 (npm 11.5.1+) required for OIDC trusted publishing (npm 10 has no OIDC support).
           # No registry-url: avoids setup-node auto-setting NODE_AUTH_TOKEN which overrides OIDC.
 
+      - name: Install dependencies
+        # Needed for the Kanban build below: vite/svelte are devDependencies, absent from a fresh checkout.
+        run: npm ci
+
+      - name: Build Kanban UI
+        # cli/kanban/client/dist is gitignored, so it must be (re)built here or the published
+        # package ships without the UI and `npx … kanban` shows "client not built".
+        run: npm run kanban:build
+
       - name: Update version for main branch
         if: ${{ needs.validate.outputs.is_main_push == 'true' }}
         run: |
@@ -256,6 +265,13 @@ jobs:
 
       - name: Generate AI bundles (chatgpt/claude/gemini)
         run: bash scripts/export-multi-ide.sh
+
+      - name: Verify Kanban UI is bundled
+        # Inspect the real tarball: fail the release loudly if the built client is missing,
+        # instead of shipping a package that greets every user with "client not built".
+        run: |
+          npm pack --dry-run 2>&1 | grep -q "cli/kanban/client/dist/index.html" \
+            || { echo "::error::Kanban UI (cli/kanban/client/dist) missing from package — kanban:build did not run"; exit 1; }
 
       - name: Publish (dry run)
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.dry_run == true }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.10.2] - 2026-06-11
+
+### Fixed
+- **Interface web Kanban** : le package npm publié n'embarquait pas le client Svelte compilé (`cli/kanban/client/dist/` est gitignored et n'était jamais buildé en CI), si bien que `npx @the-bearded-bear/claude-craft kanban` affichait *« client not built »* pour tous les utilisateurs. La CI de publication lance désormais `npm run kanban:build` avant `npm publish`, et un garde-fou fait échouer la release si `cli/kanban/client/dist` est absent du tarball.
+
 ## [8.10.1] - 2026-06-11
 
 ### Fixed

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -58,7 +58,7 @@ Replace `react` with your technology: `symfony`, `flutter`, `python`, `angular`,
 **What you should see:**
 
 ```
-  Claude Craft v8.10.1 - AI Development Framework
+  Claude Craft v8.10.2 - AI Development Framework
 
   Installing react rules to /home/user/my-project...
   [OK] Common rules installed

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -17,7 +17,7 @@ Dieser Leitfaden führt Sie durch den vollständigen Entwicklungslebenszyklus:
 7. **Deployment** – In die Produktion deployen
 
 **Voraussetzungen:**
-- Claude Craft v8.10.1 in Ihrem Projekt installiert
+- Claude Craft v8.10.2 in Ihrem Projekt installiert
 - Claude Code v2.1.159 (empfohlen) oder v2.1.97+ (Minimum, CVE-2025-59536 gepatcht)
 - Grundlegendes Verständnis Ihres gewählten Technologie-Stacks
 

--- a/docs/guides/en/10-complete-workflow.md
+++ b/docs/guides/en/10-complete-workflow.md
@@ -17,7 +17,7 @@ This guide walks you through the complete development lifecycle:
 7. **Deployment** - Ship to production
 
 **Prerequisites:**
-- Claude Craft v8.10.1 installed in your project
+- Claude Craft v8.10.2 installed in your project
 - Claude Code v2.1.159 (recommended) or v2.1.97+ (minimum, CVE-2025-59536 patched)
 - Basic understanding of your chosen technology stack
 

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -17,7 +17,7 @@ Esta guía te lleva a través del ciclo de vida de desarrollo completo:
 7. **Despliegue** - Lanza a producción
 
 **Prerequisitos:**
-- Claude Craft v8.10.1 instalado en tu proyecto
+- Claude Craft v8.10.2 instalado en tu proyecto
 - Claude Code v2.1.159 (recomendado) o v2.1.97+ (mínimo, CVE-2025-59536 parcheado)
 - Comprensión básica de tu stack tecnológico elegido
 

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -17,7 +17,7 @@ Este guia acompanha você ao longo de todo o ciclo de desenvolvimento:
 7. **Deploy** - Entregar em produção
 
 **Pré-requisitos:**
-- Claude Craft v8.10.1 instalado no seu projeto
+- Claude Craft v8.10.2 instalado no seu projeto
 - Claude Code v2.1.159 (recomendado) ou v2.1.97+ (mínimo, CVE-2025-59536 corrigido)
 - Conhecimento básico da stack de tecnologia escolhida
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.10.1",
+  "version": "8.10.2",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
## Problème

`npx @the-bearded-bear/claude-craft kanban` affiche **« client not built »** pour **tous** les utilisateurs npx.

**Cause racine :** `cli/kanban/client/dist/` (le client Svelte compilé) est **gitignored** et n'a jamais été buildé par le job `publish` de la CI, qui fait un checkout frais puis `npm publish` directement (sans même `npm ci`). Le `dist/` n'est donc jamais dans le tarball publié.

Vérifié : `npm pack @the-bearded-bear/claude-craft@8.10.1` → **0 fichier** sous `cli/kanban/client/dist/`.

L'instruction du message d'erreur (`npm run kanban:build`) est inapplicable pour un utilisateur npx (ni repo cloné, ni devDependencies `vite`/`svelte`).

## Correctif

Dans `.github/workflows/npm-publish.yml`, job `publish` :
- `npm ci` + `npm run kanban:build` **avant** la publication.
- **Garde-fou anti-régression** : `npm pack --dry-run | grep cli/kanban/client/dist/index.html` — la release échoue en rouge si l'UI est absente du tarball (= test de régression, règle 07).

Aucune doc CLI à modifier : `docs/CLI-REFERENCE.md` (+ i18n + website) présentent déjà `npx … kanban` comme directement fonctionnel. Le fix aligne la réalité sur la doc.

## Release

Bump **8.10.1 → 8.10.2** (patch) sur les 11 version-stamps + entrée CHANGELOG.

## Validation locale

- `npm run lint:versions` ✅
- `npm run lint:i18n` ✅ (parité OK)
- `npm pack --dry-run | grep cli/kanban/client/dist/index.html` ✅
- YAML du workflow validé (js-yaml), étapes dans le bon ordre.

🤖 Generated with [Claude Code](https://claude.com/claude-code)