### PR TITLE
docs(audit): strategic follow-ups — marketplace, Helm 4, Python JIT, persistent memory

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -15,7 +15,7 @@
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.11.0",
+      "version": "8.12.0",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -50,7 +50,7 @@ Tu es un **DevOps Engineer Senior** avec 10+ ans d'expérience en CI/CD, contene
 | Docker | Multi-stage builds, BuildKit cache/secrets, distroless, SBOM | Engine 29.5.3 (CVE-2026-33997 patché, juin 2026) |
 | Docker Compose | Orchestration locale, profiles, extensions | Spec v5.0.0 "Mont Blanc" (champ `version:` obsolète) |
 | Kubernetes | Gateway API, sidecar-less (Ambient/Cilium), DRA, User Namespaces, Mutating Admission Policies | 1.36.1 stable (sortie 13 mai 2026) |
-| Helm | Charts, values, templating | Helm 4.2.0 (Helm 3 EOL sécurité nov 2026 — migrer vers Helm 4) |
+| Helm | Charts, values, templating | Helm 4.2.0 (MAJOR — server-side apply, WASM plugins, API v4 ; Helm 3 EOL sécurité nov. 2026) |
 | FrankenPHP | Worker mode (Laravel Octane/Symfony), HTTP/3, max_requests | 1.12.4 (PHP 8.5, Caddy 2.11.2, CVE-2026-45062 patché) |
 | PgBouncer | Transaction pooling, prepared statements natifs | 1.25.2 (1.21+ requis pour prepared stmts ; CVE-2026-6664/6665/6666/6667 patchées) |
 
@@ -322,6 +322,22 @@ kubectl get pods -o jsonpath='{.spec.initContainers[?(@.restartPolicy=="Always")
 - Sidecar-less : https://istio.io/latest/blog/2024/ambient-reaches-beta/  
 - Support Policy : https://endoflife.date/kubernetes  
 - K8s 1.36 : https://kubernetes.io/blog/2026/04/22/kubernetes-v1-36-release/
+
+### Helm 4 — Migration 3→4
+
+> **Helm 4 est un changement MAJEUR** : server-side apply par défaut, WASM plugins, API v4 incompatible avec Helm 3.
+> **Helm 3 EOL sécurité : novembre 2026** — recommander Helm 4 pour tout nouveau projet.
+> Pour l'existant, un double-support transitoire est possible (Helm 3 et Helm 4 coexistent).
+> Guide officiel : https://helm.sh/docs/topics/v4_migration/
+
+```bash
+# Vérifier la version Helm installée
+helm version
+
+# Migrer un chart Helm 3 vers Helm 4
+helm lint ./chart          # Détecter les incompatibilités API v4
+helm template ./chart      # Vérifier le rendu avec Helm 4
+```
 
 ### GitHub Actions
 ```yaml

--- a/.claude/references/python/coding-standards.md
+++ b/.claude/references/python/coding-standards.md
@@ -659,10 +659,11 @@ import concurrent.interpreters
 interp = concurrent.interpreters.create()
 ```
 
-### JIT expérimental (PEP 744)
+### JIT (PEP 744) — expérimental, désactivé par défaut
 
-Compilation JIT activable : `PYTHON_JIT=1 python script.py`. Gains attendus sur boucles intensives.
-Désactivé par défaut — tester avant d'activer en production.
+> **⚠ Avertissement :** le JIT est expérimental (PEP 744), désactivé par défaut, et sujet à réévaluation par le Python Steering Council avant Python 3.15 (oct. 2026). Ne pas en dépendre en production.
+
+Compilation JIT activable : `PYTHON_JIT=1 python script.py`. Gains observés sur boucles intensives en benchmarks isolés — non représentatifs en charge réelle.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+- **Marketplace** : `marketplace.json` aligné sur la version courante (8.12.0).
+- **Helm 4** : note de migration 3→4 ajoutée aux agents devops (5 langues) — major (server-side apply, plugins WASM, API v4), Helm 3 EOL sécurité nov. 2026.
+- **Python JIT** : mentions du JIT (PEP 744) reformulées en avertissement neutre (expérimental, désactivé par défaut, sujet à réévaluation du Steering Council — ne pas en dépendre en production), 5 langues.
+- **Mémoire persistante inter-sessions** : section ajoutée à `ECOSYSTEM.md` (natif `/memory` + hooks PreCompact/PostCompact ; tiers claude-mem à auditer/pinner).
+
 ## [8.12.0] - 2026-06-12
 
 Audit exhaustif multi-domaines (sécurité, ergonomie/DX, concurrentiel, fonctionnalités, fiabilité, optimisation tokens/modèles, documentation, architecture) mené par une équipe d'agents avec devil's advocates, validation Context7/web et vérification de fraîcheur des 14 stacks. 80 findings confirmés (2 P0, 22 P1, 34 P2, 22 P3) ; tous les P0/P1/P2 actionnables corrigés. Rapport : `audit/2026-06-12/00-AUDIT-REPORT.md`.

