### PR TITLE
fix(ci): revert bats image pin to latest (musl/glibc broke RTK tests)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -207,21 +207,24 @@ jobs:
     name: Shell Script Tests (BATS)
     runs-on: ubuntu-latest
     needs: validate
+    # NOTE: keep `bats/bats:latest` (glibc/debian-based). Do NOT pin to a versioned
+    # alpine/musl digest (e.g. bats/bats:1.11.0): the RTK `rtk init` test installs a
+    # glibc binary that cannot execute under musl (exit 127, "required file not found").
     steps:
       - name: Checkout
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # pinned: v6.0.3
 
       - name: Run MultiAccount tests
-        run: docker run --rm -v "${{ github.workspace }}/Tools:/mnt" bats/bats:1.11.0@sha256:e8f18e0acd4ea933bf019130b85033be75e8ce081db299e93578de83d7874e33 /mnt/MultiAccount/tests/
+        run: docker run --rm -v "${{ github.workspace }}/Tools:/mnt" bats/bats:latest /mnt/MultiAccount/tests/
 
       - name: Run RTK tests
-        run: docker run --rm -v "${{ github.workspace }}/Tools:/mnt" bats/bats:1.11.0@sha256:e8f18e0acd4ea933bf019130b85033be75e8ce081db299e93578de83d7874e33 /mnt/RTK/tests/
+        run: docker run --rm -v "${{ github.workspace }}/Tools:/mnt" bats/bats:latest /mnt/RTK/tests/
 
       - name: Run StatusLine tests
-        run: docker run --rm -v "${{ github.workspace }}/Tools:/mnt" bats/bats:1.11.0@sha256:e8f18e0acd4ea933bf019130b85033be75e8ce081db299e93578de83d7874e33 /mnt/StatusLine/tests/
+        run: docker run --rm -v "${{ github.workspace }}/Tools:/mnt" bats/bats:latest /mnt/StatusLine/tests/
 
       - name: Run AgentTeams tests
-        run: docker run --rm -v "${{ github.workspace }}/Tools:/mnt" bats/bats:1.11.0@sha256:e8f18e0acd4ea933bf019130b85033be75e8ce081db299e93578de83d7874e33 /mnt/AgentTeams/tests/
+        run: docker run --rm -v "${{ github.workspace }}/Tools:/mnt" bats/bats:latest /mnt/AgentTeams/tests/
 
   publish:
     name: Publish to NPM


### PR DESCRIPTION
Le fix SEC-004 (PR #71) a épinglé `bats/bats` vers un digest versionné alpine/musl. Le test RTK (`rtk init`) installe un binaire glibc qui ne peut pas s'exécuter sous musl → `exit 127, required file not found`. Le job `bats` ne tourne qu'au push (pas en PR), donc la régression n'a surfacé qu'au merge sur main (publish NPM 8.12.0 en échec).

Revert des 4 `docker run` vers `bats/bats:latest` (glibc/debian) + commentaire anti-régression.

**Vérifié localement** : `bats/bats:latest` passe tous les tests RTK ; `bats/bats:1.11.0@digest` échoue (reproduit). Débloque la publication NPM de 8.12.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)