### PR TITLE
fix(bmad): /gate:* set -e ((var++)) abort + ship AgentTeams scripts to projects

### DIFF
--- a/.bmad/hooks/quality-gate.sh
+++ b/.bmad/hooks/quality-gate.sh
@@ -79,13 +79,13 @@ tasks_completed=$(yq ".stories.${story_id}.tasks.completed // 0" "$SPRINT_STATUS
 if [[ "$tasks_total" -gt 0 ]]; then
     if [[ "$tasks_completed" -lt "$tasks_total" ]]; then
         echo -e "${YELLOW}⚠️ Tasks incomplete: $tasks_completed/$tasks_total${NC}"
-        ((warnings++))
+        warnings=$((warnings + 1))
     else
         echo -e "${GREEN}✅ Tasks complete: $tasks_completed/$tasks_total${NC}"
     fi
 else
     echo -e "${YELLOW}⚠️ No tasks defined${NC}"
-    ((warnings++))
+    warnings=$((warnings + 1))
 fi
 
 # Check 2: TDD phase
@@ -97,15 +97,15 @@ case "$tdd_phase" in
         ;;
     "green")
         echo -e "${YELLOW}⚠️ TDD in green phase - consider refactoring${NC}"
-        ((warnings++))
+        warnings=$((warnings + 1))
         ;;
     "red")
         echo -e "${RED}❌ TDD in red phase - tests should pass first${NC}"
-        ((errors++))
+        errors=$((errors + 1))
         ;;
     *)
         echo -e "${YELLOW}⚠️ TDD phase not set${NC}"
-        ((warnings++))
+        warnings=$((warnings + 1))
         ;;
 esac
 
