### PR TITLE
chore(release): 8.14.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.13.1",
+      "version": "8.14.0",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.13.1",
+  "version": "8.14.0",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.13.1 | **Languages:** en, fr, es, de, pt
+**Version:** 8.14.0 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.14.0] - 2026-06-14
+
+### Added
+- **Dashboard Kanban web — accès à l'ensemble des artefacts BMAD v6** (`claude-craft kanban`, SPA Svelte 5) : l'UI n'exposait que le board des stories, le grouping des epics, le burndown du sprint courant et les docs racine. Les rétrospectives, reviews, l'ensemble des sprints et les corps markdown étaient scannés mais inaccessibles.
+  - **Vue Sprints dédiée** : nouvelle entrée de navigation listant **tous** les sprints (points, nombre de stories, badges goal/review/retro). Le détail d'un sprint rend le Goal, une table Stories avec leurs Tasks dépliables, et les sections **Review** et **Retro** (markdown rendu). Nouveaux endpoints `GET /api/sprints` et `GET /api/sprints/:id` ; logique pure `summarizeSprint()`/`sortSprints()` testée.
+  - **DocsView élargi** : `listDocs()` sert désormais les corps markdown des EPIC, US, sprint-goal/board/review/retro/deps (catégorie dédiée `sprint-retro`) → tout est navigable dans l'arbre de documents.
+  - **Détail US enrichi** : la modale détail du board charge la **liste des tâches associées** (id/type/statut/heures/assigné) et la **description markdown** de la story (`/api/stories/:id` renvoie désormais `body`). `marked`/`DOMPurify` importés dynamiquement (bundle du board inchangé).
+  - Tests RED-first : `tests/kanban/sprints.test.js` (logique pure) + endpoints (`app.test.js`) + classification (`file-scanner.test.js`). Suite complète verte. (#79)
+
 ## [8.13.1] - 2026-06-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ Plus **11 stack-specific reviewers** (@symfony-reviewer, @react-reviewer, @pytho
 
 A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, 48 skills**, all token-optimized via `context: fork` and sub-agent model routing.
 
-## What's New in v8.13.1
+## What's New in v8.14.0
+
+**Interface web Kanban — accès à tous les artefacts BMAD v6 (v8.14.0) :**
+
+- **Vue Sprints dédiée** : navigation listant **tous** les sprints (points, stories, badges goal/review/retro) ; le détail rend le Goal, les Stories avec leurs Tasks dépliables, et les sections **Review** et **Retro** en markdown (`GET /api/sprints`, `GET /api/sprints/:id`).
+- **Docs élargis** : les corps markdown des EPIC, US, sprint-goal/board/review/retro sont désormais navigables dans le DocsView.
+- **Détail US enrichi** : la modale du board affiche la **liste des tâches associées** et la **description** de la story (`/api/stories/:id` renvoie `body`). Tests RED-first, suite complète verte.
 
 **Corrections de l'interface web Kanban (v8.13.1) :**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.13.1",
+  "version": "8.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-bearded-bear/claude-craft",
-      "version": "8.13.1",
+      "version": "8.14.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.13.1",
+  "version": "8.14.0",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
Minor release shipping the full BMAD v6 artifact access in the Kanban web UI (merged in #79).

## Bumps
- `package.json` / `package-lock.json` / `plugin.json` / `marketplace.json` → **8.14.0**
- `.claude/CLAUDE.md` version header → 8.14.0
- CHANGELOG: 8.14.0 entry (Sprints view, broadened docs, enriched US detail)
- README: What's New v8.14.0 section

`npm run lint:versions` ✓ · `docs:check` ✓ · prettier ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)