### PR TITLE
chore(release): 8.13.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.13.0",
+      "version": "8.13.1",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.13.0",
+  "version": "8.13.1",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.13.0 | **Languages:** en, fr, es, de, pt
+**Version:** 8.13.1 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.13.1] - 2026-06-14
+
+### Fixed
+- **Dashboard Kanban web (`claude-craft kanban`, SPA Svelte 5) — 4 bugs corrigés en TDD** (remontés sur un projet BMAD v6 réel où toutes les cartes proviennent de `.bmad/sprint-status.yaml`, donc `_writable:false`) :
+  - **Vue Backlog vide** : `BacklogView` éliminait les stories dont `epic_id` est défini mais absent de `store.epics` (les stories YAML BMAD v6 portent `epic_id="E1"` sans fichier epic markdown) → écran blanc. Nouveau module pur `groupStoriesByEpic()` synthétise un groupe pour les `epic_id` inconnus au lieu de les perdre.
+  - **Raccourcis clavier inopérants** : `focusedColumnIndex`/`focusedCardIndex` n'étaient jamais synchronisés avec la carte réellement focus (défaut colonne 0 = Backlog vide) → flèches/Alt+M/Entrée agissaient sur la mauvaise colonne. Synchronisation via `onfocus`→`locateCard()` et handler réécrit en adaptateur fin sur un reducer pur `reduceKey()`.
+  - **Détails de carte inaccessibles** : aucune modale n'existait (Entrée n'écrivait que dans une région `aria-live` invisible). Ajout d'une modale `<dialog>` native ouverte au clic/Entrée via `buildCardDetails()`.
+  - **Déplacement en échec silencieux** : les cartes `sprint-status.yaml` (refusées serveur en 409 par design — single-writer conservé) affichent désormais un toast visible + une note explicite dans la modale.
+  - Correctif latent : race d'ouverture des `<dialog>` (`Promise.resolve()` → `tick()`).
+  - Tests RED-first : `tests/kanban/backlog-grouping.test.js` + `tests/kanban/kanban-nav.test.js` (logique pure, 23 tests). Suite complète verte. (#77)
+
 ## [8.13.0] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Plus **11 stack-specific reviewers** (@symfony-reviewer, @react-reviewer, @pytho
 
 A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, 48 skills**, all token-optimized via `context: fork` and sub-agent model routing.
 
-## What's New in v8.13.0
+## What's New in v8.13.1
+
+**Corrections de l'interface web Kanban (v8.13.1) :**
+
+- **Dashboard Kanban réparé** : 4 bugs corrigés en TDD sur le SPA Svelte 5 (`claude-craft kanban`) — vue Backlog vide (stories à `epic_id` inconnu désormais regroupées au lieu d'être perdues), raccourcis clavier inopérants (synchronisation focus + reducer pur), détails de carte inaccessibles (modale au clic/Entrée), et feedback visible (toast) au lieu d'un échec silencieux sur les cartes read-only `sprint-status.yaml`.
 
 **Fiabilité BMAD + distribution AgentTeams (v8.13.0) :**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.13.0",
+  "version": "8.13.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-bearded-bear/claude-craft",
-      "version": "8.13.0",
+      "version": "8.13.1",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.13.0",
+  "version": "8.13.1",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
Patch release des correctifs de l'interface web Kanban (#77).

## Changements
- `package.json` / lock / `plugin.json` / `marketplace.json` → **8.13.1**
- `.claude/CLAUDE.md` header → 8.13.1
- `CHANGELOG.md` : entrée 8.13.1 (Backlog grouping, nav clavier, modale détails, feedback read-only, `tick()`)
- `README.md` : section What's New v8.13.1
- `website/LandingPage.vue` : badges hero → v8.13.1 (5 langues, on-disk, gitignored)

## Validation
- `npm test` : **1011 ✓ / 67 fichiers** · `npm run lint` ✓
- `docs:check` ✓ · `verify-versions` ✓

Le tag `v8.13.1` poussé après merge déclenche la publication npm via la CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)