@@ -116,13 +116,13 @@ ac_validated=$(yq ".stories.${story_id}.acceptance_criteria.validated // 0" "$SP
 if [[ "$ac_total" -gt 0 ]]; then
     if [[ "$ac_validated" -lt "$ac_total" ]]; then
         echo -e "${YELLOW}⚠️ AC not validated: $ac_validated/$ac_total${NC}"
-        ((warnings++))
+        warnings=$((warnings + 1))
     else
         echo -e "${GREEN}✅ All AC validated: $ac_validated/$ac_total${NC}"
     fi
 else
     echo -e "${YELLOW}⚠️ No acceptance criteria defined${NC}"
-    ((warnings++))
+    warnings=$((warnings + 1))
 fi
 
 # Check 4: Blocked status
@@ -130,7 +130,7 @@ blocked_reason=$(yq ".stories.${story_id}.blocked_reason // \"\"" "$SPRINT_STATU
 
 if [[ -n "$blocked_reason" && "$blocked_reason" != "null" ]]; then
     echo -e "${RED}❌ Story is blocked: $blocked_reason${NC}"
-    ((errors++))
+    errors=$((errors + 1))
 else
     echo -e "${GREEN}✅ No blockers${NC}"
 fi

--- a/.bmad/lib/batch-executor.sh
+++ b/.bmad/lib/batch-executor.sh
@@ -109,7 +109,7 @@ merge_worker_reports() {
 
         if [[ "$dry_run" == "true" ]]; then
             log_info "DRY RUN - Would merge: worker=$worker_id story=$story_id status=$status"
-            ((merged_count++))
+            merged_count=$((merged_count + 1))
             continue
         fi
 
@@ -143,7 +143,7 @@ merge_worker_reports() {
 
         # Remove processed report
         rm -f "$report_file"
-        ((merged_count++))
+        merged_count=$((merged_count + 1))
     done
 
     if [[ "$dry_run" == "true" ]]; then
@@ -318,7 +318,7 @@ run_epic() {
         if [[ "$dry_run" != "true" ]]; then
             add_to_queue "$story_id" "$priority"
         fi
-        ((priority++))
+        priority=$((priority + 1))
     done
 
     if [[ "$dry_run" == "true" ]]; then
@@ -626,7 +626,7 @@ process_queue_autonomous() {
             for pid in "${!active_pids[@]}"; do
                 if ! kill -0 "$pid" 2>/dev/null; then
                     unset "active_pids[$pid]"
-                    ((active_count--))
+                    active_count=$((active_count - 1))
                 fi
             done
             sleep 2
@@ -658,7 +658,7 @@ process_queue_autonomous() {
                 fi
             ) &
             active_pids[$!]="$story_id"
-            ((active_count++))
+            active_count=$((active_count + 1))
         else
             # Sequential processing - leader writes directly (no race condition)
             if spawn_ralph_for_story "$story_id"; then
@@ -737,7 +737,7 @@ run_sprint() {
     for story_id in $stories; do
         local title=$(yq ".stories.${story_id}.title" "$SPRINT_STATUS_FILE")
         local points=$(yq ".stories.${story_id}.story_points // 0" "$SPRINT_STATUS_FILE")
-        ((count++))
+        count=$((count + 1))
 
         echo "[$count] $story_id: $title ($points pts)"
 

--- a/.bmad/lib/gate-validator.sh
+++ b/.bmad/lib/gate-validator.sh
@@ -71,7 +71,7 @@ validate_prd() {
     # Check 1: Problem statement
     if echo "$content" | grep -qi "problem\|challenge\|issue"; then
         log_success "Problem statement defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing problem statement"
     fi
@@ -79,7 +79,7 @@ validate_prd() {
     # Check 2: Target users
     if echo "$content" | grep -qi "user\|persona\|customer\|target"; then
         log_success "Target users defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing target users"
     fi
@@ -87,7 +87,7 @@ validate_prd() {
     # Check 3: Goals/Objectives
     if echo "$content" | grep -qi "goal\|objective\|aim"; then
         log_success "Goals/objectives defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing goals/objectives"
     fi
@@ -95,7 +95,7 @@ validate_prd() {
     # Check 4: Success metrics
     if echo "$content" | grep -qi "metric\|kpi\|measure\|success"; then
         log_success "Success metrics defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing success metrics"
     fi
@@ -103,7 +103,7 @@ validate_prd() {
     # Check 5: Scope defined
     if echo "$content" | grep -qi "scope\|boundary\|limitation"; then
         log_success "Scope defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing scope definition"
     fi
@@ -111,7 +111,7 @@ validate_prd() {
     # Check 6: User stories overview
     if echo "$content" | grep -qiE "(user stor|US-|epic)"; then
         log_success "User stories overview present"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing user stories overview"
     fi
@@ -119,7 +119,7 @@ validate_prd() {
     # Check 7: Assumptions documented
     if echo "$content" | grep -qi "assumption\|assume"; then
         log_success "Assumptions documented"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "Missing assumptions"
     fi
@@ -127,7 +127,7 @@ validate_prd() {
     # Check 8: Risks identified
     if echo "$content" | grep -qi "risk\|mitigation"; then
         log_success "Risks identified"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "Missing risk assessment"
     fi
@@ -178,7 +178,7 @@ validate_techspec() {
     # Check 1: Architecture overview
     if echo "$content" | grep -qi "architecture\|design\|structure"; then
         log_success "Architecture overview present"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing architecture overview"
     fi
@@ -186,7 +186,7 @@ validate_techspec() {
     # Check 2: Component diagram (mermaid or image)
     if echo "$content" | grep -qiE "(mermaid|diagram|\.png|\.svg|graph)"; then
         log_success "Architecture diagram present"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing architecture diagram"
     fi
@@ -194,7 +194,7 @@ validate_techspec() {
     # Check 3: Data model
     if echo "$content" | grep -qi "data\|model\|entity\|schema\|table"; then
         log_success "Data model defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing data model"
     fi
@@ -202,7 +202,7 @@ validate_techspec() {
     # Check 4: API contracts
     if echo "$content" | grep -qiE "(api|endpoint|rest|graphql|grpc)"; then
         log_success "API contracts defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing API contracts"
     fi
@@ -210,7 +210,7 @@ validate_techspec() {
     # Check 5: Security considerations
     if echo "$content" | grep -qi "security\|auth\|encrypt\|permission"; then
         log_success "Security considerations addressed"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing security considerations"
     fi
@@ -218,7 +218,7 @@ validate_techspec() {
     # Check 6: Performance requirements
     if echo "$content" | grep -qi "performance\|latency\|throughput\|scale"; then
         log_success "Performance requirements defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "Missing performance requirements"
     fi
@@ -226,7 +226,7 @@ validate_techspec() {
     # Check 7: Error handling
     if echo "$content" | grep -qi "error\|exception\|handling\|failure"; then
         log_success "Error handling strategy defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "Missing error handling strategy"
     fi
@@ -234,7 +234,7 @@ validate_techspec() {
     # Check 8: Testing strategy
     if echo "$content" | grep -qi "test\|quality\|coverage"; then
         log_success "Testing strategy defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Missing testing strategy"
     fi
@@ -242,7 +242,7 @@ validate_techspec() {
     # Check 9: Deployment strategy
     if echo "$content" | grep -qi "deploy\|ci\|cd\|release"; then
         log_success "Deployment strategy defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "Missing deployment strategy"
     fi
@@ -250,7 +250,7 @@ validate_techspec() {
     # Check 10: Dependencies explicit
     if echo "$content" | grep -qi "dependency\|depend\|require\|integration"; then
         log_success "Dependencies documented"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "Missing dependency documentation"
     fi
@@ -302,7 +302,7 @@ validate_backlog_story() {
     local blocked_by=$(yq ".stories.${story_id}.blocked_by // []" "$SPRINT_STATUS_FILE" 2>/dev/null)
     if [[ "$blocked_by" == "[]" || -z "$blocked_by" ]]; then
         log_success "  [I] Independent: No blocking dependencies"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "  [I] Independent: Has dependencies"
     fi
@@ -311,7 +311,7 @@ validate_backlog_story() {
     local title=$(yq ".stories.${story_id}.title // \"\"" "$SPRINT_STATUS_FILE" 2>/dev/null)
     if [[ -n "$title" && ${#title} -gt 10 ]]; then
         log_success "  [N] Negotiable: Has description"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "  [N] Negotiable: Missing/short description"
     fi
@@ -320,7 +320,7 @@ validate_backlog_story() {
     local ac_total=$(yq ".stories.${story_id}.acceptance_criteria.total // 0" "$SPRINT_STATUS_FILE" 2>/dev/null)
     if [[ "$ac_total" -gt 0 ]]; then
         log_success "  [V] Valuable: Has $ac_total acceptance criteria"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "  [V] Valuable: No acceptance criteria"
     fi
@@ -329,7 +329,7 @@ validate_backlog_story() {
     local points=$(yq ".stories.${story_id}.story_points // 0" "$SPRINT_STATUS_FILE" 2>/dev/null)
     if [[ "$points" -gt 0 ]]; then
         log_success "  [E] Estimable: $points story points"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "  [E] Estimable: No story points"
     fi
@@ -337,7 +337,7 @@ validate_backlog_story() {
     # Small: <= 8 points
     if [[ "$points" -le 8 ]]; then
         log_success "  [S] Small: $points points (≤8)"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "  [S] Small: $points points (>8, consider splitting)"
     fi
@@ -345,7 +345,7 @@ validate_backlog_story() {
     # Testable: Has acceptance criteria
     if [[ "$ac_total" -gt 0 ]]; then
         log_success "  [T] Testable: Has testable criteria"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "  [T] Testable: No testable criteria"
     fi
@@ -372,10 +372,10 @@ validate_backlog() {
     local passing_stories=0
 
     for story_id in $stories; do
-        ((total_stories++))
+        total_stories=$((total_stories + 1))
         echo ""
         if validate_backlog_story "$story_id"; then
-            ((passing_stories++))
+            passing_stories=$((passing_stories + 1))
         fi
     done
 
@@ -422,7 +422,7 @@ validate_story_complete() {
 
     if [[ "$tasks_total" -gt 0 && "$tasks_completed" -eq "$tasks_total" ]]; then
         log_success "All tasks completed ($tasks_completed/$tasks_total)"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Tasks incomplete ($tasks_completed/$tasks_total)"
     fi
@@ -433,7 +433,7 @@ validate_story_complete() {
 
     if [[ "$ac_total" -gt 0 && "$ac_validated" -eq "$ac_total" ]]; then
         log_success "All acceptance criteria validated ($ac_validated/$ac_total)"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Acceptance criteria not validated ($ac_validated/$ac_total)"
     fi
@@ -443,7 +443,7 @@ validate_story_complete() {
 
     if [[ "$tdd_phase" == "refactor" || "$tdd_phase" == "done" ]]; then
         log_success "TDD cycle complete ($tdd_phase)"
-        ((score++))
+        score=$((score + 1))
     else
         log_warning "TDD cycle not complete ($tdd_phase)"
     fi
@@ -453,7 +453,7 @@ validate_story_complete() {
 
     if [[ "$status" == "review" || "$status" == "done" ]]; then
         log_success "Code review completed"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Code review pending"
     fi
@@ -463,7 +463,7 @@ validate_story_complete() {
 
     if [[ -z "$blocked_reason" ]]; then
         log_success "No blockers"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Story blocked: $blocked_reason"
     fi
@@ -513,7 +513,7 @@ validate_sprint_ready() {
     # Check 1: Sprint metadata
     if [[ -n "$has_sprint_id" && "$has_sprint_id" != "null" ]]; then
         log_success "Sprint ID defined: $has_sprint_id"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Sprint ID not defined"
     fi
@@ -521,7 +521,7 @@ validate_sprint_ready() {
     # Check 2: Sprint dates
     if [[ -n "$has_dates" && "$has_dates" != "null" ]]; then
         log_success "Sprint dates defined"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "Sprint dates not defined"
     fi
@@ -529,7 +529,7 @@ validate_sprint_ready() {
     # Check 3: Stories ready
     if [[ "$ready_stories" -gt 0 ]]; then
         log_success "$ready_stories stories ready for development"
-        ((score++))
+        score=$((score + 1))
     else
         log_error "No stories in 'ready-for-dev' status"
     fi

--- a/.bmad/lib/routing-engine.sh
+++ b/.bmad/lib/routing-engine.sh
@@ -268,14 +268,14 @@ cmd_auto_route() {
         if [[ "$status" == "in-progress" && "$tasks_total" -gt 0 && "$tasks_completed" -eq "$tasks_total" ]]; then
             log_info "Auto-transitioning $story_id to review (all tasks complete)"
             cmd_transition "$story_id" "review"
-            ((changes++))
+            changes=$((changes + 1))
         fi
 
         # Rule: blocked_detection
         if [[ "$status" != "blocked" && -n "$blocked_reason" ]]; then
             log_info "Auto-transitioning $story_id to blocked (blocker detected)"
             cmd_transition "$story_id" "blocked"
-            ((changes++))
+            changes=$((changes + 1))
         fi
 
         # Rule: unblocked
@@ -283,7 +283,7 @@ cmd_auto_route() {
             local previous=$(yq ".stories.${story_id}.previous_status // \"backlog\"" "$SPRINT_STATUS_FILE")
             log_info "Auto-transitioning $story_id to $previous (unblocked)"
             cmd_transition "$story_id" "$previous"
-            ((changes++))
+            changes=$((changes + 1))
         fi
     done
 
@@ -496,7 +496,7 @@ cmd_auto_route_autonomous() {
         if [[ "$status" == "in-progress" && "$tasks_total" -gt 0 && "$tasks_completed" -eq "$tasks_total" ]]; then
             log_info "Auto-transitioning $story_id to review (all tasks complete)"
             cmd_transition "$story_id" "review"
-            ((changes++))
+            changes=$((changes + 1))
             continue
         fi
 
@@ -504,7 +504,7 @@ cmd_auto_route_autonomous() {
         if [[ "$status" != "blocked" && -n "$blocked_reason" ]]; then
             log_info "Auto-transitioning $story_id to blocked (blocker detected)"
             cmd_transition "$story_id" "blocked"
-            ((changes++))
+            changes=$((changes + 1))
             continue
         fi
 
@@ -513,14 +513,14 @@ cmd_auto_route_autonomous() {
             local previous=$(yq ".stories.${story_id}.previous_status // \"backlog\"" "$SPRINT_STATUS_FILE")
             log_info "Auto-transitioning $story_id to $previous (unblocked)"
             cmd_transition "$story_id" "$previous"
-            ((changes++))
+            changes=$((changes + 1))
             continue
         fi
 
         # Autonomous rule: TDD completion check
         if [[ "$status" == "in-progress" ]]; then
             if cmd_auto_transition_check "$story_id"; then
-                ((changes++))
+                changes=$((changes + 1))
             fi
         fi
     done

--- a/.bmad/tests/gate-validator.bats
+++ b/.bmad/tests/gate-validator.bats
@@ -1,0 +1,129 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Regression tests for .bmad/lib/gate-validator.sh
+#
+# Reproduces the Wrandly bug: `set -euo pipefail` + `((score++))`. In bash,
+# `((score++))` evaluates the OLD value, so when score == 0 the expression
+# returns exit code 1, and under `set -e` the script ABORTS after the first
+# check. Symptom: every /gate:* command dies after validating one item.
+#
+# Before the fix these behavioral tests are RED (script exits non-zero, no
+# PASS line). After converting `((score++))` -> `score=$((score + 1))` they
+# are GREEN.
+#
+# Run: docker run --rm -v "$(pwd):/mnt" bats/bats:latest /mnt/.bmad/tests/
+# =============================================================================
+
+BMAD_DIR="$(cd "$(dirname "$BATS_TEST_FILENAME")/.." && pwd)"
+VALIDATOR="$BMAD_DIR/lib/gate-validator.sh"
+
+# Build a PRD that satisfies all 8 validate_prd() checks.
+write_complete_prd() {
+    cat > "$1" <<'EOF'
+# Product Requirements Document
+
+## Problem statement
+The current challenge / issue is X.
+
+## Target users
+Personas: the customer / target user.
+
+## Goals and objectives
+Our goal / objective / aim is Y.
+
+## Success metrics
+KPI and metric to measure success.
+
+## Scope
+In scope and out of scope boundary / limitation.
+
+## User stories
+Epic overview: US-001 user story list.
+
+## Assumptions
+We assume / assumption Z holds.
+
+## Risks
+Risk and mitigation identified.
+EOF
+}
+
+# Build a tech-spec that satisfies all 10 validate_techspec() checks.
+write_complete_techspec() {
+    cat > "$1" <<'EOF'
+# Technical Specification
+
+## Architecture
+System architecture / design / structure overview.
+
+## Diagram
+```mermaid
+graph TD; A-->B;
+```
+
+## Data model
+Entity / schema / table data model.
+
+## API contracts
+REST api endpoint and graphql contracts.
+
+## Security
+Auth, encryption and permission security considerations.
+
+## Performance
+Latency, throughput and scale performance requirements.
+
+## Error handling
+Exception / failure handling strategy.
+
+## Testing strategy
+Test coverage and quality strategy.
+
+## Deployment
+CI / CD release / deploy strategy.
+
+## Dependencies
+External dependency / require / integration documented.
+EOF
+}
+
+@test "validate_prd runs ALL checks without aborting (set -e + ((score++)) regression)" {
+    prd="$BATS_TEST_TMPDIR/prd.md"
+    write_complete_prd "$prd"
+
+    run bash "$VALIDATOR" prd "$prd"
+
+    # Before fix: aborts at first ((score++)) -> status != 0, no final PASS.
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+    [[ "$output" == *"Score: 8/8"* ]]
+    [[ "$output" == *"PRD Gate PASSED"* ]]
+}
+
+@test "validate_techspec runs ALL checks without aborting" {
+    spec="$BATS_TEST_TMPDIR/tech-spec.md"
+    write_complete_techspec "$spec"
+
+    run bash "$VALIDATOR" techspec "$spec"
+
+    [ "$status" -eq 0 ]
+    [[ "$output" == *"PASS"* ]]
+    [[ "$output" == *"Score: 10/10"* ]]
+    [[ "$output" == *"Tech Spec Gate PASSED"* ]]
+}
+
+@test "validate_prd reaches the final score line even on a partial PRD" {
+    # A PRD missing some sections must still REACH the verdict (FAIL), not die mid-way.
+    prd="$BATS_TEST_TMPDIR/partial.md"
+    cat > "$prd" <<'EOF'
+# PRD
+## Problem
+There is a problem here.
+EOF
+
+    run bash "$VALIDATOR" prd "$prd"
+
+    # Verdict reached (script did not abort) -> output carries the Score line.
+    [[ "$output" == *"Score:"* ]]
+    [[ "$output" == *"FAIL"* ]]
+}

--- a/.bmad/tests/no-bare-arith-increment.bats
+++ b/.bmad/tests/no-bare-arith-increment.bats
@@ -1,0 +1,49 @@
+#!/usr/bin/env bats
+# =============================================================================
+# Static anti-regression guard: no bare `((var++))` / `((var--))` under set -e.
+#
+# `set -euo pipefail` + a standalone `((var++))` is a latent abort: the
+# post-increment returns exit code 1 when the variable is 0 (or the pre-value
+# is 0), killing the script. The safe form is `var=$((var + 1))` (or, if the
+# command form is required, `((var++)) || true`).
+#
+# This test FAILS if any targeted `set -e` script reintroduces the unguarded
+# command form. C-style `for ((i=0; i<n; i++))` loops are NOT matched (the
+# `((` is not immediately followed by `var++))`).
+#
+# Run: docker run --rm -v "$(pwd):/mnt" bats/bats:latest /mnt/.bmad/tests/
+# =============================================================================
+
+REPO_ROOT="$(cd "$(dirname "$BATS_TEST_FILENAME")/../.." && pwd)"
+
+# Files that combine `set -euo pipefail` with arithmetic counters.
+TARGET_FILES=(
+    ".bmad/lib/gate-validator.sh"
+    ".bmad/lib/routing-engine.sh"
+    ".bmad/lib/batch-executor.sh"
+    ".bmad/hooks/quality-gate.sh"
+    "Dev/scripts/install-from-config.sh"
+    "Dev/scripts/check-prerequisites.sh"
+)
+
+# Matches the standalone command form `((var++))` / `((var--))` only.
+BARE_INCR_RE='\(\([a-zA-Z_][a-zA-Z0-9_]*(\+\+|--)\)\)'
+
+@test "no unguarded ((var++))/((var--)) in set -e scripts" {
+    violations=""
+    for rel in "${TARGET_FILES[@]}"; do
+        f="$REPO_ROOT/$rel"
+        [ -f "$f" ] || continue
+        # Flag bare increments, excluding any guarded by `|| true`.
+        hits="$(grep -nE "$BARE_INCR_RE" "$f" | grep -v '|| true' || true)"
+        if [ -n "$hits" ]; then
+            violations+="$rel:"$'\n'"$hits"$'\n'
+        fi
+    done
+
+    if [ -n "$violations" ]; then
+        echo "Unguarded post/pre-increment found (use var=\$((var + 1))):" >&2
+        echo "$violations" >&2
+    fi
+    [ -z "$violations" ]
+}

--- a/.claude/commands/team/audit.md
+++ b/.claude/commands/team/audit.md
@@ -28,6 +28,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Ces scripts sont installés automatiquement par claude-craft (`make install-agentteams` ou via l'installeur). S'ils sont absents, la commande continue en **mode dégradé** : estimation de coût manuelle et `--ralph-mode` indisponible (non bloquant).
+
 ## Garde-Fou Fast Mode (Confirmation Bloquante)
 
 **OBLIGATOIRE** : Avant de lancer l'équipe, le leader DOIT :

--- a/.claude/commands/team/delivery.md
+++ b/.claude/commands/team/delivery.md
@@ -33,6 +33,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 
+> ℹ️ Ces scripts sont installés automatiquement par claude-craft (`make install-agentteams` ou via l'installeur). S'ils sont absents, la commande continue en **mode dégradé** : estimation de coût manuelle et `--ralph-mode` indisponible (non bloquant).
+
 ## Garde-Fou Fast Mode (Confirmation Bloquante)
 
 **OBLIGATOIRE** : Avant de lancer l'équipe, le Delivery Lead DOIT :

--- a/.claude/commands/team/security.md
+++ b/.claude/commands/team/security.md
@@ -28,6 +28,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Ces scripts sont installés automatiquement par claude-craft (`make install-agentteams` ou via l'installeur). S'ils sont absents, la commande continue en **mode dégradé** : estimation de coût manuelle et `--ralph-mode` indisponible (non bloquant).
+
 ## Garde-Fou Fast Mode (Confirmation Bloquante)
 
 **OBLIGATOIRE** : Avant de lancer l'équipe, le security lead DOIT :

--- a/.claude/commands/team/sprint.md
+++ b/.claude/commands/team/sprint.md
@@ -32,6 +32,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/compatibility-check.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Ces scripts sont installés automatiquement par claude-craft (`make install-agentteams` ou via l'installeur). S'ils sont absents, la commande continue en **mode dégradé** : estimation de coût manuelle et `--ralph-mode` indisponible (non bloquant).
+
 ## Garde-Fou Fast Mode (Confirmation Bloquante)
 
 **OBLIGATOIRE** : Avant de lancer l'équipe, le conductor DOIT :

--- a/Dev/i18n/de/Team/commands/audit.md
+++ b/Dev/i18n/de/Team/commands/audit.md
@@ -28,6 +28,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` verfügbar
 - `Tools/AgentTeams/lib/cost-estimator.sh` verfügbar
 
+> ℹ️ Diese Skripte werden automatisch von claude-craft installiert (`make install-agentteams` oder über den Installer). Fehlen sie, läuft der Befehl im **eingeschränkten Modus** weiter: manuelle Kostenschätzung und `--ralph-mode` nicht verfügbar (nicht blockierend).
+
 ## Plan-Modus
 
 > Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine modulübergreifende Untersuchung erfordert.

--- a/Dev/i18n/de/Team/commands/delivery.md
+++ b/Dev/i18n/de/Team/commands/delivery.md
@@ -33,6 +33,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/cost-estimator.sh` verfügbar
 - `Tools/AgentTeams/lib/result-aggregator.sh` verfügbar
 
+> ℹ️ Diese Skripte werden automatisch von claude-craft installiert (`make install-agentteams` oder über den Installer). Fehlen sie, läuft der Befehl im **eingeschränkten Modus** weiter: manuelle Kostenschätzung und `--ralph-mode` nicht verfügbar (nicht blockierend).
+
 ## Plan-Modus
 
 > Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine modulübergreifende Untersuchung erfordert.

--- a/Dev/i18n/de/Team/commands/security.md
+++ b/Dev/i18n/de/Team/commands/security.md
@@ -28,6 +28,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` verfügbar
 - `Tools/AgentTeams/lib/cost-estimator.sh` verfügbar
 
+> ℹ️ Diese Skripte werden automatisch von claude-craft installiert (`make install-agentteams` oder über den Installer). Fehlen sie, läuft der Befehl im **eingeschränkten Modus** weiter: manuelle Kostenschätzung und `--ralph-mode` nicht verfügbar (nicht blockierend).
+
 ## Plan-Modus
 
 > Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine modulübergreifende Untersuchung erfordert.

--- a/Dev/i18n/de/Team/commands/sprint.md
+++ b/Dev/i18n/de/Team/commands/sprint.md
@@ -32,6 +32,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/compatibility-check.sh` verfügbar
 - `Tools/AgentTeams/lib/cost-estimator.sh` verfügbar
 
+> ℹ️ Diese Skripte werden automatisch von claude-craft installiert (`make install-agentteams` oder über den Installer). Fehlen sie, läuft der Befehl im **eingeschränkten Modus** weiter: manuelle Kostenschätzung und `--ralph-mode` nicht verfügbar (nicht blockierend).
+
 ## Plan-Modus
 
 > Der Plan-Modus wird automatisch aktiviert, wenn der Umfang mehrere Module umfasst oder eine modulübergreifende Untersuchung erfordert.

--- a/Dev/i18n/en/Team/commands/audit.md
+++ b/Dev/i18n/en/Team/commands/audit.md
@@ -28,6 +28,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` available
 - `Tools/AgentTeams/lib/cost-estimator.sh` available
 
+> ℹ️ These scripts are installed automatically by claude-craft (`make install-agentteams` or via the installer). If absent, the command continues in **degraded mode**: manual cost estimation and `--ralph-mode` unavailable (non-blocking).
+
 ## Plan Mode
 
 > Plan mode is activated automatically when the scope spans multiple modules or requires cross-cutting investigation.

--- a/Dev/i18n/en/Team/commands/delivery.md
+++ b/Dev/i18n/en/Team/commands/delivery.md
@@ -33,6 +33,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/cost-estimator.sh` available
 - `Tools/AgentTeams/lib/result-aggregator.sh` available
 
+> ℹ️ These scripts are installed automatically by claude-craft (`make install-agentteams` or via the installer). If absent, the command continues in **degraded mode**: manual cost estimation and `--ralph-mode` unavailable (non-blocking).
+
 ## Plan Mode
 
 > Plan mode is activated automatically when the scope spans multiple modules or requires cross-cutting investigation.

--- a/Dev/i18n/en/Team/commands/security.md
+++ b/Dev/i18n/en/Team/commands/security.md
@@ -28,6 +28,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` available
 - `Tools/AgentTeams/lib/cost-estimator.sh` available
 
+> ℹ️ These scripts are installed automatically by claude-craft (`make install-agentteams` or via the installer). If absent, the command continues in **degraded mode**: manual cost estimation and `--ralph-mode` unavailable (non-blocking).
+
 ## Plan Mode
 
 > Plan mode is activated automatically when the scope spans multiple modules or requires cross-cutting investigation.

--- a/Dev/i18n/en/Team/commands/sprint.md
+++ b/Dev/i18n/en/Team/commands/sprint.md
@@ -32,6 +32,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/compatibility-check.sh` available
 - `Tools/AgentTeams/lib/cost-estimator.sh` available
 
+> ℹ️ These scripts are installed automatically by claude-craft (`make install-agentteams` or via the installer). If absent, the command continues in **degraded mode**: manual cost estimation and `--ralph-mode` unavailable (non-blocking).
+
 ## Plan Mode
 
 > Plan mode is activated automatically when the scope spans multiple modules or requires cross-cutting investigation.

--- a/Dev/i18n/es/Team/commands/audit.md
+++ b/Dev/i18n/es/Team/commands/audit.md
@@ -32,6 +32,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Estos scripts se instalan automáticamente con claude-craft (`make install-agentteams` o mediante el instalador). Si faltan, el comando continúa en **modo degradado**: estimación de coste manual y `--ralph-mode` no disponible (no bloqueante).
+
 ## Proteccion Fast Mode (Confirmacion Bloqueante)
 
 **OBLIGATORIO**: Antes de lanzar el equipo, el lider DEBE:

--- a/Dev/i18n/es/Team/commands/delivery.md
+++ b/Dev/i18n/es/Team/commands/delivery.md
@@ -37,6 +37,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 
+> ℹ️ Estos scripts se instalan automáticamente con claude-craft (`make install-agentteams` o mediante el instalador). Si faltan, el comando continúa en **modo degradado**: estimación de coste manual y `--ralph-mode` no disponible (no bloqueante).
+
 ## Proteccion Fast Mode (Confirmacion Bloqueante)
 
 **OBLIGATORIO**: Antes de lanzar el equipo, el Lider de Entrega DEBE:

--- a/Dev/i18n/es/Team/commands/security.md
+++ b/Dev/i18n/es/Team/commands/security.md
@@ -32,6 +32,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Estos scripts se instalan automáticamente con claude-craft (`make install-agentteams` o mediante el instalador). Si faltan, el comando continúa en **modo degradado**: estimación de coste manual y `--ralph-mode` no disponible (no bloqueante).
+
 ## Proteccion Fast Mode (Confirmacion Bloqueante)
 
 **OBLIGATORIO**: Antes de lanzar el equipo, el lider de seguridad DEBE:

--- a/Dev/i18n/es/Team/commands/sprint.md
+++ b/Dev/i18n/es/Team/commands/sprint.md
@@ -36,6 +36,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/compatibility-check.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Estos scripts se instalan automáticamente con claude-craft (`make install-agentteams` o mediante el instalador). Si faltan, el comando continúa en **modo degradado**: estimación de coste manual y `--ralph-mode` no disponible (no bloqueante).
+
 ## Proteccion Fast Mode (Confirmacion Bloqueante)
 
 **OBLIGATORIO**: Antes de lanzar el equipo, el conductor DEBE:

--- a/Dev/i18n/fr/Team/commands/audit.md
+++ b/Dev/i18n/fr/Team/commands/audit.md
@@ -27,6 +27,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Ces scripts sont installés automatiquement par claude-craft (`make install-agentteams` ou via l'installeur). S'ils sont absents, la commande continue en **mode dégradé** : estimation de coût manuelle et `--ralph-mode` indisponible (non bloquant).
+
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.

--- a/Dev/i18n/fr/Team/commands/delivery.md
+++ b/Dev/i18n/fr/Team/commands/delivery.md
@@ -55,6 +55,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 
+> ℹ️ Ces scripts sont installés automatiquement par claude-craft (`make install-agentteams` ou via l'installeur). S'ils sont absents, la commande continue en **mode dégradé** : estimation de coût manuelle et `--ralph-mode` indisponible (non bloquant).
+
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.

--- a/Dev/i18n/fr/Team/commands/security.md
+++ b/Dev/i18n/fr/Team/commands/security.md
@@ -50,6 +50,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Ces scripts sont installés automatiquement par claude-craft (`make install-agentteams` ou via l'installeur). S'ils sont absents, la commande continue en **mode dégradé** : estimation de coût manuelle et `--ralph-mode` indisponible (non bloquant).
+
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.

--- a/Dev/i18n/fr/Team/commands/sprint.md
+++ b/Dev/i18n/fr/Team/commands/sprint.md
@@ -54,6 +54,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/compatibility-check.sh` disponible
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponible
 
+> ℹ️ Ces scripts sont installés automatiquement par claude-craft (`make install-agentteams` ou via l'installeur). S'ils sont absents, la commande continue en **mode dégradé** : estimation de coût manuelle et `--ralph-mode` indisponible (non bloquant).
+
 ## Mode Plan
 
 > Le mode plan est activé automatiquement lorsque le périmètre couvre plusieurs modules ou nécessite une investigation transversale.

--- a/Dev/i18n/pt/Team/commands/audit.md
+++ b/Dev/i18n/pt/Team/commands/audit.md
@@ -32,6 +32,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponivel
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponivel
 
+> ℹ️ Esses scripts são instalados automaticamente pelo claude-craft (`make install-agentteams` ou via instalador). Se ausentes, o comando continua em **modo degradado**: estimativa de custo manual e `--ralph-mode` indisponível (não bloqueante).
+
 ## Protecao Fast Mode (Confirmacao Bloqueante)
 
 **OBRIGATORIO**: Antes de lancar a equipe, o lider DEVE:

--- a/Dev/i18n/pt/Team/commands/delivery.md
+++ b/Dev/i18n/pt/Team/commands/delivery.md
@@ -37,6 +37,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponivel
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponivel
 
+> ℹ️ Esses scripts são instalados automaticamente pelo claude-craft (`make install-agentteams` ou via instalador). Se ausentes, o comando continua em **modo degradado**: estimativa de custo manual e `--ralph-mode` indisponível (não bloqueante).
+
 ## Protecao Fast Mode (Confirmacao Bloqueante)
 
 **OBRIGATORIO**: Antes de lancar a equipe, o Delivery Lead DEVE:

--- a/Dev/i18n/pt/Team/commands/security.md
+++ b/Dev/i18n/pt/Team/commands/security.md
@@ -32,6 +32,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/result-aggregator.sh` disponivel
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponivel
 
+> ℹ️ Esses scripts são instalados automaticamente pelo claude-craft (`make install-agentteams` ou via instalador). Se ausentes, o comando continua em **modo degradado**: estimativa de custo manual e `--ralph-mode` indisponível (não bloqueante).
+
 ## Protecao Fast Mode (Confirmacao Bloqueante)
 
 **OBRIGATORIO**: Antes de lancar a equipe, o lider de seguranca DEVE:

--- a/Dev/i18n/pt/Team/commands/sprint.md
+++ b/Dev/i18n/pt/Team/commands/sprint.md
@@ -36,6 +36,8 @@ $ARGUMENTS
 - `Tools/AgentTeams/lib/compatibility-check.sh` disponivel
 - `Tools/AgentTeams/lib/cost-estimator.sh` disponivel
 
+> ℹ️ Esses scripts são instalados automaticamente pelo claude-craft (`make install-agentteams` ou via instalador). Se ausentes, o comando continua em **modo degradado**: estimativa de custo manual e `--ralph-mode` indisponível (não bloqueante).
+
 ## Protecao Fast Mode (Confirmacao Bloqueante)
 
 **OBRIGATORIO**: Antes de lancar a equipe, o condutor DEVE:

--- a/Dev/scripts/check-prerequisites.sh
+++ b/Dev/scripts/check-prerequisites.sh
@@ -73,7 +73,7 @@ check() {
     else
         if [[ "$required" == "required" ]]; then
             ui_check_fail "$cmd - $description"
-            ((ERRORS++))
+            ERRORS=$((ERRORS + 1))
             if $FIX; then
                 case $OS in
                     macos) ui_check_info "Fix: $install_macos" ;;
@@ -108,7 +108,7 @@ check_yq_version() {
                 ui_check_info "Fix (macOS): brew install yq"
                 ui_check_info "Fix (Linux): sudo wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq && sudo chmod +x /usr/local/bin/yq"
             fi
-            ((ERRORS++))
+            ERRORS=$((ERRORS + 1))
             return 1
         fi
     fi
@@ -126,7 +126,7 @@ check_node_version() {
             if $FIX; then
                 ui_check_info "Fix: Use nvm to install Node.js 20: nvm install 20 && nvm use 20"
             fi
-            ((ERRORS++))
+            ERRORS=$((ERRORS + 1))
             return 1
         fi
     fi

--- a/Dev/scripts/install-common-rules.sh
+++ b/Dev/scripts/install-common-rules.sh
@@ -473,6 +473,30 @@ install_commands() {
     fi
 }
 
+# Install AgentTeams helper scripts (cost-estimator, ralph-teams-adapter,
+# compatibility-check, ...) used by the /team:* commands. They are shipped
+# alongside the Team command namespace so /team:sprint etc. find them at
+# <project>/Tools/AgentTeams/lib/ instead of warning "scripts MISSING".
+install_agentteams() {
+    local craft_root
+    craft_root="$(cd "$SCRIPT_DIR/../.." && pwd)"
+    local src_lib="$craft_root/Tools/AgentTeams/lib"
+    local dest_lib="$target_dir/Tools/AgentTeams/lib"
+
+    if [[ ! -d "$src_lib" ]]; then
+        log_warning "AgentTeams lib not found at $src_lib (skipping)"
+        return 0
+    fi
+
+    log_info "${MSG_INSTALLING_AGENTTEAMS:-Installing AgentTeams helper scripts...}"
+    copy_directory "$src_lib" "$dest_lib" "*.sh"
+
+    # Some helper scripts ship without the executable bit; ensure +x on copies.
+    if ! $dry_run && [[ -d "$dest_lib" ]]; then
+        chmod +x "$dest_lib"/*.sh 2>/dev/null || true
+    fi
+}
+
 install_templates() {
     log_info "${MSG_INSTALLING_TEMPLATES}"
 
@@ -830,6 +854,7 @@ main() {
 
     if $commands_only; then
         install_commands
+        install_agentteams
     fi
 
     if $templates_only; then

--- a/Dev/scripts/install-from-config.sh
+++ b/Dev/scripts/install-from-config.sh
@@ -226,7 +226,7 @@ validate_config() {
     if [[ "$lang_valid" == "false" ]]; then
         log_error "Langue par défaut invalide: $default_lang"
         log_error "Langues valides: ${VALID_LANGS[*]}"
-        ((errors++))
+        errors=$((errors + 1))
     else
         log_success "Langue par défaut: $default_lang"
     fi
@@ -246,12 +246,12 @@ validate_config() {
         # Vérifier les champs obligatoires
         if [[ "$name" == "null" || -z "$name" ]]; then
             log_error "  Champ 'name' manquant pour le projet $((i+1))"
-            ((errors++))
+            errors=$((errors + 1))
         fi
 
         if [[ "$root" == "null" || -z "$root" ]]; then
             log_error "  Champ 'root' manquant pour le projet: $name"
-            ((errors++))
+            errors=$((errors + 1))
         else
             # Expand le chemin (direct assignment, no subshell — SEC-1)
             local expanded_root="${root/#\~/$HOME}"
@@ -260,7 +260,7 @@ validate_config() {
 
         if [[ "$module_count" -eq 0 ]]; then
             log_error "  Aucun module défini pour le projet: $name"
-            ((errors++))
+            errors=$((errors + 1))
         else
             log_step "  Modules: $module_count"
         fi
@@ -277,7 +277,7 @@ validate_config() {
             if [[ "$project_lang_valid" == "false" ]]; then
                 log_error "  Langue invalide pour le projet: $project_lang"
                 log_error "  Langues valides: ${VALID_LANGS[*]}"
-                ((errors++))
+                errors=$((errors + 1))
             else
                 log_step "  Langue: $project_lang"
             fi
@@ -292,13 +292,13 @@ validate_config() {
 
             if [[ "$path" == "null" || -z "$path" ]]; then
                 log_error "    Module $((j+1)): champ 'path' manquant"
-                ((errors++))
+                errors=$((errors + 1))
                 continue
             fi
 
             if [[ "$techs" == "null" || -z "$techs" ]]; then
                 log_error "    Module '$path': champ 'tech' manquant"
-                ((errors++))
+                errors=$((errors + 1))
                 continue
             fi
 
@@ -320,7 +320,7 @@ validate_config() {
                 if [[ "$valid" == "false" ]]; then
                     log_error "    Module '$path': technologie '$tech' invalide"
                     log_error "    Technologies valides: ${VALID_TECHS[*]}"
-                    ((errors++))
+                    errors=$((errors + 1))
                     module_valid=false
                 else
                     if [[ -z "$tech_list" ]]; then
@@ -615,7 +615,7 @@ install_project() {
     if [[ "$common" == "true" ]]; then
         print_section "[$step/$total_steps] Installation des règles communes"
         install_module "$expanded_root" "common" "" "$project_lang"
-        ((step++))
+        step=$((step + 1))
     fi
 
     # Installer chaque module
@@ -664,7 +664,7 @@ install_project() {
 
             install_module "$target_path" "$tech" "$desc" "$project_lang" "$skip_common_flag"
             is_first=false
-            ((step++))
+            step=$((step + 1))
         done <<< "$techs"
     done
 }

--- a/Makefile
+++ b/Makefile
@@ -14,12 +14,12 @@
 #===============================================================================
 
 .PHONY: help install-all install-common install-project install-infra \
-        install-tools install-tools-lib install-completions \
+        install-tools install-tools-lib install-completions install-agentteams \
         install-web install-fullstack-js install-mobile install-backend \
         list list-agents list-commands \
         config-install config-install-all config-validate config-list config-dry-run \
         config-check config-check-fix check fix-permissions stats \
-        migrate-check test-tools test-rtk test-statusline test-agent-teams test-bats test-all \
+        migrate-check test-tools test-rtk test-statusline test-agent-teams test-bmad test-bats test-all \
         plugin-export plugin-export-all
 
 # Configuration
@@ -107,6 +107,9 @@ install-projectconfig: install-tools-lib ## Installe le gestionnaire de projets 
 install-rtk: ## Installe RTK (Rust Token Killer)
 	@bash "$(TOOLS_DIR)/RTK/install-rtk.sh" --lang=$(RULES_LANG)
 
+install-agentteams: ## Installe les scripts AgentTeams (/team:*) dans TARGET (defaut: .)
+	@bash "$(TOOLS_DIR)/AgentTeams/install-agentteams.sh" "$(TARGET)"
+
 install-completions: ## Installe les completions bash/zsh
 	@mkdir -p ~/.local/share/bash-completion/completions ~/.zsh/completions && \
 	cp "$(TOOLS_DIR)/MultiAccount/completions/claude-accounts.bash" ~/.local/share/bash-completion/completions/ && \
@@ -125,7 +128,12 @@ BATS_RUN = docker run --rm -v "$(CURDIR)/Tools:/mnt" bats/bats:latest /mnt/$*/te
 test-%: ## Lance les tests bats pour un outil (ex: make test-tools)
 	@$(BATS_RUN)
 
-test-bats: test-MultiAccount test-StatusLine test-RTK test-AgentTeams ## Lance tous les tests bats
+# .bmad/ lives outside Tools/ — mount the repo root so tests can reach
+# .bmad/lib, .bmad/hooks and Dev/scripts. Explicit target overrides test-%.
+test-bmad: ## Lance les tests bats BMAD (gate-validator + garde anti ((var++)))
+	@docker run --rm -v "$(CURDIR):/mnt" bats/bats:latest /mnt/.bmad/tests/
+
+test-bats: test-MultiAccount test-StatusLine test-RTK test-AgentTeams test-bmad ## Lance tous les tests bats
 
 test-all: ## Lance tous les tests (vitest + bats)
 	@npm test && $(MAKE) test-bats

--- a/Tools/AgentTeams/install-agentteams.sh
+++ b/Tools/AgentTeams/install-agentteams.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+# =============================================================================
+# install-agentteams.sh — Install AgentTeams helper scripts into a project
+#
+# The /team:* commands (sprint, audit, delivery, security) expect helper
+# scripts at <project>/Tools/AgentTeams/lib/:
+#   - cost-estimator.sh      (token/cost estimation)
+#   - cost-dashboard.sh      (cost dashboard)
+#   - ralph-teams-adapter.sh (--ralph-mode integration)
+#   - compatibility-check.sh (Claude Code tool/agent compatibility)
+#   - result-aggregator.sh   (aggregate parallel agent results)
+#
+# When they are absent the commands degrade gracefully (manual estimation, no
+# --ralph-mode). This script copies them into the target project so the
+# commands work out of the box.
+#
+# Usage:
+#   bash install-agentteams.sh [TARGET_DIR]   # default TARGET_DIR: .
+#   bash install-agentteams.sh --check [TARGET_DIR]
+#   bash install-agentteams.sh --uninstall [TARGET_DIR]
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_LIB="$SCRIPT_DIR/lib"
+
+# Minimal UI (no hard dependency on shared helpers).
+print_success() { echo "✓ $1"; }
+print_error()   { echo "✗ $1" >&2; }
+print_info()    { echo "ℹ $1"; }
+print_warning() { echo "⚠ $1"; }
+
+mode="install"
+target="."
+
+for arg in "$@"; do
+    case "$arg" in
+        --check)     mode="check" ;;
+        --uninstall) mode="uninstall" ;;
+        -h|--help)
+            sed -n '2,22p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
+            exit 0
+            ;;
+        -*)
+            print_error "Unknown option: $arg"
+            exit 1
+            ;;
+        *) target="$arg" ;;
+    esac
+done
+
+target="$(cd "$target" 2>/dev/null && pwd)" || {
+    print_error "Target directory not found: $target"
+    exit 1
+}
+dest_lib="$target/Tools/AgentTeams/lib"
+
+if [[ ! -d "$SRC_LIB" ]]; then
+    print_error "Source lib not found: $SRC_LIB"
+    exit 1
+fi
+
+case "$mode" in
+    check)
+        missing=0
+        for f in "$SRC_LIB"/*.sh; do
+            name="$(basename "$f")"
+            if [[ -f "$dest_lib/$name" ]]; then
+                print_success "$name present"
+            else
+                print_warning "$name MISSING at $dest_lib"
+                missing=$((missing + 1))
+            fi
+        done
+        [[ $missing -eq 0 ]] && print_success "AgentTeams installed at $dest_lib" || exit 1
+        ;;
+    uninstall)
+        if [[ -d "$dest_lib" ]]; then
+            rm -f "$dest_lib"/*.sh
+            rmdir "$dest_lib" 2>/dev/null || true
+            print_success "Removed AgentTeams scripts from $dest_lib"
+        else
+            print_info "Nothing to remove at $dest_lib"
+        fi
+        ;;
+    install)
+        mkdir -p "$dest_lib"
+        cp "$SRC_LIB"/*.sh "$dest_lib/"
+        chmod +x "$dest_lib"/*.sh 2>/dev/null || true
+        count=$(find "$dest_lib" -maxdepth 1 -name '*.sh' | wc -l | tr -d ' ')
+        print_success "Installed $count AgentTeams helper scripts to $dest_lib"
+        ;;
+esac

--- a/docs/AGENT-TEAMS-GUIDE.md
+++ b/docs/AGENT-TEAMS-GUIDE.md
@@ -16,6 +16,33 @@ Agent Teams (Claude Code v2.1.32+ Research Preview) enables multi-agent coordina
 export CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1
 ```
 
+## Installation
+
+The `/team:*` commands rely on helper scripts in `Tools/AgentTeams/lib/`
+(`cost-estimator.sh`, `cost-dashboard.sh`, `ralph-teams-adapter.sh`,
+`compatibility-check.sh`, `result-aggregator.sh`).
+
+These are **installed automatically** into your project whenever the common
+rules/commands are installed (the npx installer and `make install-common` both
+ship the Team namespace together with these scripts).
+
+To install or refresh them manually:
+
+```bash
+# From the claude-craft repo (or npm package), targeting your project:
+make install-agentteams TARGET=/path/to/your/project
+
+# Or directly:
+bash Tools/AgentTeams/install-agentteams.sh /path/to/your/project
+
+# Verify they are present:
+bash Tools/AgentTeams/install-agentteams.sh --check /path/to/your/project
+```
+
+If the scripts are absent, the `/team:*` commands **degrade gracefully**:
+cost estimation falls back to manual, and `--ralph-mode` is unavailable — the
+commands still run.
+
 ## When to Use Agent Teams
 
 Agent Teams adds coordination overhead. Use it only when the parallelization benefit outweighs the cost.


### PR DESCRIPTION
## Contexte

Remontées d'utilisation sur le projet **Wrandly** :

1. **`/gate:*` cassé** — `.bmad/lib/gate-validator.sh` combine `set -euo pipefail` + `((score++))`. `((score++))` renvoie l'ancienne valeur → exit 1 quand `score=0` → le script avorte après le **1er check**. Touche toutes les commandes `/gate:*`, le hook quality-gate, le routing engine, le batch executor et 2 scripts d'install. **68 occurrences** sur **6 fichiers** (pas un fix 1-ligne).
2. **Scripts AgentTeams manquants** — `/team:*` attend `Tools/AgentTeams/lib/*.sh` à la racine du projet, mais aucun installer ne les copiait (présents dans le repo + package npm seulement). → warning « scripts MISSING », pas de dashboard coût ni `--ralph-mode`.

## Changements

### Fix bug `((var++))` (TDD)
- Tests de non-régression écrits **avant** le fix : `.bmad/tests/gate-validator.bats` (comportemental) + `.bmad/tests/no-bare-arith-increment.bats` (garde statique). Cible Makefile `test-bmad` (bats docker, monte la racine), ajoutée à `test-bats`.
- Remplacement des 68 `((var++))`/`((var--))` nus par `var=$((var + 1))` sur les 6 fichiers. Boucles `for ((i++))` intactes.

### Distribution AgentTeams
- Nouveau `Tools/AgentTeams/install-agentteams.sh` (`install`/`--check`/`--uninstall`).
- `install-common-rules.sh` installe désormais la lib AgentTeams avec le namespace Team (npx installer + `make install-common`), `chmod +x` sur les copies.
- Target `make install-agentteams TARGET=.`.
- Note **dégradation gracieuse** dans les prérequis `/team:*` (`.claude/` + 5 locales i18n).
- Section Installation dans `docs/AGENT-TEAMS-GUIDE.md`.

## Vérifications
- `make test-bmad` : **4/4 rouge avant fix** (bug prouvé) → **4/4 vert après**.
- `make test-AgentTeams` : pass. Parité i18n : ✓ (count + size ≥ 0.80).
- Run réel `gate-validator prd` : 8/8, PASS (ne s'arrête plus au 1er check).
- `make install-agentteams` : 5 scripts copiés +x, `--check` vert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)