--- a/Dev/i18n/de/Common/agents/devops-engineer.md
+++ b/Dev/i18n/de/Common/agents/devops-engineer.md
@@ -31,7 +31,7 @@ Sie sind ein **Senior DevOps Engineer** mit über 10 Jahren Erfahrung in CI/CD, 
 | Docker | Multi-Stage-Builds, Image-Optimierung, Security-Scanning |
 | Docker Compose | Lokale Orchestrierung, Profiles, Extensions |
 | Kubernetes | Deployments, Services, Ingress, ConfigMaps, Secrets |
-| Helm | Charts, Values, Templating |
+| Helm | Charts, Values, Templating | 4.2.0 (MAJOR — Server-Side Apply, WASM-Plugins, API v4 ; Helm 3 Sicherheits-EOL Nov. 2026) |
 
 ### Cloud-Provider
 | Provider | Services |
@@ -123,6 +123,13 @@ kubectl describe pod <pod>
 kubectl rollout undo deployment/<name>
 kubectl rollout history deployment/<name>
 ```
+
+### Helm 4 — Migration 3→4
+
+> **Helm 4 ist ein MAJOR-Wechsel**: Server-Side Apply standardmäßig, WASM-Plugins, API v4 inkompatibel mit Helm 3.
+> **Helm 3 Sicherheits-EOL: November 2026** — Helm 4 für alle neuen Projekte empfehlen.
+> Für bestehende Projekte ist ein übergangsweiser Doppel-Support möglich (Helm 3 und Helm 4 koexistieren).
+> Offizielle Anleitung: https://helm.sh/docs/topics/v4_migration/
 
 ### GitHub Actions
 ```yaml

--- a/Dev/i18n/de/Python/rules/06-tooling.md
+++ b/Dev/i18n/de/Python/rules/06-tooling.md
@@ -1,7 +1,7 @@
 # Regel 06: Tooling
 
 > **Referenzversion:** Python **3.14 (stabil, 3.14.6+)** — Ruff 0.15+, pytest 9.x (Python 3.9 wird nicht mehr unterstützt).
-> **JIT (PEP 744):** experimentell in Python 3.14, vor der Python 3.15-Version (Okt. 2026) erneut zu bewerten. Nicht in Produktion ohne explizite Tests verwenden.
+> **⚠ JIT (PEP 744):** experimentell in Python 3.14, **standardmäßig deaktiviert**, vor Python 3.15 (Okt. 2026) durch das Python Steering Council erneut zu bewerten. Nicht in Produktion einsetzen.
 
 Python-Tooling für Codequalität, Testing und Entwicklungs-Workflow.
 

--- a/Dev/i18n/en/Common/agents/devops-engineer.md
+++ b/Dev/i18n/en/Common/agents/devops-engineer.md
@@ -41,7 +41,7 @@ You are a **Senior DevOps Engineer** with 10+ years of experience in CI/CD, cont
 | Docker | Multi-stage builds, image optimization, security scanning |
 | Docker Compose | Local orchestration, profiles, extensions |
 | Kubernetes | Deployments, Services, Ingress, ConfigMaps, Secrets |
-| Helm | Charts, values, templating |
+| Helm | Charts, values, templating | 4.2.0 (MAJOR — server-side apply, WASM plugins, API v4 ; Helm 3 EOL security Nov. 2026) |
 
 ### Cloud Providers
 | Provider | Services |
