### PR TITLE
fix(kanban): repair keyboard nav, card details, backlog grouping + read-only feedback

### DIFF
--- a/cli/kanban/client/src/lib/backlog.js
+++ b/cli/kanban/client/src/lib/backlog.js
@@ -1,0 +1,43 @@
+// Epic-grouping logic for the Backlog view. Pure (no Svelte/DOM) so it is unit-testable.
+
+/**
+ * Group stories under their epic.
+ *
+ * Stories whose `epic_id` matches a known epic land in that epic's group. Stories whose
+ * `epic_id` is set but unknown (e.g. BMAD v6 `.bmad/sprint-status.yaml` stories with
+ * `epic_id="E1"` and no markdown epic file) get a *synthesized* minimal group so they
+ * still render — otherwise the Backlog screen goes blank. Stories without an `epic_id`
+ * are orphans.
+ *
+ * @param {Array<object>} stories
+ * @param {Array<{id:string,title?:string,business_value?:string,status?:string}>} epics
+ * @returns {{groups: Array<{epic:object, stories:object[]}>, orphans: object[]}}
+ */
+export function groupStoriesByEpic(stories, epics) {
+  const groups = new Map();
+  for (const epic of epics) {
+    groups.set(epic.id, { epic, stories: [] });
+  }
+
+  const orphans = [];
+  for (const story of stories) {
+    const epicId = story.epic_id;
+    if (!epicId) {
+      orphans.push(story);
+      continue;
+    }
+    if (!groups.has(epicId)) {
+      // Unknown epic_id: synthesize a group so the story stays visible.
+      groups.set(epicId, { epic: { id: epicId, title: epicId, business_value: '', status: '' }, stories: [] });
+    }
+    groups.get(epicId).stories.push(story);
+  }
+
+  const sorted = [...groups.values()].sort((a, b) => a.epic.id.localeCompare(b.epic.id));
+  for (const group of sorted) {
+    group.stories.sort((a, b) => a.id.localeCompare(b.id));
+  }
+  orphans.sort((a, b) => a.id.localeCompare(b.id));
+
+  return { groups: sorted, orphans };
+}

