### PR TITLE
feat(kanban): expose all EPICs/US/Tasks/Sprints/Retro/Review in web UI

### DIFF
--- a/cli/kanban/client/src/App.svelte
+++ b/cli/kanban/client/src/App.svelte
@@ -8,6 +8,7 @@
   const lazyBurndown = () => import('./views/BurndownView.svelte');
   const lazyDeps = () => import('./views/DepsView.svelte');
   const lazyDocs = () => import('./views/DocsView.svelte');
+  const lazySprints = () => import('./views/SprintsView.svelte');
 
   onMount(async () => {
     await Promise.all([loadStories(), loadSprint()]);
@@ -19,6 +20,7 @@
   const navItems = [
     { path: '/kanban', label: 'Kanban' },
     { path: '/backlog', label: 'Backlog' },
+    { path: '/sprints', label: 'Sprints' },
     { path: '/burndown', label: 'Burndown' },
     { path: '/deps', label: 'Dependencies' },
     { path: '/docs', label: 'Docs' },
@@ -75,6 +77,13 @@
       <KanbanView />
     {:else if currentPath() === '/backlog'}
       <BacklogView />
+    {:else if currentPath() === '/sprints'}
+      {#await lazySprints()}
+        <div class="empty">Loading…</div>
+      {:then mod}
+        {@const Comp = mod.default}
+        <Comp />
+      {/await}
     {:else if currentPath() === '/burndown'}
       {#await lazyBurndown()}
         <div class="empty">Loading…</div>

--- a/cli/kanban/client/src/lib/router.svelte.js
+++ b/cli/kanban/client/src/lib/router.svelte.js
@@ -1,5 +1,5 @@
 // Minimal hash-based router using Svelte 5 runes.
-// Routes : #/kanban, #/backlog, #/burndown, #/deps, #/docs[/<path>]
+// Routes : #/kanban, #/backlog, #/sprints[/<id>], #/burndown, #/deps, #/docs[/<path>]
 
 function parse() {
   const raw = window.location.hash.slice(1) || '/kanban';

--- a/cli/kanban/client/src/lib/sprints.js
+++ b/cli/kanban/client/src/lib/sprints.js
@@ -1,0 +1,34 @@
+// Pure sprint-summary logic (no DOM, no Svelte) — unit-tested in tests/kanban/sprints.test.js.
+
+/**
+ * Roll up a sprint aggregation entry against the full story list.
+ * @param {{ id:string, files?:object[], goalPath?:string|null }} sprintEntry
+ *   — shaped like a repository.sprints Map value
+ * @param {Array<{ sprint_id?:string, status?:string, story_points?:number }>} stories
+ * @returns {{ id:string, story_count:number, total_points:number, done_points:number,
+ *            has_goal:boolean, has_review:boolean, has_retro:boolean }}
+ */
+export function summarizeSprint(sprintEntry, stories) {
+  const files = sprintEntry.files ?? [];
+  const mine = stories.filter((s) => s.sprint_id === sprintEntry.id);
+  return {
+    id: sprintEntry.id,
+    story_count: mine.length,
+    total_points: mine.reduce((n, s) => n + (s.story_points ?? 0), 0),
+    done_points: mine
+      .filter((s) => s.status === 'done')
+      .reduce((n, s) => n + (s.story_points ?? 0), 0),
+    has_goal: !!sprintEntry.goalPath,
+    has_review: files.some((f) => f.category === 'sprint-review'),
+    has_retro: files.some((f) => f.category === 'sprint-retro'),
+  };
+}
+
+/**
+ * Sort sprint summaries by id descending (most recent sprint first).
+ * @param {Array<{ id:string }>} summaries
+ * @returns {Array<{ id:string }>}
+ */
+export function sortSprints(summaries) {
+  return [...summaries].sort((a, b) => b.id.localeCompare(a.id));
+}

--- a/cli/kanban/client/src/lib/sprints.js
+++ b/cli/kanban/client/src/lib/sprints.js
@@ -15,9 +15,7 @@ export function summarizeSprint(sprintEntry, stories) {
     id: sprintEntry.id,
     story_count: mine.length,
     total_points: mine.reduce((n, s) => n + (s.story_points ?? 0), 0),
-    done_points: mine
-      .filter((s) => s.status === 'done')
-      .reduce((n, s) => n + (s.story_points ?? 0), 0),
+    done_points: mine.filter((s) => s.status === 'done').reduce((n, s) => n + (s.story_points ?? 0), 0),
     has_goal: !!sprintEntry.goalPath,
     has_review: files.some((f) => f.category === 'sprint-review'),
     has_retro: files.some((f) => f.category === 'sprint-retro'),

--- a/cli/kanban/client/src/views/KanbanView.svelte
+++ b/cli/kanban/client/src/views/KanbanView.svelte
@@ -15,6 +15,11 @@
   let detailCard = $state(null);
   /** Élément ayant déclenché l'ouverture de la modale (pour retour de focus) */
   let detailTriggerEl = $state(null);
+  /** Tâches associées à la story affichée (chargées à l'ouverture via /api/stories/:id) */
+  let detailTasks = $state([]);
+  /** Corps markdown de la story rendu en HTML (AC, Gherkin…) */
+  let detailBody = $state('');
+  let detailLoading = $state(false);
 
   const COLUMNS = [
     { key: 'backlog', label: 'Backlog', emptyHint: 'No stories — run /workflow:plan' },
@@ -228,14 +233,44 @@
   async function openDetail(card) {
     detailTriggerEl = document.activeElement;
     detailCard = card;
+    detailTasks = [];
+    detailBody = '';
     announceCardDetails(card); // annonce sr-only en plus du visuel
     await tick();
     detailDialog?.showModal();
+    loadDetailExtras(card.id);
+  }
+
+  /**
+   * Charge tâches + corps markdown de la story et rend le markdown.
+   * marked/DOMPurify importés dynamiquement pour ne pas alourdir le bundle du board.
+   */
+  async function loadDetailExtras(id) {
+    detailLoading = true;
+    try {
+      const res = await fetch(`/api/stories/${encodeURIComponent(id)}`);
+      if (!res.ok) return;
+      const data = await res.json();
+      // La story affichée peut avoir changé entre-temps : on ignore une réponse périmée.
+      if (detailCard?.id !== id) return;
+      detailTasks = data.tasks ?? [];
+      if (data.body) {
+        const [{ marked }, dompurify] = await Promise.all([import('marked'), import('dompurify')]);
+        const DOMPurify = dompurify.default ?? dompurify;
+        if (detailCard?.id === id) detailBody = DOMPurify.sanitize(marked.parse(data.body));
+      }
+    } catch {
+      /* on garde les détails de base issus du frontmatter */
+    } finally {
+      detailLoading = false;
+    }
   }
 
   /** Ferme la modale de détail et retourne le focus à la carte source. */
   function closeDetail() {
     detailCard = null;
+    detailTasks = [];
+    detailBody = '';
     detailDialog?.close();
     if (detailTriggerEl) {
       detailTriggerEl.focus();
@@ -419,6 +454,34 @@
         {/if}
         {#if detailFields.blockedReason}<dt>Bloqué</dt><dd>{detailFields.blockedReason}</dd>{/if}
       </dl>
+
+      {#if detailTasks.length > 0}
+        <h4 class="detail-subtitle">Tâches ({detailFields.tasks.completed}/{detailFields.tasks.total})</h4>
+        <table class="detail-tasks">
+          <thead>
+            <tr><th>ID</th><th>Type</th><th>Statut</th><th>Est.</th><th>Réel</th><th>Assigné</th></tr>
+          </thead>
+          <tbody>
+            {#each detailTasks as t}
+              <tr>
+                <td>{t.id}</td>
+                <td>{t.type}</td>
+                <td>{t.status}</td>
+                <td>{t.estimation_hours ?? '—'}</td>
+                <td>{t.actual_hours ?? '—'}</td>
+                <td>{t.assigned_to || '—'}</td>
+              </tr>
+            {/each}
+          </tbody>
+        </table>
+      {:else if detailLoading}
+        <p class="detail-muted">Chargement des tâches…</p>
+      {/if}
+
+      {#if detailBody}
+        <h4 class="detail-subtitle">Description</h4>
+        <div class="detail-body markdown-body">{@html detailBody}</div>
+      {/if}
 
       {#if detailFields.readOnly}
         <p class="detail-readonly-note">
@@ -753,5 +816,85 @@
   .detail-readonly-note code {
     font-family: var(--mono);
     font-size: 11px;
+  }
+
+  .detail-subtitle {
+    margin: 18px 0 8px;
+    font-size: 13px;
+    font-weight: 700;
+    color: var(--fg-dim);
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+  }
+
+  .detail-muted {
+    font-size: 12px;
+    color: var(--fg-dim);
+    margin: 8px 0 0;
+  }
+
+  .detail-tasks {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 12px;
+  }
+  .detail-tasks th,
+  .detail-tasks td {
+    border: 1px solid var(--border);
+    padding: 5px 8px;
+    text-align: left;
+  }
+  .detail-tasks th {
+    background: var(--bg-sidebar);
+    font-weight: 600;
+  }
+
+  .detail-body {
+    font-size: 13px;
+    line-height: 1.6;
+    color: var(--fg);
+  }
+  .detail-body :global(h1),
+  .detail-body :global(h2),
+  .detail-body :global(h3) {
+    font-size: 15px;
+    font-weight: 600;
+    margin: 14px 0 8px;
+  }
+  .detail-body :global(p) {
+    margin: 0 0 10px;
+  }
+  .detail-body :global(ul),
+  .detail-body :global(ol) {
+    margin: 0 0 10px;
+    padding-left: 20px;
+  }
+  .detail-body :global(code) {
+    background: var(--bg-sidebar);
+    padding: 2px 4px;
+    border-radius: 3px;
+    font-family: var(--mono);
+    font-size: 0.9em;
+  }
+  .detail-body :global(pre) {
+    background: var(--bg-sidebar);
+    padding: 10px;
+    border-radius: var(--radius);
+    overflow-x: auto;
+    border: 1px solid var(--border);
+  }
+  .detail-body :global(pre code) {
+    background: none;
+    padding: 0;
+  }
+  .detail-body :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0 0 10px;
+  }
+  .detail-body :global(th),
+  .detail-body :global(td) {
+    border: 1px solid var(--border);
+    padding: 6px 8px;
   }
 </style>

--- a/cli/kanban/client/src/views/SprintsView.svelte
+++ b/cli/kanban/client/src/views/SprintsView.svelte
@@ -1,0 +1,435 @@
+<script>
+  import { marked } from 'marked';
+  import DOMPurify from 'dompurify';
+  import { route, navigate } from '../lib/router.svelte.js';
+  import { sortSprints } from '../lib/sprints.js';
+
+  let sprints = $state([]);
+  let loadingList = $state(true);
+  let listError = $state(null);
+
+  let detail = $state(null);
+  let loadingDetail = $state(false);
+  let detailError = $state(null);
+
+  const selectedId = $derived(route.parts[1] ?? null);
+
+  async function loadList() {
+    loadingList = true;
+    listError = null;
+    try {
+      const res = await fetch('/api/sprints');
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      const data = await res.json();
+      sprints = sortSprints(data.sprints || []);
+    } catch (err) {
+      listError = err.message;
+    } finally {
+      loadingList = false;
+    }
+  }
+
+  async function loadDetail(id) {
+    if (!id) {
+      detail = null;
+      return;
+    }
+    loadingDetail = true;
+    detailError = null;
+    try {
+      const res = await fetch(`/api/sprints/${encodeURIComponent(id)}`);
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      detail = await res.json();
+    } catch (err) {
+      detailError = err.message;
+      detail = null;
+    } finally {
+      loadingDetail = false;
+    }
+  }
+
+  function render(md) {
+    if (!md) return '';
+    try {
+      return DOMPurify.sanitize(marked.parse(md));
+    } catch {
+      return '<p>Error rendering markdown</p>';
+    }
+  }
+
+  // Group a detail's tasks under their parent story for the stories table.
+  const tasksByStory = $derived.by(() => {
+    const map = {};
+    for (const t of detail?.tasks ?? []) {
+      (map[t.us_id] ??= []).push(t);
+    }
+    return map;
+  });
+
+  let expanded = $state(new Set());
+  function toggleStory(id) {
+    if (expanded.has(id)) expanded.delete(id);
+    else expanded.add(id);
+    expanded = new Set(expanded);
+  }
+
+  $effect(() => {
+    loadList();
+  });
+
+  $effect(() => {
+    loadDetail(selectedId);
+  });
+</script>
+
+<div class="sprints-container">
+  <aside class="sprints-sidebar" aria-label="Liste des sprints">
+    {#if loadingList}
+      <div class="muted">Loading…</div>
+    {:else if listError}
+      <div class="error">Error: {listError}</div>
+    {:else if sprints.length === 0}
+      <div class="muted">Aucun sprint</div>
+    {:else}
+      <nav class="sprint-list" aria-label="Sprints">
+        {#each sprints as s}
+          <button
+            class="sprint-item"
+            class:active={selectedId === s.id}
+            onclick={() => navigate(`/sprints/${s.id}`)}
+          >
+            <span class="sprint-id">{s.id}</span>
+            <span class="sprint-meta">{s.story_count} US · {s.done_points}/{s.total_points} pts</span>
+            <span class="badges">
+              {#if s.has_goal}<span class="badge" title="Sprint goal">goal</span>{/if}
+              {#if s.has_review}<span class="badge review" title="Sprint review">review</span>{/if}
+              {#if s.has_retro}<span class="badge retro" title="Retrospective">retro</span>{/if}
+            </span>
+          </button>
+        {/each}
+      </nav>
+    {/if}
+  </aside>
+
+  <div class="sprints-content" role="region" aria-label="Détail du sprint">
+    {#if !selectedId}
+      <div class="empty">Sélectionnez un sprint</div>
+    {:else if loadingDetail}
+      <div class="empty">Loading…</div>
+    {:else if detailError}
+      <div class="error">Error: {detailError}</div>
+    {:else if detail}
+      <header class="content-header">
+        <h1>{detail.sprint.id}</h1>
+      </header>
+
+      {#if detail.goal}
+        <section class="md-section">
+          <h2>Goal</h2>
+          <div class="markdown-body">{@html render(detail.goal)}</div>
+        </section>
+      {/if}
+
+      <section class="md-section">
+        <h2>Stories &amp; Tasks</h2>
+        {#if detail.stories.length === 0}
+          <p class="muted">Aucune story dans ce sprint.</p>
+        {:else}
+          <table class="stories-table">
+            <thead>
+              <tr><th></th><th>ID</th><th>Titre</th><th>Statut</th><th>Points</th><th>Assigné</th></tr>
+            </thead>
+            <tbody>
+              {#each detail.stories as st}
+                {@const tasks = tasksByStory[st.id] ?? []}
+                <tr>
+                  <td>
+                    {#if tasks.length}
+                      <button
+                        class="toggle"
+                        aria-expanded={expanded.has(st.id)}
+                        aria-label="Afficher les tâches de {st.id}"
+                        onclick={() => toggleStory(st.id)}
+                      >{expanded.has(st.id) ? '▼' : '▶'}</button>
+                    {/if}
+                  </td>
+                  <td>{st.id}</td>
+                  <td>{st.title}</td>
+                  <td><span class="status status-{st.status}">{st.status}</span></td>
+                  <td>{st.story_points ?? '—'}</td>
+                  <td>{st.assigned_to || '—'}</td>
+                </tr>
+                {#if expanded.has(st.id) && tasks.length}
+                  <tr class="tasks-row">
+                    <td></td>
+                    <td colspan="5">
+                      <table class="tasks-table">
+                        <thead>
+                          <tr><th>Task</th><th>Type</th><th>Statut</th><th>Est.</th><th>Réel</th><th>Assigné</th></tr>
+                        </thead>
+                        <tbody>
+                          {#each tasks as t}
+                            <tr>
+                              <td>{t.id}</td>
+                              <td>{t.type}</td>
+                              <td>{t.status}</td>
+                              <td>{t.estimation_hours ?? '—'}</td>
+                              <td>{t.actual_hours ?? '—'}</td>
+                              <td>{t.assigned_to || '—'}</td>
+                            </tr>
+                          {/each}
+                        </tbody>
+                      </table>
+                    </td>
+                  </tr>
+                {/if}
+              {/each}
+            </tbody>
+          </table>
+        {/if}
+      </section>
+
+      {#if detail.review}
+        <section class="md-section">
+          <h2>Review</h2>
+          <div class="markdown-body">{@html render(detail.review)}</div>
+        </section>
+      {/if}
+
+      {#if detail.retro}
+        <section class="md-section">
+          <h2>Retro</h2>
+          <div class="markdown-body">{@html render(detail.retro)}</div>
+        </section>
+      {/if}
+    {/if}
+  </div>
+</div>
+
+<style>
+  .sprints-container {
+    display: flex;
+    height: 100%;
+    overflow: hidden;
+  }
+
+  .sprints-sidebar {
+    width: 240px;
+    background: var(--bg-sidebar);
+    border-right: 1px solid var(--border);
+    overflow-y: auto;
+    padding: 12px 8px;
+  }
+
+  .sprint-list {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+  }
+
+  .sprint-item {
+    background: none;
+    border: none;
+    text-align: left;
+    cursor: pointer;
+    border-radius: var(--radius);
+    padding: 8px 10px;
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    color: var(--fg);
+    transition: background 0.1s;
+  }
+
+  .sprint-item:hover {
+    background: var(--border);
+  }
+
+  .sprint-item.active {
+    background: var(--accent);
+    color: var(--accent-fg);
+  }
+
+  .sprint-item:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: -2px;
+  }
+
+  .sprint-id {
+    font-weight: 600;
+    font-size: 13px;
+  }
+
+  .sprint-meta {
+    font-size: 11px;
+    color: var(--fg-dim);
+  }
+
+  .sprint-item.active .sprint-meta {
+    color: var(--accent-fg);
+  }
+
+  .badges {
+    display: flex;
+    gap: 4px;
+    flex-wrap: wrap;
+  }
+
+  .badge {
+    font-size: 10px;
+    padding: 1px 6px;
+    border-radius: 10px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+    color: var(--fg-dim);
+  }
+
+  .badge.review {
+    border-color: var(--accent);
+    color: var(--accent);
+  }
+
+  .badge.retro {
+    border-color: var(--success, #16a34a);
+    color: var(--success, #16a34a);
+  }
+
+  .sprints-content {
+    flex: 1;
+    overflow-y: auto;
+    padding: 20px;
+    background: var(--bg);
+  }
+
+  .content-header {
+    margin-bottom: 16px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid var(--border);
+  }
+
+  .content-header h1 {
+    margin: 0;
+    font-size: 20px;
+    font-weight: 600;
+    color: var(--fg);
+  }
+
+  .md-section {
+    margin-bottom: 28px;
+  }
+
+  .md-section h2 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--fg);
+    margin: 0 0 10px;
+  }
+
+  .stories-table,
+  .tasks-table {
+    border-collapse: collapse;
+    width: 100%;
+    font-size: 13px;
+  }
+
+  .stories-table th,
+  .stories-table td,
+  .tasks-table th,
+  .tasks-table td {
+    border: 1px solid var(--border);
+    padding: 6px 10px;
+    text-align: left;
+  }
+
+  .stories-table th,
+  .tasks-table th {
+    background: var(--bg-sidebar);
+    font-weight: 600;
+  }
+
+  .tasks-row td {
+    background: var(--bg-sidebar);
+    padding: 6px;
+  }
+
+  .toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--fg-dim);
+    font-size: 10px;
+  }
+
+  .toggle:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+  }
+
+  .status {
+    font-size: 11px;
+    padding: 1px 6px;
+    border-radius: 10px;
+    background: var(--bg-elev);
+    border: 1px solid var(--border);
+  }
+
+  .empty,
+  .muted {
+    color: var(--fg-dim);
+    padding: 12px;
+  }
+
+  .error {
+    color: var(--danger);
+    padding: 12px;
+  }
+
+  .markdown-body {
+    line-height: 1.7;
+  }
+
+  .markdown-body :global(h1) {
+    font-size: 22px;
+    margin: 16px 0 12px;
+  }
+
+  .markdown-body :global(h2) {
+    font-size: 18px;
+    margin: 14px 0 10px;
+  }
+
+  .markdown-body :global(table) {
+    border-collapse: collapse;
+    width: 100%;
+    margin: 0 0 12px;
+  }
+
+  .markdown-body :global(th),
+  .markdown-body :global(td) {
+    border: 1px solid var(--border);
+    padding: 8px 12px;
+    text-align: left;
+  }
+
+  .markdown-body :global(th) {
+    background: var(--bg-sidebar);
+    font-weight: 600;
+  }
+
+  .markdown-body :global(blockquote) {
+    border-left: 3px solid var(--accent);
+    padding-left: 12px;
+    margin: 0 0 12px;
+    color: var(--fg-dim);
+    font-style: italic;
+  }
+
+  .markdown-body :global(code) {
+    background: var(--bg-sidebar);
+    padding: 2px 4px;
+    border-radius: 3px;
+    font-family: var(--mono);
+    font-size: 0.9em;
+  }
+</style>

--- a/cli/kanban/server/app.js
+++ b/cli/kanban/server/app.js
@@ -57,7 +57,8 @@ export function createApp({ repository, port, readonly = false, eventBus = null,
     const story = repository.getStory(id);
     if (!story) return c.json({ error: 'not_found' }, 404);
     const tasks = repository.listTasksForStory(id);
-    return c.json({ story, tasks });
+    const body = repository.getStoryBody(id);
+    return c.json({ story, tasks, body });
   });
 
   app.get('/api/dependencies', (c) => {

--- a/cli/kanban/server/app.js
+++ b/cli/kanban/server/app.js
@@ -65,7 +65,7 @@ export function createApp({ repository, port, readonly = false, eventBus = null,
   });
 
   app.get('/api/docs', (c) => {
-    return c.json({ docs: repository.listDocs().map((d) => ({ rel: d.rel })) });
+    return c.json({ docs: repository.listDocs().map((d) => ({ rel: d.rel, category: d.category })) });
   });
 
   app.get('/api/docs/:rel{.+}', async (c) => {
@@ -212,6 +212,69 @@ export function createApp({ repository, port, readonly = false, eventBus = null,
         tasks: s.tasks,
       })),
       burndown,
+    });
+  });
+
+  // List every scanned sprint with rolled-up story/point counts.
+  // Declared after /api/sprints/current so :id below never captures "current".
+  app.get('/api/sprints', (c) => {
+    const allStories = repository.listStories();
+    const sprints = repository.listSprints().map((s) => {
+      const stories = allStories.filter((st) => st.sprint_id === s.id);
+      return {
+        ...s,
+        story_count: stories.length,
+        total_points: stories.reduce((n, st) => n + (st.story_points ?? 0), 0),
+        done_points: stories.filter((st) => st.status === 'done').reduce((n, st) => n + (st.story_points ?? 0), 0),
+      };
+    });
+    return c.json({ sprints });
+  });
+
+  // Sprint detail : stories + their tasks, plus goal/review/retro markdown bodies.
+  app.get('/api/sprints/:id', async (c) => {
+    const id = c.req.param('id');
+    const sprint = repository.getSprint(id);
+    if (!sprint) return c.json({ error: 'not_found' }, 404);
+
+    const stories = repository.listStories({ sprintId: id });
+    const tasks = stories.flatMap((s) => repository.listTasksForStory(s.id));
+
+    // Read an optional markdown file under the project-management root only.
+    const readIfExists = async (absPath) => {
+      if (!absPath) return null;
+      try {
+        const rel = path.relative(repository.rootDir, absPath).split(path.sep).join('/');
+        resolveSafe(repository.rootDir, rel);
+        return await fs.promises.readFile(absPath, 'utf8');
+      } catch {
+        return null;
+      }
+    };
+
+    const goalFile = sprint.goalPath ?? null;
+    const reviewFile = sprint.files.find((f) => f.category === 'sprint-review')?.path ?? null;
+    const retroFile = sprint.files.find((f) => f.category === 'sprint-retro')?.path ?? null;
+
+    const [goal, review, retro] = await Promise.all([
+      readIfExists(goalFile),
+      readIfExists(reviewFile),
+      readIfExists(retroFile),
+    ]);
+
+    return c.json({
+      sprint: { id, has_goal: !!goalFile, has_review: !!reviewFile, has_retro: !!retroFile },
+      stories: stories.map((s) => ({
+        id: s.id,
+        title: s.title,
+        status: s.status,
+        story_points: s.story_points,
+        assigned_to: s.assigned_to,
+      })),
+      tasks,
+      goal,
+      review,
+      retro,
     });
   });
 

--- a/cli/kanban/server/services/file-scanner.js
+++ b/cli/kanban/server/services/file-scanner.js
@@ -55,6 +55,7 @@ function classify(rootDir, absPath) {
     if (rest === 'board.md') return 'board';
     if (rest.startsWith('status-')) return 'sprint-status-snapshot';
     if (rest === 'sprint-review.md') return 'sprint-review';
+    if (rest === 'sprint-retro.md') return 'sprint-retro';
     if (rest === 'sprint-dependencies.md') return 'sprint-deps';
     return 'sprint-other';
   }

--- a/cli/kanban/server/services/repository.js
+++ b/cli/kanban/server/services/repository.js
@@ -57,12 +57,25 @@ export class Repository {
       this.filesByPath.set(f.path, { kind: 'task', id: res.ok ? res.data.id : null });
     }
 
-    // Docs (root + architecture)
-    for (const category of ['doc', 'architecture']) {
+    // Docs browsable in the DocsView. Every markdown body that carries prose is
+    // exposed ; 'task' is excluded (frontmatter-only, already in the stories API).
+    const DOC_CATEGORIES = [
+      'doc',
+      'architecture',
+      'epic',
+      'story',
+      'sprint-goal',
+      'board',
+      'sprint-review',
+      'sprint-retro',
+      'sprint-deps',
+      'sprint-other',
+    ];
+    for (const category of DOC_CATEGORIES) {
       for (const f of groups[category] ?? []) {
         const rel = path.relative(this.rootDir, f.path).split(path.sep).join('/');
         const arr = this.docs.get(category) ?? [];
-        arr.push({ path: f.path, rel });
+        arr.push({ path: f.path, rel, category });
         this.docs.set(category, arr);
       }
     }
@@ -174,6 +187,31 @@ export class Repository {
     const known = this.listDocs().find((d) => d.rel === rel);
     if (!known) return null;
     return await readFile(known.path, 'utf8');
+  }
+
+  /**
+   * Summaries of every scanned sprint, sorted by id descending (most recent first).
+   * @returns {Array<{id:string, has_goal:boolean, has_review:boolean, has_retro:boolean, file_count:number}>}
+   */
+  listSprints() {
+    return [...this.sprints.values()]
+      .map((s) => ({
+        id: s.id,
+        has_goal: !!s.goalPath,
+        has_review: s.files.some((f) => f.category === 'sprint-review'),
+        has_retro: s.files.some((f) => f.category === 'sprint-retro'),
+        file_count: s.files.length,
+      }))
+      .sort((a, b) => b.id.localeCompare(a.id));
+  }
+
+  /**
+   * Raw sprint aggregation entry (files + tasks + goalPath) for the detail route.
+   * @param {string} id
+   * @returns {{ id:string, files:object[], tasks:string[], goalPath?:string } | undefined}
+   */
+  getSprint(id) {
+    return this.sprints.get(id);
   }
 
   buildDependenciesGraph() {

--- a/cli/kanban/server/services/repository.js
+++ b/cli/kanban/server/services/repository.js
@@ -170,6 +170,12 @@ export class Repository {
     return entry ? entry.path : null;
   }
 
+  /** Markdown body (prose after frontmatter) of a story, '' for YAML-only stories. */
+  getStoryBody(id) {
+    const entry = this.stories.get(id);
+    return entry?.body ?? '';
+  }
+
   listTasksForStory(usId) {
     return [...this.tasks.values()].filter((t) => t.ok && t.data.us_id === usId).map((t) => t.data);
   }

--- a/tests/fixtures/project-management/sprints/sprint-001-skeleton/sprint-retro.md
+++ b/tests/fixtures/project-management/sprints/sprint-001-skeleton/sprint-retro.md
@@ -1,0 +1,19 @@
+# Rétrospective - Sprint 001
+
+## Informations
+
+| Date       | Format   | Facilitateur |
+| ---------- | -------- | ------------ |
+| 2026-06-14 | Starfish | @alice       |
+
+## Observations
+
+- **Keep** : pairing efficace
+- **Stop** : commits non atomiques
+
+## Actions
+
+### Action 1
+
+- **Responsable** : @alice
+- **Status** : 🔵 À faire

--- a/tests/fixtures/project-management/sprints/sprint-001-skeleton/sprint-review.md
+++ b/tests/fixtures/project-management/sprints/sprint-001-skeleton/sprint-review.md
@@ -1,0 +1,20 @@
+# Sprint Review - Sprint 001
+
+## Sprint Goal
+
+> "Deliver authentication end-to-end."
+
+**Atteint : ⚠️**
+
+## Démonstration
+
+### US-001 : Login
+
+- **Démo par** : @alice
+- **Feedback** : OK
+
+## Métriques
+
+| Planifié | Livré | Vélocité |
+| -------- | ----- | -------- |
+| 5 pts    | 0 pts | 0 pts    |

--- a/tests/kanban/app.test.js
+++ b/tests/kanban/app.test.js
@@ -158,6 +158,23 @@ describe('GET /api/docs', () => {
     expect(rels).toContain('architecture/c4-context.md');
   });
 
+  it('also exposes backlog and sprint markdown bodies (epics, stories, goal, review, retro)', async () => {
+    const r = await req('GET', '/api/docs');
+    const { docs } = await r.json();
+    const rels = docs.map((d) => d.rel);
+    expect(rels).toContain('backlog/epics/EPIC-001-auth.md');
+    expect(rels).toContain('backlog/user-stories/US-001-login.md');
+    expect(rels).toContain('sprints/sprint-001-skeleton/sprint-goal.md');
+    expect(rels).toContain('sprints/sprint-001-skeleton/sprint-review.md');
+    expect(rels).toContain('sprints/sprint-001-skeleton/sprint-retro.md');
+  });
+
+  it('serves a sprint retro body', async () => {
+    const r = await req('GET', '/api/docs/sprints/sprint-001-skeleton/sprint-retro.md');
+    expect(r.status).toBe(200);
+    expect(await r.text()).toContain('Rétrospective');
+  });
+
   it('returns markdown content', async () => {
     const r = await req('GET', '/api/docs/prd.md');
     expect(r.status).toBe(200);
@@ -172,6 +189,42 @@ describe('GET /api/docs', () => {
   it('blocks path traversal', async () => {
     const r = await req('GET', '/api/docs/..%2F..%2Fetc%2Fpasswd');
     expect([400, 404]).toContain(r.status);
+  });
+});
+
+describe('GET /api/sprints', () => {
+  it('lists all sprints with rolled-up counts', async () => {
+    const r = await req('GET', '/api/sprints');
+    expect(r.status).toBe(200);
+    const { sprints } = await r.json();
+    const s = sprints.find((x) => x.id === 'sprint-001-skeleton');
+    expect(s).toBeTruthy();
+    expect(s.has_goal).toBe(true);
+    expect(s.has_review).toBe(true);
+    expect(s.has_retro).toBe(true);
+    expect(s.story_count).toBe(1);
+    expect(s.total_points).toBe(5);
+    expect(s.done_points).toBe(0);
+  });
+});
+
+describe('GET /api/sprints/:id', () => {
+  it('returns detail with goal, stories and tasks', async () => {
+    const r = await req('GET', '/api/sprints/sprint-001-skeleton');
+    expect(r.status).toBe(200);
+    const body = await r.json();
+    expect(body.sprint.id).toBe('sprint-001-skeleton');
+    expect(body.sprint.has_goal).toBe(true);
+    expect(body.goal).toContain('Walking Skeleton');
+    expect(body.review).toContain('Sprint Review');
+    expect(body.retro).toContain('Rétrospective');
+    expect(body.stories.map((s) => s.id)).toEqual(['US-001']);
+    expect(body.tasks.map((t) => t.id)).toContain('TASK-001');
+  });
+
+  it('404 on unknown sprint', async () => {
+    const r = await req('GET', '/api/sprints/sprint-999');
+    expect(r.status).toBe(404);
   });
 });
 

--- a/tests/kanban/app.test.js
+++ b/tests/kanban/app.test.js
@@ -123,13 +123,15 @@ describe('GET /api/events (SSE)', () => {
 });
 
 describe('GET /api/stories/:id', () => {
-  it('returns story + tasks', async () => {
+  it('returns story + tasks + markdown body', async () => {
     const r = await req('GET', '/api/stories/US-001');
     expect(r.status).toBe(200);
-    const { story, tasks } = await r.json();
+    const { story, tasks, body } = await r.json();
     expect(story.id).toBe('US-001');
     expect(tasks.length).toBe(1);
     expect(tasks[0].id).toBe('TASK-001');
+    expect(typeof body).toBe('string');
+    expect(body.length).toBeGreaterThan(0);
   });
 
   it('404 on unknown id', async () => {

--- a/tests/kanban/file-scanner.test.js
+++ b/tests/kanban/file-scanner.test.js
@@ -70,6 +70,7 @@ describe('FileScanner.classify', () => {
     ['sprints/sprint-001/board.md', 'board'],
     ['sprints/sprint-001/status-2026-01-30.md', 'sprint-status-snapshot'],
     ['sprints/sprint-001/sprint-review.md', 'sprint-review'],
+    ['sprints/sprint-001/sprint-retro.md', 'sprint-retro'],
     ['sprints/sprint-001/sprint-dependencies.md', 'sprint-deps'],
     ['architecture/c4-context.md', 'architecture'],
     ['architecture/erd.md', 'architecture'],

--- a/tests/kanban/sprints.test.js
+++ b/tests/kanban/sprints.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { summarizeSprint, sortSprints } from '../../cli/kanban/client/src/lib/sprints.js';
+
+const mkFile = (category, name) => ({
+  category,
+  path: `/pm/sprints/sprint-001/${name}`,
+});
+
+describe('summarizeSprint', () => {
+  it('counts stories and points belonging to the sprint', () => {
+    const entry = { id: 'sprint-001', files: [], goalPath: null };
+    const stories = [
+      { sprint_id: 'sprint-001', status: 'done', story_points: 3 },
+      { sprint_id: 'sprint-001', status: 'in-progress', story_points: 5 },
+      { sprint_id: 'sprint-002', status: 'done', story_points: 8 }, // excluded
+    ];
+    const s = summarizeSprint(entry, stories);
+    expect(s.story_count).toBe(2);
+    expect(s.total_points).toBe(8);
+    expect(s.done_points).toBe(3);
+  });
+
+  it('has_goal reflects goalPath presence', () => {
+    expect(summarizeSprint({ id: 'sprint-001', files: [], goalPath: '/x/sprint-goal.md' }, []).has_goal).toBe(true);
+    expect(summarizeSprint({ id: 'sprint-001', files: [] }, []).has_goal).toBe(false);
+  });
+
+  it('has_review is true when a sprint-review file exists', () => {
+    const entry = { id: 'sprint-001', files: [mkFile('sprint-review', 'sprint-review.md')] };
+    expect(summarizeSprint(entry, []).has_review).toBe(true);
+  });
+
+  it('has_retro is true for a sprint-retro file and false for board', () => {
+    expect(summarizeSprint({ id: 'sprint-001', files: [mkFile('sprint-retro', 'sprint-retro.md')] }, []).has_retro).toBe(
+      true
+    );
+    expect(summarizeSprint({ id: 'sprint-001', files: [mkFile('board', 'board.md')] }, []).has_retro).toBe(false);
+  });
+
+  it('returns zero counts when no story belongs to the sprint', () => {
+    const s = summarizeSprint({ id: 'sprint-001', files: [] }, [
+      { sprint_id: 'sprint-002', status: 'done', story_points: 5 },
+    ]);
+    expect(s.story_count).toBe(0);
+    expect(s.total_points).toBe(0);
+    expect(s.done_points).toBe(0);
+  });
+});
+
+describe('sortSprints', () => {
+  it('sorts by id descending', () => {
+    const input = [{ id: 'sprint-001' }, { id: 'sprint-003' }, { id: 'sprint-002' }];
+    expect(sortSprints(input).map((s) => s.id)).toEqual(['sprint-003', 'sprint-002', 'sprint-001']);
+  });
+
+  it('handles an empty array', () => {
+    expect(sortSprints([])).toEqual([]);
+  });
+
+  it('does not mutate the input array', () => {
+    const input = [{ id: 'a' }, { id: 'b' }];
+    sortSprints(input);
+    expect(input.map((s) => s.id)).toEqual(['a', 'b']);
+  });
+});


### PR DESCRIPTION
## Contexte

L'interface web Kanban (`cli/kanban/`, SPA Svelte 5 + serveur Hono) n'exposait qu'une partie du modèle BMAD v6 : board des stories, grouping epics, burndown du sprint courant, deps, docs racine. Les **rétrospectives, reviews, l'ensemble des sprints** et les **corps markdown** des artefacts étaient scannés sur disque mais inaccessibles dans l'UI. Le détail d'une US ne montrait que le frontmatter.

## Changements

### Sprints / Retro / Review + docs élargis (`8843d997`)
- **file-scanner** : catégorie dédiée `sprint-retro`.
- **repository** : `listDocs()` élargi (epic/story/sprint-goal/board/review/retro/deps) → corps md navigables dans DocsView ; `listSprints()` + `getSprint()`.
- **app** : `GET /api/sprints` (tous les sprints + counts/points) et `GET /api/sprints/:id` (goal/stories/tasks/review/retro). Ordre route préservé (`/current` avant `/:id`). Lecture fichiers protégée par `resolveSafe()`.
- **client** : `SprintsView.svelte` (liste + détail rendu marked+DOMPurify, table stories/tasks collapsible), logique pure `sprints.js`, nav + route lazy.

### Détail US enrichi (`5a43ec90`)
- **server** : `/api/stories/:id` renvoie `body` ; `repository.getStoryBody()`.
- **client** : la modale détail du board charge tasks + corps, affiche la table des tâches (id/type/statut/heures/assigné) et la description markdown. `marked`/`DOMPurify` en import dynamique (bundle board inchangé) ; réponses périmées ignorées.

## Couverture du besoin
EPICs (grouping + corps via Docs) · US (board + corps + tasks) · Tasks (détail sprint + modale US) · Sprints (vue dédiée, tous) · Retro (détail sprint + Docs) · Review (détail sprint + Docs).

## Tests
- Logique pure `sprints.test.js` ; endpoints `app.test.js` ; classification `file-scanner.test.js` ; fixtures `sprint-review.md` / `sprint-retro.md`.
- Suite complète : **1025+ tests verts**. Build client Kanban clean.
- Smoke HTTP réel des nouveaux endpoints validé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)