@@ -133,6 +133,13 @@ kubectl describe pod <pod>
 kubectl rollout undo deployment/<name>
 kubectl rollout history deployment/<name>
 ```
+
+### Helm 4 — Migration 3→4
+
+> **Helm 4 is a MAJOR change**: server-side apply by default, WASM plugins, API v4 incompatible with Helm 3.
+> **Helm 3 security EOL: November 2026** — recommend Helm 4 for all new projects.
+> For existing projects, transitional dual-support is possible (Helm 3 and Helm 4 coexist).
+> Official guide: https://helm.sh/docs/topics/v4_migration/
 
 ### GitHub Actions
 ```yaml

--- a/Dev/i18n/en/Python/rules/06-tooling.md
+++ b/Dev/i18n/en/Python/rules/06-tooling.md
@@ -1,7 +1,7 @@
 # Rule 06: Tooling
 
 > **Reference version:** Python **3.14 (stable, 3.14.6+)** — Ruff 0.15+, pytest 9.x (drops Python 3.9).
-> **JIT (PEP 744):** experimental in Python 3.14, subject to re-evaluation before Python 3.15 release (oct. 2026). Do not rely on it in production unless explicitly tested.
+> **⚠ JIT (PEP 744):** experimental in Python 3.14, **disabled by default**, subject to re-evaluation by the Python Steering Council before Python 3.15 (Oct. 2026). Do not rely on it in production.
 
 Python tooling for code quality, testing, and development workflow.
 

--- a/Dev/i18n/es/Common/agents/devops-engineer.md
+++ b/Dev/i18n/es/Common/agents/devops-engineer.md
@@ -31,7 +31,7 @@ Eres un **Ingeniero DevOps Senior** con más de 10 años de experiencia en CI/CD
 | Docker | Builds multi-etapa, optimización de imágenes, escaneo de seguridad |
 | Docker Compose | Orquestación local, perfiles, extensiones |
 | Kubernetes | Deployments, Services, Ingress, ConfigMaps, Secrets |
-| Helm | Charts, values, templating |
+| Helm | Charts, values, templating | 4.2.0 (MAJOR — server-side apply, WASM plugins, API v4 ; Helm 3 EOL seguridad nov. 2026) |
 
 ### Proveedores Cloud
 | Proveedor | Servicios |
@@ -123,6 +123,13 @@ kubectl describe pod <pod>
 kubectl rollout undo deployment/<name>
 kubectl rollout history deployment/<name>
 ```
+
+### Helm 4 — Migración 3→4
+
+> **Helm 4 es un cambio MAYOR**: server-side apply por defecto, plugins WASM, API v4 incompatible con Helm 3.
+> **Helm 3 EOL seguridad: noviembre 2026** — recomendar Helm 4 para todos los proyectos nuevos.
+> Para proyectos existentes, el soporte dual transitorio es posible (Helm 3 y Helm 4 coexisten).
+> Guía oficial: https://helm.sh/docs/topics/v4_migration/
 
 ### GitHub Actions
 ```yaml

--- a/Dev/i18n/es/Python/rules/06-tooling.md
+++ b/Dev/i18n/es/Python/rules/06-tooling.md
@@ -1,7 +1,7 @@
 # Regla 06: Herramientas
 
 > **Versión de referencia:** Python **3.14 (estable, 3.14.6+)** — Ruff 0.15+, pytest 9.x (elimina soporte Python 3.9).
-> **JIT (PEP 744):** experimental en Python 3.14, sujeto a reevaluación antes del lanzamiento de Python 3.15 (oct. 2026). No usar en producción sin pruebas explícitas.
+> **⚠ JIT (PEP 744):** experimental en Python 3.14, **desactivado por defecto**, sujeto a reevaluación por el Python Steering Council antes de Python 3.15 (oct. 2026). No depender de él en producción.
 
 Herramientas de Python para calidad de código, pruebas y flujo de trabajo de desarrollo.
 

--- a/Dev/i18n/fr/Common/agents/devops-engineer.md
+++ b/Dev/i18n/fr/Common/agents/devops-engineer.md
@@ -31,7 +31,7 @@ Tu es un **DevOps Engineer Senior** avec 10+ ans d'expérience en CI/CD, contene
 | Docker | Multi-stage builds, optimisation images, security scanning |
 | Docker Compose | Orchestration locale, profiles, extensions |
 | Kubernetes | Deployments, Services, Ingress, ConfigMaps, Secrets |