--- a/cli/kanban/client/src/lib/kanban-nav.js
+++ b/cli/kanban/client/src/lib/kanban-nav.js
@@ -1,0 +1,119 @@
+// Keyboard-navigation logic for the Kanban board. Pure (no Svelte/DOM) so it is unit-testable.
+// The Svelte view is a thin adapter: it builds `ctx`, calls reduceKey(), applies the returned
+// state, and dispatches the returned action (focus a card, open/close the move menu, move a
+// card, signal a read-only card, or open the detail modal).
+
+/**
+ * Find a card's column/card index on the board.
+ * @returns {{columnIndex:number, cardIndex:number} | null}
+ */
+export function locateCard(storiesByStatus, columns, cardId) {
+  for (let c = 0; c < columns.length; c++) {
+    const cards = storiesByStatus[columns[c].key] ?? [];
+    const idx = cards.findIndex((s) => s.id === cardId);
+    if (idx !== -1) return { columnIndex: c, cardIndex: idx };
+  }
+  return null;
+}
+
+function clamp(n, min, max) {
+  return Math.max(min, Math.min(n, max));
+}
+
+const noop = (state) => ({ state, action: null });
+
+/**
+ * Reduce a keyboard event into the next navigation state + an action descriptor.
+ *
+ * @param {{focusedColumnIndex:number, focusedCardIndex:number, showMoveMenu:boolean}} state
+ * @param {{key:string, altKey?:boolean}} event
+ * @param {{columns:Array<{key:string,label:string}>, storiesByStatus:Record<string,object[]>}} ctx
+ * @returns {{state:object, action:object|null}}
+ */
+export function reduceKey(state, event, ctx) {
+  const { columns, storiesByStatus } = ctx;
+  const { key, altKey } = event;
+  const colKey = (i) => columns[i]?.key;
+  const cardsIn = (i) => storiesByStatus[colKey(i)] ?? [];
+
+  // Alt+M : toggle the move menu, only when a card is focused.
+  if (altKey && key === 'm') {
+    const card = cardsIn(state.focusedColumnIndex)[state.focusedCardIndex];
+    if (state.focusedCardIndex < 0 || !card) return noop(state);
+    if (state.showMoveMenu) {
+      return { state: { ...state, showMoveMenu: false }, action: { type: 'close-menu' } };
+    }
+    return { state: { ...state, showMoveMenu: true }, action: { type: 'open-menu' } };
+  }
+
+  // Vertical navigation within the focused column.
+  if (key === 'ArrowDown' || key === 'ArrowUp') {
+    const cards = cardsIn(state.focusedColumnIndex);
+    if (cards.length === 0) return noop(state);
+    const next =
+      key === 'ArrowDown'
+        ? clamp(state.focusedCardIndex + 1, 0, cards.length - 1)
+        : clamp(state.focusedCardIndex - 1, 0, cards.length - 1);
+    return { state: { ...state, focusedCardIndex: next }, action: { type: 'focus', cardId: cards[next].id } };
+  }
+
+  // Horizontal navigation between columns; reset to the first card of the new column.
+  if (key === 'ArrowRight' || key === 'ArrowLeft') {
+    const nextCol =
+      key === 'ArrowRight'
+        ? clamp(state.focusedColumnIndex + 1, 0, columns.length - 1)
+        : clamp(state.focusedColumnIndex - 1, 0, columns.length - 1);
+    const cards = cardsIn(nextCol);
+    const action = cards.length > 0 ? { type: 'focus', cardId: cards[0].id } : null;
+    return { state: { ...state, focusedColumnIndex: nextCol, focusedCardIndex: 0 }, action };
+  }
+
+  // Move menu open: number keys 1-6 target a column, Escape closes.
+  if (state.showMoveMenu) {
+    if (/^[1-6]$/.test(key)) {
+      const target = columns[parseInt(key, 10) - 1];
+      const card = cardsIn(state.focusedColumnIndex)[state.focusedCardIndex];
+      if (target && card) {
+        if (card._writable === false) return { state, action: { type: 'readonly', cardId: card.id } };
+        return { state, action: { type: 'move', cardId: card.id, targetStatus: target.key } };
+      }
+      return noop(state);
+    }
+    if (key === 'Escape') {
+      return { state: { ...state, showMoveMenu: false }, action: { type: 'close-menu' } };
+    }
+  }
+
+  // Enter opens the focused card's details (when the move menu is closed).
+  if (key === 'Enter' && !state.showMoveMenu) {
+    const card = cardsIn(state.focusedColumnIndex)[state.focusedCardIndex];
+    if (card) return { state, action: { type: 'details', card } };
+    return noop(state);
+  }
+
+  return noop(state);
+}
+
+/**
+ * Normalize a story into the fields the detail modal renders. Pure + defensive against
+ * missing fields (YAML-only stories omit several).
+ */
+export function buildCardDetails(story) {
+  return {
+    id: story.id,
+    title: story.title ?? story.id,
+    status: story.status ?? '',
+    priority: story.priority ?? '',
+    storyPoints: story.story_points ?? 0,
+    epicId: story.epic_id ?? null,
+    persona: story.persona ?? '',
+    assignedTo: story.assigned_to ?? '',
+    tddPhase: story.tdd_phase ?? '',
+    tasks: {
+      total: story.tasks?.total ?? 0,
+      completed: story.tasks?.completed ?? 0,
+    },
+    blockedReason: story.blocked_reason ?? '',
+    readOnly: story._writable === false,
+  };
+}

--- a/cli/kanban/client/src/views/BacklogView.svelte
+++ b/cli/kanban/client/src/views/BacklogView.svelte
@@ -1,34 +1,10 @@
 <script>
   import { store } from '../lib/store.svelte.js';
+  import { groupStoriesByEpic } from '../lib/backlog.js';
 
-  const epicGroups = $derived.by(() => {
-    const groups = new Map();
-    const orphans = [];
-
-    for (const epic of store.epics) {
-      groups.set(epic.id, {
-        epic,
-        stories: [],
-        expanded: false
-      });
-    }
-
-    for (const story of store.stories) {
-      if (story.epic_id && groups.has(story.epic_id)) {
-        groups.get(story.epic_id).stories.push(story);
-      } else if (!story.epic_id) {
-        orphans.push(story);
-      }
-    }
-
-    const sorted = Array.from(groups.values()).sort((a, b) => a.epic.id.localeCompare(b.epic.id));
-    for (const group of sorted) {
-      group.stories.sort((a, b) => a.id.localeCompare(b.id));
-    }
-    orphans.sort((a, b) => a.id.localeCompare(b.id));
-
-    return { groups: sorted, orphans };
-  });
+  // Stories with an unknown epic_id (e.g. BMAD v6 sprint-status.yaml, epic_id="E1" with no
+  // markdown epic) are kept in a synthesized group instead of being dropped — see backlog.js.
+  const epicGroups = $derived(groupStoriesByEpic(store.stories, store.epics));
 
   let expanded = $state(new Set());
 

--- a/cli/kanban/client/src/views/KanbanView.svelte
+++ b/cli/kanban/client/src/views/KanbanView.svelte
@@ -1,13 +1,20 @@
 <script>
