### PR TITLE
feat(kanban): ingest .bmad/sprint-status.yaml as a read-only story source + v8.11.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.10.2",
+      "version": "8.11.0",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.10.2",
+  "version": "8.11.0",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.10.2 | **Languages:** en, fr, es, de, pt
+**Version:** 8.11.0 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/.claude/COMPATIBILITY.md
+++ b/.claude/COMPATIBILITY.md
@@ -1,4 +1,4 @@
-# Claude Code Compatibility — Claude Craft v8.10.2
+# Claude Code Compatibility — Claude Craft v8.11.0
 
 **Minimum Version:** 2.1.97 (elevated from 2.1.47 — see [rationale](#why-we-elevated-minimum-from-2147-to-2197))
 **Recommended Version:** 2.1.168 (Opus 4.8, `fallbackModel`, `ultracode` trigger, June 6, 2026)

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.10.2
+- **Version:** 8.11.0
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.11.0] - 2026-06-12
+
+### Added
+- **Kanban — lecture des stories BMAD v6** : le tableau Kanban ingère désormais les stories déclarées dans `.bmad/sprint-status.yaml` (piste `team:`/`qa:`, single-writer), en plus des fichiers markdown `backlog/user-stories/US-*.md` (piste `workflow:`). Les projets initialisés BMAD v6 affichaient un board vide et *« no sprint »* alors que leur `sprint-status.yaml` était complet — c'est corrigé. Les stories issues de la YAML sont exposées en **lecture seule** (`_source: 'sprint-status'`, `_writable: false`) ; sur collision d'identifiant, le fichier markdown l'emporte (pas de double source de vérité).
+
+### Fixed
+- **Board Kanban vide sur projet BMAD v6** : `PATCH /api/stories/:id/status` sur une story gérée par `sprint-status.yaml` renvoie un `409 read_only_source` explicite (au lieu d'un `404` trompeur) ; le client désactive le drag et affiche un cadenas sur ces cartes. `SprintStatusSchema.metadata` accepte désormais le champ `epic` (auparavant supprimé par Zod), pour que les stories synthétiques héritent de l'épic du sprint.
+
 ## [8.10.2] - 2026-06-11
 
 ### Fixed

--- a/cli/kanban/client/src/views/KanbanView.svelte
+++ b/cli/kanban/client/src/views/KanbanView.svelte
@@ -59,6 +59,7 @@
     if (!id) return;
     const story = store.stories.find((s) => s.id === id);
     if (!story || story.status === targetStatus) return;
+    if (story._writable === false) { announceReadOnly(story.id); return; }
     const body = { status: targetStatus };
     if (targetStatus === 'blocked') {
       const reason = await promptDialog.prompt('Blocked reason?');
@@ -168,6 +169,11 @@
   }
 
   async function moveCard(card, targetStatus) {
+    if (card._writable === false) {
+      announceReadOnly(card.id);
+      closeMoveMenu();
+      return;
+    }
     const body = { status: targetStatus };
     if (targetStatus === 'blocked') {
       const reason = await promptDialog.prompt('Blocked reason?');
@@ -190,6 +196,12 @@
     const targetCol = COLUMNS.find(c => c.key === targetStatus);
     liveRegion = `Card ${cardId} moved to ${targetCol?.label || targetStatus}`;
     setTimeout(() => liveRegion = '', 2000);
+  }
+
+  /** Story issue de .bmad/sprint-status.yaml : statut non modifiable depuis le board. */
+  function announceReadOnly(cardId) {
+    liveRegion = `Card ${cardId} is read-only (managed by .bmad/sprint-status.yaml — use team:/qa: commands)`;
+    setTimeout(() => liveRegion = '', 3000);
   }
 
   function announceCardDetails(card) {
@@ -237,9 +249,10 @@
           {@const tdd = tddBadge(s.tdd_phase)}
           <li
             class="card"
-            draggable="true"
+            class:read-only={s._writable === false}
+            draggable={s._writable !== false}
             ondragstart={(e) => onDragStart(e, s.id)}
-            aria-label="{s.id} {s.title}"
+            aria-label="{s.id} {s.title}{s._writable === false ? ' (lecture seule)' : ''}"
             data-card-id={s.id}
             tabindex="0"
             role="listitem"
@@ -247,6 +260,9 @@
           >
             <div class="card-top">
               <span class="id">{s.id}</span>
+              {#if s._writable === false}
+                <span class="readonly" aria-label="Lecture seule — gérée par .bmad/sprint-status.yaml" role="img">🔒</span>
+              {/if}
               <span class="priority" style="color: {priorityColor(s.priority)}">{s.priority}</span>
               <span class="points">{s.story_points}p</span>
               {#if tdd}
@@ -402,6 +418,10 @@
     box-shadow: var(--shadow);
   }
   .card:active { cursor: grabbing; }
+  /* Story issue de .bmad/sprint-status.yaml : non déplaçable depuis le board */
+  .card.read-only { cursor: default; opacity: 0.85; }
+  .card.read-only:active { cursor: default; }
+  .card-top .readonly { font-size: 12px; }
   /* Focus visible explicite (WCAG 2.2 SC 2.4.11) */
   .card:focus,
   .card:focus-visible {

--- a/cli/kanban/server/app.js
+++ b/cli/kanban/server/app.js
@@ -76,7 +76,18 @@ export function createApp({ repository, port, readonly = false, eventBus = null,
     const id = c.req.param('id');
     const filepath = repository.getStoryFile(id);
     const story = repository.getStory(id);
-    if (!story || !filepath) return c.json({ error: 'not_found' }, 404);
+    if (!story) return c.json({ error: 'not_found' }, 404);
+    // YAML-only story (BMAD v6 single-writer): no markdown file to rewrite.
+    if (!filepath) {
+      return c.json(
+        {
+          error: 'read_only_source',
+          reason:
+            'story gérée par .bmad/sprint-status.yaml (BMAD v6) ; utilisez les commandes team:/qa: pour changer le statut',
+        },
+        409
+      );
+    }
 
     let body;
     try {

--- a/cli/kanban/server/services/repository.js
+++ b/cli/kanban/server/services/repository.js
@@ -2,6 +2,7 @@ import path from 'node:path';
 import { readFile } from 'node:fs/promises';
 import { scan, groupByCategory } from './file-scanner.js';
 import { parseAndValidate } from './frontmatter.js';
+import { loadSprintStatus } from './sprint-cache.js';
 import { StoryFrontmatterSchema, EpicFrontmatterSchema, TaskFrontmatterSchema } from '../../shared/schemas.js';
 
 /**
@@ -75,6 +76,57 @@ export class Repository {
       if (f.category === 'sprint-goal') s.goalPath = f.path;
       this.sprints.set(f.sprintId, s);
     }
+
+    // BMAD v6 single-writer track stores stories only in .bmad/sprint-status.yaml
+    // (no individual markdown files). Surface them so the board isn't empty.
+    await this.#ingestSprintStatusStories();
+  }
+
+  /**
+   * Overlay stories declared in <projectRoot>/.bmad/sprint-status.yaml that have
+   * no backing markdown file. Markdown-backed stories (already in this.stories)
+   * always win — the YAML entry is ignored for a colliding id so there is no
+   * double source of truth. Synthetic stories are read-only (path === null).
+   */
+  async #ingestSprintStatusStories() {
+    const projectRoot = path.dirname(this.rootDir);
+    let ss;
+    try {
+      ss = await loadSprintStatus(projectRoot);
+    } catch {
+      // A broken sprint-status.yaml must not break the whole board scan.
+      return;
+    }
+    if (!ss || ss._invalid || !ss.stories) return;
+
+    const sprintId = ss.metadata?.sprint_id ?? null;
+    const epicFromMeta = ss.metadata?.epic ?? null;
+
+    for (const [id, s] of Object.entries(ss.stories)) {
+      if (this.stories.has(id)) continue; // markdown-backed story wins
+      this.stories.set(id, {
+        path: null, // no backing file -> read-only
+        mtime: 0,
+        ok: true,
+        source: 'sprint-status',
+        data: {
+          id,
+          title: s.title ?? id,
+          status: s.status,
+          previous_status: s.previous_status ?? '',
+          assigned_to: s.assigned_to ?? '',
+          tdd_phase: s.tdd_phase ?? '',
+          story_points: s.story_points ?? 0,
+          epic_id: s.epic_id || epicFromMeta || null,
+          // BMAD priorities are P0..P3 (outside the must/should/could/wont enum),
+          // so we don't map them; the board just needs a valid default.
+          priority: 'should',
+          sprint_id: sprintId,
+          tasks: s.tasks ?? { total: 0, completed: 0, list: [] },
+          dependencies: [],
+        },
+      });
+    }
   }
 
   listStories({ sprintId, status, epicId } = {}) {
@@ -85,7 +137,7 @@ export class Repository {
       if (sprintId && d.sprint_id !== sprintId) continue;
       if (status && d.status !== status) continue;
       if (epicId && d.epic_id !== epicId) continue;
-      out.push({ ...d, _mtime: entry.mtime });
+      out.push({ ...d, _mtime: entry.mtime, _source: entry.source ?? 'markdown', _writable: entry.path !== null });
     }
     return out.sort((a, b) => a.id.localeCompare(b.id));
   }
@@ -97,7 +149,7 @@ export class Repository {
   getStory(id) {
     const entry = this.stories.get(id);
     if (!entry || !entry.ok) return null;
-    return { ...entry.data, _mtime: entry.mtime };
+    return { ...entry.data, _mtime: entry.mtime, _source: entry.source ?? 'markdown', _writable: entry.path !== null };
   }
 
   getStoryFile(id) {

--- a/cli/kanban/shared/schemas.js
+++ b/cli/kanban/shared/schemas.js
@@ -86,6 +86,7 @@ export const SprintStatusSchema = z
       start_date: z.string(),
       end_date: z.string(),
       goal: z.string().default(''),
+      epic: z.string().optional().default(''),
     }),
     stories: z
       .record(

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -58,7 +58,7 @@ Replace `react` with your technology: `symfony`, `flutter`, `python`, `angular`,
 **What you should see:**
 
 ```
-  Claude Craft v8.10.2 - AI Development Framework
+  Claude Craft v8.11.0 - AI Development Framework
 
   Installing react rules to /home/user/my-project...
   [OK] Common rules installed

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -17,7 +17,7 @@ Dieser Leitfaden führt Sie durch den vollständigen Entwicklungslebenszyklus:
 7. **Deployment** – In die Produktion deployen
 
 **Voraussetzungen:**
-- Claude Craft v8.10.2 in Ihrem Projekt installiert
+- Claude Craft v8.11.0 in Ihrem Projekt installiert
 - Claude Code v2.1.159 (empfohlen) oder v2.1.97+ (Minimum, CVE-2025-59536 gepatcht)
 - Grundlegendes Verständnis Ihres gewählten Technologie-Stacks
 

--- a/docs/guides/en/10-complete-workflow.md
+++ b/docs/guides/en/10-complete-workflow.md
@@ -17,7 +17,7 @@ This guide walks you through the complete development lifecycle:
 7. **Deployment** - Ship to production
 
 **Prerequisites:**
-- Claude Craft v8.10.2 installed in your project
+- Claude Craft v8.11.0 installed in your project
 - Claude Code v2.1.159 (recommended) or v2.1.97+ (minimum, CVE-2025-59536 patched)
 - Basic understanding of your chosen technology stack
 

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -17,7 +17,7 @@ Esta guía te lleva a través del ciclo de vida de desarrollo completo:
 7. **Despliegue** - Lanza a producción
 
 **Prerequisitos:**
-- Claude Craft v8.10.2 instalado en tu proyecto
+- Claude Craft v8.11.0 instalado en tu proyecto
 - Claude Code v2.1.159 (recomendado) o v2.1.97+ (mínimo, CVE-2025-59536 parcheado)
 - Comprensión básica de tu stack tecnológico elegido
 

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -17,7 +17,7 @@ Este guia acompanha você ao longo de todo o ciclo de desenvolvimento:
 7. **Deploy** - Entregar em produção
 
 **Pré-requisitos:**
-- Claude Craft v8.10.2 instalado no seu projeto
+- Claude Craft v8.11.0 instalado no seu projeto
 - Claude Code v2.1.159 (recomendado) ou v2.1.97+ (mínimo, CVE-2025-59536 corrigido)
 - Conhecimento básico da stack de tecnologia escolhida
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.10.2",
+  "version": "8.11.0",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",

--- a/tests/fixtures/bmad-sprint-status/.bmad/sprint-status.yaml
+++ b/tests/fixtures/bmad-sprint-status/.bmad/sprint-status.yaml
@@ -1,0 +1,40 @@
+# BMAD v6 - Sprint Status (test fixture)
+# Reproduces the Wrandly case: stories tracked only in this YAML, no individual
+# markdown story files. US-100 also exists as markdown -> markdown must win.
+
+version: "1.0"
+
+metadata:
+  sprint_id: "sprint-x"
+  name: "Sprint X — Infrastructure"
+  start_date: "2026-06-11"
+  end_date: "2026-06-21"
+  goal: "Demonstrate YAML-only story ingestion."
+  epic: "E1"
+
+stories:
+  US-100:
+    title: "From YAML (should be overridden by markdown)"
+    status: "backlog"
+    previous_status: "backlog"
+    story_points: 1
+    priority: "P0"
+
+  US-E1-01:
+    title: "YAML-only story one"
+    status: "ready-for-dev"
+    previous_status: "backlog"
+    assigned_to: ""
+    story_points: 3
+    tasks:
+      total: 2
+      completed: 0
+      list:
+        - "First task"
+        - "Second task"
+
+  US-E1-02:
+    title: "YAML-only story two"
+    status: "ready-for-dev"
+    previous_status: "backlog"
+    story_points: 5

--- a/tests/fixtures/bmad-sprint-status/project-management/backlog/user-stories/US-100-existing.md
+++ b/tests/fixtures/bmad-sprint-status/project-management/backlog/user-stories/US-100-existing.md
@@ -1,0 +1,20 @@
+---
+id: US-100
+title: Markdown-backed story (wins over YAML)
+status: in-progress
+previous_status: ready-for-dev
+story_points: 8
+priority: must
+sprint_id: sprint-x
+assigned_to: alice
+tasks:
+  total: 2
+  completed: 1
+  list: [TASK-100, TASK-101]
+dependencies: []
+---
+
+# US-100
+
+This story exists as a markdown file. When the same id is also present in
+`.bmad/sprint-status.yaml`, the markdown entry must take precedence.

--- a/tests/fixtures/bmad-sprint-status/project-management/prd.md
+++ b/tests/fixtures/bmad-sprint-status/project-management/prd.md
@@ -1,0 +1,7 @@
+# PRD
+
+Minimal project-management/ used by the BMAD-v6 sprint-status ingestion fixture.
+
+This project has **no** `backlog/user-stories/US-*.md` markdown files for the YAML-only
+stories — they live exclusively in `../.bmad/sprint-status.yaml`, reproducing the
+real-world Wrandly layout that left the Kanban board empty.

--- a/tests/kanban/sprint-status-ingestion.test.js
+++ b/tests/kanban/sprint-status-ingestion.test.js
@@ -1,0 +1,105 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Repository } from '../../cli/kanban/server/services/repository.js';
+import { createApp } from '../../cli/kanban/server/app.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+// Project initialized BMAD-v6 style: stories live in ../.bmad/sprint-status.yaml.
+const FIXTURE_ROOT = path.resolve(__dirname, '../fixtures/bmad-sprint-status');
+const PM_DIR = path.join(FIXTURE_ROOT, 'project-management');
+const PORT = 3737;
+
+let repo;
+let app;
+
+beforeAll(async () => {
+  repo = new Repository(PM_DIR);
+  await repo.refresh();
+  app = createApp({ repository: repo, port: PORT, projectRoot: FIXTURE_ROOT });
+});
+
+function req(method, url, { origin, body } = {}) {
+  const headers = { 'Content-Type': 'application/json' };
+  if (origin) headers.Origin = origin;
+  return app.request(url, { method, headers, body: body ? JSON.stringify(body) : undefined });
+}
+
+describe('Repository — .bmad/sprint-status.yaml ingestion', () => {
+  it('surfaces YAML-only stories so the board is not empty', () => {
+    const stories = repo.listStories();
+    const ids = stories.map((s) => s.id).sort();
+    // US-100 (markdown) + US-E1-01 + US-E1-02 (YAML-only)
+    expect(ids).toEqual(['US-100', 'US-E1-01', 'US-E1-02']);
+  });
+
+  it('tags YAML-sourced stories as read-only and markdown stories as writable', () => {
+    const byId = Object.fromEntries(repo.listStories().map((s) => [s.id, s]));
+
+    expect(byId['US-E1-01']._source).toBe('sprint-status');
+    expect(byId['US-E1-01']._writable).toBe(false);
+    expect(byId['US-E1-01'].sprint_id).toBe('sprint-x');
+    expect(byId['US-E1-01'].status).toBe('ready-for-dev');
+    expect(byId['US-E1-01'].story_points).toBe(3);
+    expect(byId['US-E1-01'].epic_id).toBe('E1'); // from metadata.epic
+
+    expect(byId['US-100']._source).toBe('markdown');
+    expect(byId['US-100']._writable).toBe(true);
+  });
+
+  it('lets a markdown story win over a same-id YAML entry (no double source)', () => {
+    const us100 = repo.getStory('US-100');
+    // markdown title + status, not the YAML ones
+    expect(us100.title).toBe('Markdown-backed story (wins over YAML)');
+    expect(us100.status).toBe('in-progress');
+    expect(repo.getStoryFile('US-100')).not.toBeNull();
+  });
+
+  it('keeps no backing file for YAML-only stories', () => {
+    expect(repo.getStoryFile('US-E1-01')).toBeNull();
+  });
+});
+
+describe('GET /api/stories — board populated from YAML', () => {
+  it('returns the three stories', async () => {
+    const r = await req('GET', '/api/stories');
+    expect(r.status).toBe(200);
+    const { stories } = await r.json();
+    expect(stories.map((s) => s.id).sort()).toEqual(['US-100', 'US-E1-01', 'US-E1-02']);
+  });
+});
+
+describe('GET /api/sprints/current — no longer "no sprint"', () => {
+  it('returns 200 with sprint metadata, stories and burndown', async () => {
+    const r = await req('GET', '/api/sprints/current');
+    expect(r.status).toBe(200);
+    const data = await r.json();
+    expect(data.sprint.sprint_id).toBe('sprint-x');
+    expect(data.stories.map((s) => s.id).sort()).toEqual(['US-100', 'US-E1-01', 'US-E1-02']);
+    // 8 (US-100 md) + 3 + 5
+    expect(data.burndown.total_points).toBe(16);
+    expect(data.burndown.ideal.length).toBeGreaterThan(0);
+  });
+});
+
+describe('PATCH /api/stories/:id/status — read-only YAML source', () => {
+  const origin = `http://127.0.0.1:${PORT}`;
+
+  it('rejects a transition on a YAML-only story with 409 read_only_source (not a misleading 404)', async () => {
+    const r = await req('PATCH', '/api/stories/US-E1-01/status', {
+      origin,
+      body: { status: 'in-progress' },
+    });
+    expect(r.status).toBe(409);
+    const body = await r.json();
+    expect(body.error).toBe('read_only_source');
+  });
+
+  it('still returns 404 for a genuinely unknown story id', async () => {
+    const r = await req('PATCH', '/api/stories/US-999/status', {
+      origin,
+      body: { status: 'in-progress' },
+    });
+    expect(r.status).toBe(404);
+  });
+});


### PR DESCRIPTION
## Problème

Les projets initialisés **BMAD v6** (piste `team:`/`qa:`) stockent leurs stories **uniquement** dans `.bmad/sprint-status.yaml` (single-writer), jamais en fichiers markdown `backlog/user-stories/US-*.md`. Or le scanner du Kanban ne lisait que le markdown → **board vide + « no sprint »** alors que le `sprint-status.yaml` était complet (constaté sur le projet Wrandly : 8 stories `US-E0-*`, sprint `sprint-1-infrastructure`, 25 pts).

claude-craft a deux conventions de stories incohérentes : `workflow:plan` écrit `US-*.md` (lu par le Kanban), `team:`/`qa:` n'écrivent que la YAML (ignorée comme source de stories).

## Correctif (cause racine, côté outil)

`Repository` superpose désormais les stories de `.bmad/sprint-status.yaml` qui n'ont pas de fichier markdown, en **lecture seule** :
- `listStories()`/`getStory()` exposent `_source` (`markdown`|`sprint-status`) et `_writable` ;
- sur collision d'ID, le **markdown l'emporte** (pas de double source de vérité) ;
- `PATCH /api/stories/:id/status` sur une story YAML → **`409 read_only_source`** (au lieu d'un `404` trompeur) ;
- le client désactive le drag et affiche un cadenas 🔒 sur ces cartes ;
- `SprintStatusSchema.metadata` accepte le champ `epic` (auparavant supprimé par Zod).

**Hors scope** (assumé) : écriture YAML depuis le board (single-writer BMAD), reconnaissance des epics/tasks non conformes, réconciliation des deux pistes de génération.

## Tests & vérification

- TDD : fixture dédiée `tests/fixtures/bmad-sprint-status/` + **8 tests** (ingestion, précédence markdown, `/api/sprints/current`, garde-fou écriture).
- Suite complète **968/968** verte ; lint/prettier OK sur les fichiers touchés ; `npm run kanban:build` OK.
- **Run réel sur Wrandly** : `/api/stories` → 8 stories (`writable=false`), `/api/sprints/current` → 200 (`sprint-1-infrastructure`, 25 pts), `PATCH` → `409 read_only_source`.

## Release

Bundle **v8.11.0** (MINOR) : bump des stamps + CHANGELOG. Tag à créer après merge (publish NPM par la CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)