-| Helm | Charts, values, templating |
+| Helm | Charts, values, templating | 4.2.0 (MAJOR — server-side apply, WASM plugins, API v4 ; Helm 3 EOL sécurité nov. 2026) |
 
 ### Cloud Providers
 | Provider | Services |
@@ -123,6 +123,13 @@ kubectl describe pod <pod>
 kubectl rollout undo deployment/<name>
 kubectl rollout history deployment/<name>
 ```
+
+### Helm 4 — Migration 3→4
+
+> **Helm 4 est un changement MAJEUR** : server-side apply par défaut, WASM plugins, API v4 incompatible avec Helm 3.
+> **Helm 3 EOL sécurité : novembre 2026** — recommander Helm 4 pour tout nouveau projet.
+> Pour l'existant, un double-support transitoire est possible (Helm 3 et Helm 4 coexistent).
+> Guide officiel : https://helm.sh/docs/topics/v4_migration/
 
 ### GitHub Actions
 ```yaml

--- a/Dev/i18n/fr/Python/rules/06-tooling.md
+++ b/Dev/i18n/fr/Python/rules/06-tooling.md
@@ -1,7 +1,7 @@
 # Outils de Développement Python
 
 > **Version de référence :** Python **3.14 (stable, 3.14.6+)** — Ruff 0.15+, pytest 9.x (fin du support Python 3.9).
-> **JIT (PEP 744) :** expérimental en Python 3.14, sujet à réévaluation avant la sortie de Python 3.15 (oct. 2026). Ne pas utiliser en production sans tests explicites.
+> **⚠ JIT (PEP 744) :** expérimental en Python 3.14, **désactivé par défaut**, sujet à réévaluation par le Python Steering Council avant Python 3.15 (oct. 2026). Ne pas en dépendre en production.
 
 ## Package Management
 

--- a/Dev/i18n/pt/Common/agents/devops-engineer.md
+++ b/Dev/i18n/pt/Common/agents/devops-engineer.md
@@ -31,7 +31,7 @@ Você é um **Engenheiro DevOps Sênior** com mais de 10 anos de experiência em
 | Docker | Multi-stage builds, otimização de imagem, security scanning |
 | Docker Compose | Orquestração local, profiles, extensions |
 | Kubernetes | Deployments, Services, Ingress, ConfigMaps, Secrets |
-| Helm | Charts, values, templating |
+| Helm | Charts, values, templating | 4.2.0 (MAJOR — server-side apply, plugins WASM, API v4 ; Helm 3 EOL segurança nov. 2026) |
 
 ### Provedores de Nuvem
 | Provedor | Serviços |
@@ -123,6 +123,13 @@ kubectl describe pod <pod>
 kubectl rollout undo deployment/<name>
 kubectl rollout history deployment/<name>
 ```
+
+### Helm 4 — Migração 3→4
+
+> **Helm 4 é uma mudança MAJOR**: server-side apply por padrão, plugins WASM, API v4 incompatível com Helm 3.
+> **Helm 3 EOL segurança: novembro 2026** — recomendar Helm 4 para todos os novos projetos.
+> Para projetos existentes, suporte dual transitório é possível (Helm 3 e Helm 4 coexistem).
+> Guia oficial: https://helm.sh/docs/topics/v4_migration/
 
 ### GitHub Actions
 ```yaml

--- a/Dev/i18n/pt/Python/rules/06-tooling.md
+++ b/Dev/i18n/pt/Python/rules/06-tooling.md
@@ -1,7 +1,7 @@
 # Regra 06: Ferramentas
 
 > **Versão de referência:** Python **3.14 (estável, 3.14.6+)** — Ruff 0.15+, pytest 9.x (remove suporte ao Python 3.9).
-> **JIT (PEP 744):** experimental no Python 3.14, sujeito a reavaliação antes do lançamento do Python 3.15 (out. 2026). Não usar em produção sem testes explícitos.
+> **⚠ JIT (PEP 744):** experimental no Python 3.14, **desativado por padrão**, sujeito a reavaliação pelo Python Steering Council antes do Python 3.15 (out. 2026). Não depender em produção.
 
 Ferramentas Python para qualidade de código, testes e fluxo de desenvolvimento.
 