-  import { store, patchStatus } from '../lib/store.svelte.js';
-  import { onMount } from 'svelte';
+  import { store, patchStatus, toast } from '../lib/store.svelte.js';
+  import { onMount, tick } from 'svelte';
   import PromptDialog from '../components/PromptDialog.svelte';
+  import { locateCard, reduceKey, buildCardDetails } from '../lib/kanban-nav.js';
 
   let promptDialog = $state(null);
   /** Référence au <dialog> natif du menu de déplacement */
   let moveMenuDialog = $state(null);
   /** Élément de carte ayant déclenché l'ouverture du menu (pour retour de focus) */
   let moveMenuTriggerEl = $state(null);
+  /** Référence au <dialog> natif de la modale de détail */
+  let detailDialog = $state(null);
+  /** Carte actuellement affichée dans la modale de détail */
+  let detailCard = $state(null);
+  /** Élément ayant déclenché l'ouverture de la modale (pour retour de focus) */
+  let detailTriggerEl = $state(null);
 
   const COLUMNS = [
     { key: 'backlog', label: 'Backlog', emptyHint: 'No stories — run /workflow:plan' },
@@ -77,84 +84,53 @@
     const enabled = import.meta.env.CC_A11Y_KANBAN !== '0';
     if (!enabled) return;
 
+    const HANDLED = new Set(['ArrowDown', 'ArrowUp', 'ArrowLeft', 'ArrowRight', 'Escape', 'Enter']);
+
     function handleKeyboard(e) {
       // Guard : n'agir que si le focus est dans le board ou le menu ouvert
       const inBoard = document.activeElement?.closest('.board');
-      const menuOpen = showMoveMenu;
-      if (!inBoard && !menuOpen) return;
+      if (!inBoard && !showMoveMenu) return;
 
-      // Navigation verticale entre cartes
-      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+      const ctx = { columns: COLUMNS, storiesByStatus };
+      const { state, action } = reduceKey(
+        { focusedColumnIndex, focusedCardIndex, showMoveMenu },
+        { key: e.key, altKey: e.altKey },
+        ctx
+      );
+
+      // Empêche le scroll/typeahead du navigateur uniquement pour les touches gérées.
+      if (HANDLED.has(e.key) || (e.altKey && e.key === 'm') || (showMoveMenu && /^[1-6]$/.test(e.key))) {
         e.preventDefault();
-        const currentColumn = COLUMNS[focusedColumnIndex];
-        const cards = storiesByStatus[currentColumn.key];
-        if (cards.length === 0) return;
-
-        if (e.key === 'ArrowDown') {
-          focusedCardIndex = Math.min(focusedCardIndex + 1, cards.length - 1);
-        } else {
-          focusedCardIndex = Math.max(0, focusedCardIndex - 1);
-        }
-        focusCard(cards[focusedCardIndex]?.id);
       }
 
-      // Arrow navigation between columns
-      if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-        e.preventDefault();
-        if (e.key === 'ArrowRight') {
-          focusedColumnIndex = Math.min(focusedColumnIndex + 1, COLUMNS.length - 1);
-        } else {
-          focusedColumnIndex = Math.max(0, focusedColumnIndex - 1);
-        }
-        focusedCardIndex = 0;
-        const newColumn = COLUMNS[focusedColumnIndex];
-        const cards = storiesByStatus[newColumn.key];
-        if (cards.length > 0) {
-          focusCard(cards[0].id);
-        }
-      }
+      // Applique le nouvel état de navigation
+      focusedColumnIndex = state.focusedColumnIndex;
+      focusedCardIndex = state.focusedCardIndex;
+      showMoveMenu = state.showMoveMenu;
 
-      // Ouvrir le menu de déplacement avec Alt+M
-      if (e.altKey && e.key === 'm') {
-        e.preventDefault();
-        const currentColumn = COLUMNS[focusedColumnIndex];
-        const cards = storiesByStatus[currentColumn.key];
-        if (focusedCardIndex >= 0 && cards[focusedCardIndex]) {
-          if (showMoveMenu) {
-            closeMoveMenu();
-          } else {
-            openMoveMenu();
-          }
+      if (!action) return;
+      switch (action.type) {
+        case 'focus':
+          focusCard(action.cardId);
+          break;
+        case 'open-menu':
+          openMoveMenu();
+          break;
+        case 'close-menu':
+          closeMoveMenu();
+          break;
+        case 'move': {
+          const card = store.stories.find((s) => s.id === action.cardId);
+          if (card) moveCard(card, action.targetStatus);
+          break;
         }
-      }
-
-      // Move card with number keys when menu is open
-      if (showMoveMenu && /^[1-6]$/.test(e.key)) {
-        e.preventDefault();
-        const targetColumn = COLUMNS[parseInt(e.key) - 1];
-        if (targetColumn) {
-          const currentColumn = COLUMNS[focusedColumnIndex];
-          const cards = storiesByStatus[currentColumn.key];
-          const card = cards[focusedCardIndex];
-          if (card) {
-            moveCard(card, targetColumn.key);
-          }
-        }
-      }
-
-      // Fermer le menu de déplacement avec Escape
-      if (e.key === 'Escape' && showMoveMenu) {
-        closeMoveMenu();
-      }
-
-      // Enter to focus card details (could be extended)
-      if (e.key === 'Enter' && !showMoveMenu) {
-        const currentColumn = COLUMNS[focusedColumnIndex];
-        const cards = storiesByStatus[currentColumn.key];
-        const card = cards[focusedCardIndex];
-        if (card) {
-          announceCardDetails(card);
-        }
+        case 'readonly':
+          announceReadOnly(action.cardId);
+          closeMoveMenu();
+          break;
+        case 'details':
+          openDetail(action.card);
+          break;
       }
     }
 
@@ -166,6 +142,15 @@
     if (!cardId) return;
     const el = document.querySelector(`[data-card-id="${cardId}"]`);
     if (el) el.focus();
+  }
+
+  /** Synchronise l'état de navigation clavier avec la carte réellement focus (souris/Tab). */
+  function syncFocus(cardId) {
+    const pos = locateCard(storiesByStatus, COLUMNS, cardId);
+    if (pos) {
+      focusedColumnIndex = pos.columnIndex;
+      focusedCardIndex = pos.cardIndex;
+    }
   }
 
   async function moveCard(card, targetStatus) {
@@ -202,6 +187,12 @@
   function announceReadOnly(cardId) {
     liveRegion = `Card ${cardId} is read-only (managed by .bmad/sprint-status.yaml — use team:/qa: commands)`;
     setTimeout(() => liveRegion = '', 3000);
+    // Feedback VISIBLE pour les utilisateurs voyants (au-delà de l'annonce sr-only).
+    toast({
+      kind: 'info',
+      message: `${cardId} en lecture seule — gérée par .bmad/sprint-status.yaml (commandes team:/qa:)`,
+      ttl: 5000,
+    });
   }
 
   function announceCardDetails(card) {
@@ -210,12 +201,13 @@
   }
 
   /** Ouvre le menu de déplacement via l'élément <dialog> natif. */
-  function openMoveMenu() {
+  async function openMoveMenu() {
     // Mémorise l'élément déclencheur pour y retourner le focus à la fermeture
     moveMenuTriggerEl = document.activeElement;
     showMoveMenu = true;
-    // Attend le prochain tick Svelte pour que le dialog soit dans le DOM
-    Promise.resolve().then(() => moveMenuDialog?.showModal());
+    // Attend que Svelte ait rendu le dialog (bind:this résolu) avant showModal()
+    await tick();
+    moveMenuDialog?.showModal();
   }
 
   /** Ferme le menu de déplacement et retourne le focus à la carte source. */
@@ -226,6 +218,28 @@
     if (moveMenuTriggerEl) {
       moveMenuTriggerEl.focus();
       moveMenuTriggerEl = null;
+    }
+  }
+
+  /** Détails normalisés de la carte affichée (null si modale fermée). */
+  const detailFields = $derived(detailCard ? buildCardDetails(detailCard) : null);
+
+  /** Ouvre la modale de détail (clic ou Entrée). */
+  async function openDetail(card) {
+    detailTriggerEl = document.activeElement;
+    detailCard = card;
+    announceCardDetails(card); // annonce sr-only en plus du visuel
+    await tick();
+    detailDialog?.showModal();
+  }
+
+  /** Ferme la modale de détail et retourne le focus à la carte source. */
+  function closeDetail() {
+    detailCard = null;
+    detailDialog?.close();
+    if (detailTriggerEl) {
+      detailTriggerEl.focus();
+      detailTriggerEl = null;
     }
   }
 </script>
@@ -247,11 +261,17 @@
       <ul class="column-body" role="list">
         {#each storiesByStatus[col.key] as s (s.id)}
           {@const tdd = tddBadge(s.tdd_phase)}
+          <!-- Enter (détails) est géré par le handler clavier global du board ; onclick couvre la souris. -->
+          <!-- svelte-ignore a11y_click_events_have_key_events -->
+          <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
+          <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
           <li
             class="card"
             class:read-only={s._writable === false}
             draggable={s._writable !== false}
             ondragstart={(e) => onDragStart(e, s.id)}
+            onfocus={() => syncFocus(s.id)}
+            onclick={() => openDetail(s)}
             aria-label="{s.id} {s.title}{s._writable === false ? ' (lecture seule)' : ''}"
             data-card-id={s.id}
             tabindex="0"
@@ -361,6 +381,51 @@
         </button>
       {/each}
       <button onclick={() => closeMoveMenu()}>Annuler (Échap)</button>
+    </div>
+  </dialog>
+{/if}
+
+<!--
+  Modale de détail de carte : <dialog> natif (piège de focus + aria-modal natifs).
+  Ouverte au clic ou via Entrée (WCAG SC 1.3.2, 2.1.2, 2.4.3).
+-->
+{#if detailFields}
+  <dialog
+    bind:this={detailDialog}
+    class="detail-dialog"
+    aria-labelledby="detail-title"
+    onclose={() => { if (detailCard) closeDetail(); }}
+  >
+    <div class="detail-content">
+      <header class="detail-header">
+        <span class="detail-id">{detailFields.id}</span>
+        {#if detailFields.readOnly}
+          <span class="detail-lock" aria-label="Lecture seule" role="img">🔒</span>
+        {/if}
+        <button class="detail-close" onclick={() => closeDetail()} aria-label="Fermer">✕</button>
+      </header>
+      <h3 id="detail-title">{detailFields.title}</h3>
+
+      <dl class="detail-grid">
+        <dt>Statut</dt><dd>{detailFields.status}</dd>
+        <dt>Priorité</dt><dd>{detailFields.priority || '—'}</dd>
+        <dt>Points</dt><dd>{detailFields.storyPoints}</dd>
+        {#if detailFields.epicId}<dt>Epic</dt><dd>{detailFields.epicId}</dd>{/if}
+        {#if detailFields.persona}<dt>Persona</dt><dd>{detailFields.persona}</dd>{/if}
+        {#if detailFields.assignedTo}<dt>Assigné à</dt><dd>{detailFields.assignedTo}</dd>{/if}
+        {#if detailFields.tddPhase}<dt>TDD</dt><dd>{detailFields.tddPhase}</dd>{/if}
+        {#if detailFields.tasks.total > 0}
+          <dt>Tâches</dt><dd>{detailFields.tasks.completed}/{detailFields.tasks.total}</dd>
+        {/if}
+        {#if detailFields.blockedReason}<dt>Bloqué</dt><dd>{detailFields.blockedReason}</dd>{/if}
+      </dl>
+
+      {#if detailFields.readOnly}
+        <p class="detail-readonly-note">
+          Carte en lecture seule — gérée par <code>.bmad/sprint-status.yaml</code> (BMAD v6 single-writer).
+          Changez son statut via les commandes <code>team:</code> / <code>qa:</code>.
+        </p>
+      {/if}
     </div>
   </dialog>
 {/if}
@@ -603,5 +668,90 @@
     color: var(--accent-fg);
     outline: 2px solid var(--accent);
     outline-offset: 1px;
+  }
+
+  /* Modale de détail de carte */
+  .detail-dialog {
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    padding: 0;
+    min-width: 340px;
+    max-width: 480px;
+    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+    color: var(--fg);
+  }
+  .detail-dialog::backdrop {
+    background: rgba(0, 0, 0, 0.5);
+  }
+  .detail-content {
+    padding: 20px;
+  }
+  .detail-header {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    margin-bottom: 4px;
+  }
+  .detail-id {
+    font-family: var(--mono);
+    font-weight: 600;
+    font-size: 13px;
+    color: var(--accent);
+  }
+  .detail-lock {
+    font-size: 13px;
+  }
+  .detail-close {
+    margin-left: auto;
+    background: transparent;
+    border: none;
+    color: var(--fg-dim);
+    cursor: pointer;
+    font-size: 16px;
+    line-height: 1;
+    padding: 4px;
+    border-radius: 4px;
+  }
+  .detail-close:hover,
+  .detail-close:focus-visible {
+    background: var(--bg-sidebar);
+    outline: 2px solid var(--accent);
+    outline-offset: 1px;
+  }
+  .detail-content h3 {
+    margin: 0 0 14px;
+    font-size: 16px;
+  }
+  .detail-grid {
+    display: grid;
+    grid-template-columns: auto 1fr;
+    gap: 6px 14px;
+    margin: 0;
+    font-size: 13px;
+  }
+  .detail-grid dt {
+    color: var(--fg-dim);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    align-self: center;
+  }
+  .detail-grid dd {
+    margin: 0;
+  }
+  .detail-readonly-note {
+    margin: 14px 0 0;
+    padding: 10px 12px;
+    background: var(--bg-sidebar);
+    border: 1px solid var(--border);
+    border-radius: var(--radius);
+    font-size: 12px;
+    color: var(--fg-dim);
+    line-height: 1.5;
+  }
+  .detail-readonly-note code {
+    font-family: var(--mono);
+    font-size: 11px;
   }
 </style>

--- a/tests/kanban/backlog-grouping.test.js
+++ b/tests/kanban/backlog-grouping.test.js
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import { groupStoriesByEpic } from '../../cli/kanban/client/src/lib/backlog.js';
+
+const story = (id, extra = {}) => ({ id, title: id, status: 'review', story_points: 1, ...extra });
+
+describe('groupStoriesByEpic', () => {
+  it('places a story under its known epic', () => {
+    const epics = [{ id: 'EPIC-001', title: 'Auth', business_value: 'high', status: 'in-progress' }];
+    const stories = [story('US-001', { epic_id: 'EPIC-001' })];
+
+    const { groups, orphans } = groupStoriesByEpic(stories, epics);
+
+    expect(orphans).toHaveLength(0);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].epic.id).toBe('EPIC-001');
+    expect(groups[0].epic.title).toBe('Auth');
+    expect(groups[0].stories.map((s) => s.id)).toEqual(['US-001']);
+  });
+
+  // Regression: BMAD v6 sprint-status.yaml stories carry epic_id="E1" with no markdown
+  // epic file, so store.epics is empty. The old code dropped them entirely (neither a
+  // known group nor an orphan) -> blank Backlog screen.
+  it('synthesizes a group for an unknown epic_id instead of dropping the story', () => {
+    const stories = [story('US-E1-01', { epic_id: 'E1' }), story('US-E1-02', { epic_id: 'E1' })];
+
+    const { groups, orphans } = groupStoriesByEpic(stories, []);
+
+    expect(orphans).toHaveLength(0);
+    expect(groups).toHaveLength(1);
+    expect(groups[0].epic.id).toBe('E1');
+    expect(groups[0].epic.title).toBe('E1');
+    expect(groups[0].stories.map((s) => s.id)).toEqual(['US-E1-01', 'US-E1-02']);
+  });
+
+  it('treats a story without epic_id as an orphan', () => {
+    const stories = [story('US-099', { epic_id: null })];
+
+    const { groups, orphans } = groupStoriesByEpic(stories, []);
+
+    expect(groups).toHaveLength(0);
+    expect(orphans.map((s) => s.id)).toEqual(['US-099']);
+  });
+
+  it('sorts groups by epic id, stories and orphans by id', () => {
+    const epics = [
+      { id: 'EPIC-002', title: 'B' },
+      { id: 'EPIC-001', title: 'A' },
+    ];
+    const stories = [
+      story('US-003', { epic_id: 'EPIC-001' }),
+      story('US-001', { epic_id: 'EPIC-001' }),
+      story('US-z', {}),
+      story('US-a', {}),
+    ];
+
+    const { groups, orphans } = groupStoriesByEpic(stories, epics);
+
+    expect(groups.map((g) => g.epic.id)).toEqual(['EPIC-001', 'EPIC-002']);
+    expect(groups[0].stories.map((s) => s.id)).toEqual(['US-001', 'US-003']);
+    expect(orphans.map((s) => s.id)).toEqual(['US-a', 'US-z']);
+  });
+
+  it('returns empty structures for no input', () => {
+    expect(groupStoriesByEpic([], [])).toEqual({ groups: [], orphans: [] });
+  });
+});

--- a/tests/kanban/kanban-nav.test.js
+++ b/tests/kanban/kanban-nav.test.js
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest';
+import { locateCard, reduceKey, buildCardDetails } from '../../cli/kanban/client/src/lib/kanban-nav.js';
+
+const COLUMNS = [
+  { key: 'backlog', label: 'Backlog' },
+  { key: 'ready-for-dev', label: 'Ready for Dev' },
+  { key: 'in-progress', label: 'In Progress' },
+  { key: 'review', label: 'Review' },
+  { key: 'done', label: 'Done' },
+  { key: 'blocked', label: 'Blocked' },
+];
+
+const card = (id, extra = {}) => ({ id, title: id, status: 'review', _writable: true, ...extra });
+
+// Two stories in the Review column (index 3), one in Blocked (index 5).
+function fixtureBoard() {
+  return {
+    backlog: [],
+    'ready-for-dev': [],
+    'in-progress': [],
+    review: [card('R-1'), card('R-2')],
+    done: [],
+    blocked: [card('B-1', { status: 'blocked', _writable: false })],
+  };
+}
+
+const ctx = () => ({ columns: COLUMNS, storiesByStatus: fixtureBoard() });
+const base = { focusedColumnIndex: 0, focusedCardIndex: -1, showMoveMenu: false };
+
+describe('locateCard', () => {
+  it('finds the column/card index of a card by id', () => {
+    expect(locateCard(fixtureBoard(), COLUMNS, 'R-2')).toEqual({ columnIndex: 3, cardIndex: 1 });
+    expect(locateCard(fixtureBoard(), COLUMNS, 'B-1')).toEqual({ columnIndex: 5, cardIndex: 0 });
+  });
+
+  it('returns null for an unknown card', () => {
+    expect(locateCard(fixtureBoard(), COLUMNS, 'NOPE')).toBeNull();
+  });
+});
+
+describe('reduceKey — vertical navigation', () => {
+  it('ArrowDown clamps within the focused column and emits a focus action', () => {
+    // Focused on R-1 (column 3, card 0)
+    const state = { focusedColumnIndex: 3, focusedCardIndex: 0, showMoveMenu: false };
+    const r1 = reduceKey(state, { key: 'ArrowDown' }, ctx());
+    expect(r1.state.focusedCardIndex).toBe(1);
+    expect(r1.action).toEqual({ type: 'focus', cardId: 'R-2' });
+
+    // Already at the last card -> stays clamped
+    const r2 = reduceKey(r1.state, { key: 'ArrowDown' }, ctx());
+    expect(r2.state.focusedCardIndex).toBe(1);
+  });
+
+  it('ArrowUp clamps at 0', () => {
+    const state = { focusedColumnIndex: 3, focusedCardIndex: 0, showMoveMenu: false };
+    const r = reduceKey(state, { key: 'ArrowUp' }, ctx());
+    expect(r.state.focusedCardIndex).toBe(0);
+  });
+});
+
+describe('reduceKey — horizontal navigation', () => {
+  it('ArrowRight moves to the next column, resets card index and focuses its first card', () => {
+    // From an empty column (0) to the right; lands on review (3) which has cards only after
+    // passing empty 1 and 2. Step once: column 1 (empty) -> no focus action.
+    const fromReview = { focusedColumnIndex: 2, focusedCardIndex: 0, showMoveMenu: false };
+    const r = reduceKey(fromReview, { key: 'ArrowRight' }, ctx());
+    expect(r.state.focusedColumnIndex).toBe(3);
+    expect(r.state.focusedCardIndex).toBe(0);
+    expect(r.action).toEqual({ type: 'focus', cardId: 'R-1' });
+  });
+
+  it('ArrowLeft clamps at column 0', () => {
+    const r = reduceKey(base, { key: 'ArrowLeft' }, ctx());
+    expect(r.state.focusedColumnIndex).toBe(0);
+  });
+
+  it('ArrowRight clamps at the last column', () => {
+    const state = { focusedColumnIndex: 5, focusedCardIndex: 0, showMoveMenu: false };
+    const r = reduceKey(state, { key: 'ArrowRight' }, ctx());
+    expect(r.state.focusedColumnIndex).toBe(5);
+  });
+});
+
+describe('reduceKey — move menu', () => {
+  it('Alt+M opens the menu when a card is focused', () => {
+    const state = { focusedColumnIndex: 3, focusedCardIndex: 0, showMoveMenu: false };
+    const r = reduceKey(state, { key: 'm', altKey: true }, ctx());
+    expect(r.state.showMoveMenu).toBe(true);
+    expect(r.action).toEqual({ type: 'open-menu' });
+  });
+
+  it('Alt+M does nothing when no card is focused', () => {
+    const state = { focusedColumnIndex: 0, focusedCardIndex: -1, showMoveMenu: false };
+    const r = reduceKey(state, { key: 'm', altKey: true }, ctx());
+    expect(r.state.showMoveMenu).toBe(false);
+    expect(r.action).toBeNull();
+  });
+
+  it('Alt+M closes the menu when already open', () => {
+    const state = { focusedColumnIndex: 3, focusedCardIndex: 0, showMoveMenu: true };
+    const r = reduceKey(state, { key: 'm', altKey: true }, ctx());
+    expect(r.state.showMoveMenu).toBe(false);
+    expect(r.action).toEqual({ type: 'close-menu' });
+  });
+
+  it('number key with menu open emits a move action for a writable card', () => {
+    const state = { focusedColumnIndex: 3, focusedCardIndex: 0, showMoveMenu: true };
+    const r = reduceKey(state, { key: '5' }, ctx());
+    expect(r.action).toEqual({ type: 'move', cardId: 'R-1', targetStatus: 'done' });
+  });
+
+  it('number key on a read-only card emits a readonly action, not a move', () => {
+    const state = { focusedColumnIndex: 5, focusedCardIndex: 0, showMoveMenu: true };
+    const r = reduceKey(state, { key: '1' }, ctx());
+    expect(r.action).toEqual({ type: 'readonly', cardId: 'B-1' });
+  });
+
+  it('Escape closes the menu when open', () => {
+    const state = { focusedColumnIndex: 3, focusedCardIndex: 0, showMoveMenu: true };
+    const r = reduceKey(state, { key: 'Escape' }, ctx());
+    expect(r.state.showMoveMenu).toBe(false);
+    expect(r.action).toEqual({ type: 'close-menu' });
+  });
+});
+
+describe('reduceKey — details', () => {
+  it('Enter on a focused card emits a details action with the card', () => {
+    const state = { focusedColumnIndex: 3, focusedCardIndex: 1, showMoveMenu: false };
+    const r = reduceKey(state, { key: 'Enter' }, ctx());
+    expect(r.action.type).toBe('details');
+    expect(r.action.card.id).toBe('R-2');
+  });
+
+  it('Enter while the menu is open does not open details', () => {
+    const state = { focusedColumnIndex: 3, focusedCardIndex: 1, showMoveMenu: true };
+    const r = reduceKey(state, { key: 'Enter' }, ctx());
+    expect(r.action).not.toMatchObject({ type: 'details' });
+  });
+
+  it('unhandled keys return the state unchanged and a null action', () => {
+    const r = reduceKey(base, { key: 'x' }, ctx());
+    expect(r.state).toEqual(base);
+    expect(r.action).toBeNull();
+  });
+});
+
+describe('buildCardDetails', () => {
+  it('maps a story into a display object', () => {
+    const story = {
+      id: 'US-E1-02',
+      title: 'Atomes web',
+      status: 'review',
+      priority: 'should',
+      story_points: 8,
+      epic_id: 'E1',
+      persona: 'P-001',
+      assigned_to: 'workflow',
+      tdd_phase: 'green',
+      tasks: { total: 4, completed: 2 },
+      _writable: false,
+    };
+    const d = buildCardDetails(story);
+    expect(d).toMatchObject({
+      id: 'US-E1-02',
+      title: 'Atomes web',
+      status: 'review',
+      priority: 'should',
+      storyPoints: 8,
+      epicId: 'E1',
+      persona: 'P-001',
+      assignedTo: 'workflow',
+      tddPhase: 'green',
+      readOnly: true,
+    });
+    expect(d.tasks).toEqual({ total: 4, completed: 2 });
+  });
+
+  it('flags writable stories as not read-only and tolerates missing fields', () => {
+    const d = buildCardDetails({ id: 'US-1', title: 'x', status: 'backlog', _writable: true });
+    expect(d.readOnly).toBe(false);
+    expect(d.tasks).toEqual({ total: 0, completed: 0 });
+    expect(d.blockedReason).toBe('');
+  });
+});


### PR DESCRIPTION
## Contexte

L'interface web de suivi (`claude-craft kanban`, SPA Svelte 5) présentait 4 bugs rapportés en l'utilisant sur un vrai projet BMAD v6 (toutes les cartes proviennent de `.bmad/sprint-status.yaml`, donc `_writable:false` 🔒 avec `epic_id="E1"` sans epic markdown).

## Corrections (TDD-first, logique pure testée en vitest)

| Bug | Cause racine | Fix |
|-----|--------------|-----|
| **Backlog vide** | `BacklogView` droppait les stories dont `epic_id` est défini mais absent de `store.epics` | `groupStoriesByEpic()` synthétise un groupe pour les `epic_id` inconnus |
| **Raccourcis clavier KO** | `focusedColumnIndex/Index` jamais synchronisés avec la carte focus (défaut colonne 0 = Backlog vide) | `onfocus` → `locateCard()` ; handler = adaptateur fin sur `reduceKey()` pur |
| **Détails inaccessibles** | Aucune modale (Entrée = annonce sr-only invisible) | `<dialog>` natif au clic/Entrée via `buildCardDetails()` |
| **Déplacement silencieux** | Cartes read-only refusées serveur (409, single-writer **gardé**) sans feedback visuel | Toast visible + note explicite dans la modale |
| _Bonus_ | Race d'ouverture des `<dialog>` | `Promise.resolve()` → `tick()` |

## Tests

- `tests/kanban/backlog-grouping.test.js` + `tests/kanban/kanban-nav.test.js` : **23 tests RED-first**
- Suite complète : **1011 tests / 67 fichiers ✓**, eslint ✓, build client ✓
- Vérif visuelle Chrome sur `tests/fixtures/bmad-sprint-status` : les 4 comportements OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)