--- a/docs/COMPETITIVE-ANALYSIS.md
+++ b/docs/COMPETITIVE-ANALYSIS.md
@@ -35,7 +35,7 @@ Orchestration **multi-modèle** : route les sous-agents vers Claude, Gemini CLI 
 
 ### Ruflo (~59k ★)
 
-Mémoire persistante inter-sessions via indexation vectorielle. Claude Craft gère la mémoire via `/memory` (natif Claude Code v2.1.59+) et les hooks `PostCompact` — pas de vectorDB. Ruflo est positionné comme **moteur complémentaire** documenté dans `docs/ECOSYSTEM.md`. Voir `DIFF-04` dans la roadmap.
+Mémoire persistante inter-sessions via indexation vectorielle. Claude Craft gère la mémoire via `/memory` (natif Claude Code v2.1.59+) et les hooks `PostCompact` — pas de vectorDB. Ruflo est positionné comme **moteur complémentaire** documenté dans `docs/ECOSYSTEM.md` (section « Mémoire persistante inter-sessions »). Voir `DIFF-04` dans la roadmap.
 
 ### GitHub Spec Kit (~80k ★)
 

--- a/docs/ECOSYSTEM.md
+++ b/docs/ECOSYSTEM.md
@@ -150,6 +150,92 @@ The two tools are **complementary**, not competing: oh-my-claudecode provides th
 
 ---
 
+## Mémoire persistante inter-sessions
+
+La mémoire inter-sessions — conserver les décisions d'architecture, les ADR, l'état du sprint et les
+conventions entre deux conversations Claude Code — est couverte à trois niveaux : natif, hooks, et
+tiers. Aucun des trois n'est mutuellement exclusif.
+
+### Natif : `/memory` + hooks PreCompact / PostCompact
+
+Claude Code v2.1.59+ expose la commande **`/memory`** : les apprentissages saisis sont persistés dans
+un fichier `MEMORY.md` rattaché au profil de projet et rechargés à chaque session. C'est le point
+d'entrée recommandé pour les décisions non urgentes (style, conventions, contexte métier).
+
+Pour les décisions critiques qui ne doivent pas disparaître lors d'une compaction automatique, Claude
+Craft distribue deux hooks complémentaires (dossier [`.claude/templates/hooks/`](../.claude/templates/hooks/)) :
+
+| Hook | Fichier template | Rôle |
+|------|-----------------|------|
+| **PreCompact** | `pre-compact.json` | Injecte `.claude/context-essentials.md` comme `systemMessage` juste _avant_ la compaction (peut bloquer via exit code 2 depuis v2.1.105). |
+| **PostCompact** | `post-compact.json` | Ré-injecte le même fichier immédiatement _après_ la compaction (v2.1.76+). |
+| **SessionStart** (matcher `compact`) | `context-reinject.json` | Repli pour les éditeurs qui ne déclenchent pas PostCompact : ré-injecte à chaque démarrage post-compaction. |
+
+**Pattern recommandé pour BMAD / ADR :**
+
+1. Créer `.claude/context-essentials.md` à la racine du projet (gitignored ou commité selon l'équipe).
+2. Y consigner les sections : Architecture, Conventions, Sprint actif, Contraintes critiques, ADR.
+3. Copier `post-compact.json` dans `.claude/settings.json` (hooks projet) ou `~/.claude/settings.json`
+   (hooks globaux).
+4. Optionnel : ajouter également `pre-compact.json` pour couvrir la fenêtre _pendant_ la compaction.
+
+Le fichier `context-essentials.md` devient le canal canonique de persistance : il est lu par les hooks,
+re-injecté automatiquement, et peut être édité manuellement ou par `/memory` (les deux coexistent).
+
+> **Compatibilité :** `/memory` ≥ v2.1.59 · PostCompact ≥ v2.1.76 · PreCompact exit-code-2 ≥ v2.1.105.
+> Vérifier avec `claude --version` avant d'activer PostCompact.
+
+### Tiers : claude-mem
+
+**[claude-mem](https://github.com/punkpeye/claude-mem)** (~MIT, statut à vérifier avant usage) est un
+serveur MCP open-source qui expose une interface mémoire inter-sessions via un stockage local structuré.
+Il propose des opérations `memory_add` / `memory_search` / `memory_list` utilisables depuis les
+instructions d'un agent ou d'une commande.
+
+| Aspect | Détail |
+|--------|--------|
+| Licence | MIT (auditer la version avant de pinner — règle 11) |
+| Stockage | Fichier JSON local (pas de vectorDB) |
+| Intégration | Serveur MCP `.mcp.json` |
+| Complémentarité | Couvre les requêtes de mémoire _explicites_ depuis les agents ; les hooks natifs couvrent la persistance _automatique_ autour des compactions. |
+
+```jsonc
+// .mcp.json — à auditer et pinner avant activation
+{
+  "mcpServers": {
+    "claude-mem": {
+      "command": "npx",
+      "args": ["-y", "claude-mem@<version-exacte>"]
+    }
+  }
+}
+```
+
+> **Sécurité avant activation :** auditer le code source, pinner une version exacte (jamais `latest`),
+> accorder uniquement les permissions nécessaires — voir [`.claude/rules/11-security.md`](../.claude/rules/11-security.md).
+
+### Ruflo (~59k ★, mémoire vectorielle)
+
+**Ruflo** ([repo](https://github.com/ruflo/ruflo), licence à vérifier) opte pour une **indexation
+vectorielle** : chaque session est indexée, et les sessions suivantes récupèrent par similarité
+sémantique les contextes pertinents. C'est la seule approche qui scale sur des historiques longs (des
+centaines de sessions).
+
+Claude Craft ne l'intègre pas nativement car elle introduit une dépendance externe (base vectorielle),
+mais elle est documentée ici comme option complémentaire pour les équipes à fort volume de sessions.
+Voir aussi `DIFF-04` dans [`docs/ROADMAP.md`](ROADMAP.md).
+
+### Tableau de décision
+
+| Besoin | Approche recommandée |
+|--------|---------------------|
+| Conserver conventions / ADR entre sessions | `/memory` natif + `context-essentials.md` |
+| Survivre aux compactions automatiques | Hooks `PreCompact` + `PostCompact` (templates intégrés) |
+| Mémoire _explicite_ depuis un agent | claude-mem (MCP, MIT, à pinner) |
+| Historique long > 100 sessions, recherche sémantique | Ruflo (vectorDB, évaluer licence) |
+
+---
+
 ## Also worth watching (from the 2026 roundup)
 
 Not evaluated in depth here, but flagged for future integration assessment:


### PR DESCRIPTION
Items hors-code de l'audit 2026-06-12 (section 8 « décision humaine »), validés avec toi.

- **Marketplace** : `marketplace.json` aligné sur 8.12.0. Les changements de `$schema`/enum proposés par l'agent ont été **écartés** (URL `anthropic.com/...` → 404, enums non vérifiables) ; conservé uniquement le bump de version vérifié. Conformité au schéma à confirmer avec `claude plugin validate` côté humain avant soumission.
- **Helm 3→4** : note de migration ajoutée aux agents devops (5 langues) — major (server-side apply par défaut, plugins WASM, API v4), Helm 3 EOL sécurité nov. 2026, double-support transitoire recommandé.
- **Python JIT (PEP 744)** : reformulé en avertissement neutre (expérimental, désactivé par défaut, sujet à réévaluation du Steering Council — ne pas en dépendre en production), 5 langues. `free-threading` (stable) non touché.
- **Mémoire persistante inter-sessions** : section ajoutée à `ECOSYSTEM.md` (natif `/memory` + hooks PreCompact/PostCompact + `.claude/context-essentials.md` ; tiers `claude-mem` à auditer/pinner — règle 11).

**Prépa awesome-claude-code** : entrée + checklist de PR dans `audit/2026-06-12/awesome-claude-code-submission.md` (local, gitignored) — action de soumission humaine.

Docs/manifest uniquement, pas de bump de version runtime (8.12.0 inchangé). Gates : i18n parité, verify-versions, verify-includes, content tests (90) — verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)