### PR TITLE
feat(kanban): redesign UI from Claude Design mockup (dark acid-lime theme)

### DIFF
--- a/cli/kanban/client/index.html
+++ b/cli/kanban/client/index.html
@@ -8,7 +8,6 @@
       http-equiv="Content-Security-Policy"
       content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';"
     />
-    <link rel="stylesheet" href="./src/app.css" />
   </head>
   <body>
     <div id="app"></div>

--- a/cli/kanban/client/src/App.svelte
+++ b/cli/kanban/client/src/App.svelte
@@ -2,15 +2,21 @@
   import { onMount, onDestroy } from 'svelte';
   import { route } from './lib/router.svelte.js';
   import { store, loadStories, loadSprint, connectEvents, disconnectEvents, dismissToast } from './lib/store.svelte.js';
+  import { tweaks, initTweaks } from './lib/tweaks.svelte.js';
+  import Icon from './components/Icon.svelte';
+  import TweaksPanel from './components/TweaksPanel.svelte';
   import KanbanView from './views/KanbanView.svelte';
   import BacklogView from './views/BacklogView.svelte';
-  // Lazy-loaded : pulls heavy viz libs (uPlot, Cytoscape, marked+dompurify).
+  // Lazy-loaded : tire des libs viz lourdes (uPlot, Cytoscape, marked+dompurify).
   const lazyBurndown = () => import('./views/BurndownView.svelte');
   const lazyDeps = () => import('./views/DepsView.svelte');
   const lazyDocs = () => import('./views/DocsView.svelte');
   const lazySprints = () => import('./views/SprintsView.svelte');
 
+  let tweaksPanel = $state(null);
+
   onMount(async () => {
+    initTweaks();
     await Promise.all([loadStories(), loadSprint()]);
     connectEvents();
   });
@@ -18,138 +24,160 @@
   onDestroy(() => disconnectEvents());
 
   const navItems = [
-    { path: '/kanban', label: 'Kanban' },
-    { path: '/backlog', label: 'Backlog' },
-    { path: '/sprints', label: 'Sprints' },
-    { path: '/burndown', label: 'Burndown' },
-    { path: '/deps', label: 'Dependencies' },
-    { path: '/docs', label: 'Docs' },
+    { path: '/kanban', label: 'Board', icon: 'board' },
+    { path: '/backlog', label: 'Backlog', icon: 'backlog' },
+    { path: '/sprints', label: 'Sprints', icon: 'sprint' },
+    { path: '/burndown', label: 'Burndown', icon: 'burndown' },
+    { path: '/deps', label: 'Dependencies', icon: 'deps' },
+    { path: '/docs', label: 'Docs', icon: 'docs' },
   ];
 
-  function currentPath() {
-    return '/' + (route.parts[0] ?? 'kanban');
-  }
+  const titleMap = {
+    '/kanban': 'Board',
+    '/backlog': 'Backlog',
+    '/sprints': 'Sprints',
+    '/burndown': 'Burndown',
+    '/deps': 'Dependencies',
+    '/docs': 'Docs',
+  };
 
-  let sprintLabel = $derived(store.sprint ? `${store.sprint.name} (${store.sprint.sprint_id})` : 'no sprint');
+  let currentPath = $derived('/' + (route.parts[0] ?? 'kanban'));
+  let title = $derived(titleMap[currentPath] ?? 'Board');
+
+  // Progression sprint dérivée du board (pas de fetch supplémentaire).
+  let totalPoints = $derived(store.stories.reduce((a, s) => a + (s.story_points || 0), 0));
+  let donePoints = $derived(
+    store.stories.filter((s) => s.status === 'done').reduce((a, s) => a + (s.story_points || 0), 0),
+  );
+  let progressPct = $derived(totalPoints ? (donePoints / totalPoints) * 100 : 0);
+  let sprintName = $derived(store.sprint ? store.sprint.name : null);
 </script>
 
 <a href="#main" class="skip-link">Skip to main content</a>
 
-<div class="app-shell">
+<div class="app-shell" data-density={tweaks.density}>
   <aside class="sidebar" aria-label="Navigation">
-    <h1>claude-craft</h1>
-    <nav class="nav" aria-label="Views">
+    <div class="brand">
+      <div class="brand-mark mono">cc</div>
+      <div>
+        <div class="brand-name">claude-craft</div>
+        <div class="brand-sub">BMAD v6</div>
+      </div>
+    </div>
+
+    <nav class="nav" aria-label="Vues">
+      <div class="nav-label">Workspace</div>
       {#each navItems as item}
         <a
+          class="nav-item"
           href={'#' + item.path}
-          aria-current={currentPath() === item.path ? 'page' : undefined}
-        >{item.label}</a>
+          aria-current={currentPath === item.path ? 'page' : undefined}
+        >
+          <Icon name={item.icon} cls="ico" size={18} />
+          {item.label}
+          {#if item.path === '/kanban'}<span class="nav-count mono">{store.stories.length}</span>{/if}
+        </a>
       {/each}
     </nav>
 
-    <!-- h2 : un seul h1 par page (WCAG SC 1.3.1, SC 2.4.6) -->
-    <h2 class="sidebar-section-title">Sprint</h2>
-    <div style="font-size:12px; color: var(--fg-dim); padding: 0 10px;">
-      {sprintLabel}
+    <div class="sidebar-foot">
+      <div class="proj-card">
+        <div class="row">
+          <div class="pname">{sprintName ?? 'Sprint'}</div>
+          {#if store.sprint}<span class="si-state active">active</span>{/if}
+        </div>
+        <div class="pmeta">{donePoints}/{totalPoints} pts</div>
+        <div class="proj-bar"><span style="width: {progressPct}%"></span></div>
+      </div>
     </div>
   </aside>
 
-  <header class="topbar" role="banner">
-    <div class="title">
-      {#if store.sprint}
-        {store.sprint.goal || store.sprint.name}
-      {:else}
-        Kanban
-      {/if}
-    </div>
-    <div class="status {store.connected ? 'connected' : 'disconnected'}" aria-live="polite">
-      {store.connected ? '● live' : '○ offline'}
-    </div>
-  </header>
+  <div class="main">
+    <header class="topbar">
+      <h1>{title}</h1>
+      {#if sprintName}<span class="crumb mono">/ {sprintName}</span>{/if}
+      <div class="topbar-spacer"></div>
 
-  <main class="main" id="main">
-    {#if store.error && store.stories.length === 0}
-      <div class="empty">
-        <strong>Cannot reach server.</strong><br/>
-        {store.error}
+      <div class="search" role="search">
+        <Icon name="search" size={15} />
+        <input placeholder="Rechercher des stories…" aria-label="Rechercher des stories" />
+        <kbd class="mono">⌘K</kbd>
       </div>
-    {:else if currentPath() === '/kanban'}
-      <KanbanView />
-    {:else if currentPath() === '/backlog'}
-      <BacklogView />
-    {:else if currentPath() === '/sprints'}
-      {#await lazySprints()}
-        <div class="empty">Loading…</div>
-      {:then mod}
-        {@const Comp = mod.default}
-        <Comp />
-      {/await}
-    {:else if currentPath() === '/burndown'}
-      {#await lazyBurndown()}
-        <div class="empty">Loading…</div>
-      {:then mod}
-        {@const Comp = mod.default}
-        <Comp />
-      {/await}
-    {:else if currentPath() === '/deps'}
-      {#await lazyDeps()}
-        <div class="empty">Loading…</div>
-      {:then mod}
-        {@const Comp = mod.default}
-        <Comp />
-      {/await}
-    {:else if currentPath() === '/docs'}
-      {#await lazyDocs()}
-        <div class="empty">Loading…</div>
-      {:then mod}
-        {@const Comp = mod.default}
-        <Comp />
-      {/await}
-    {/if}
-  </main>
+
+      {#if store.sprint}
+        <div class="sprint-pill">
+          <span class="lbl">Sprint</span>
+          <span class="val">{store.sprint.sprint_id ?? store.sprint.name}</span>
+        </div>
+      {/if}
+
+      <div
+        class="live {store.connected ? 'live-on' : 'live-off'}"
+        aria-live="polite"
+        title={store.connected ? 'Flux SSE connecté' : 'Flux SSE déconnecté'}
+      >
+        <span class="dot"></span>{store.connected ? 'Live' : 'Offline'}
+      </div>
+
+      <button class="icon-btn" aria-label="Réglages d'affichage" onclick={() => tweaksPanel?.open()}>
+        <Icon name="settings" size={18} />
+      </button>
+    </header>
+
+    <main class="view" id="main">
+      {#if store.error && store.stories.length === 0}
+        <div class="empty">
+          <strong>Serveur injoignable.</strong><br />
+          {store.error}
+        </div>
+      {:else if currentPath === '/kanban'}
+        <KanbanView />
+      {:else if currentPath === '/backlog'}
+        <BacklogView />
+      {:else if currentPath === '/sprints'}
+        {#await lazySprints()}
+          <div class="empty">Chargement…</div>
+        {:then mod}
+          {@const Comp = mod.default}
+          <Comp />
+        {/await}
+      {:else if currentPath === '/burndown'}
+        {#await lazyBurndown()}
+          <div class="empty">Chargement…</div>
+        {:then mod}
+          {@const Comp = mod.default}
+          <Comp />
+        {/await}
+      {:else if currentPath === '/deps'}
+        {#await lazyDeps()}
+          <div class="empty">Chargement…</div>
+        {:then mod}
+          {@const Comp = mod.default}
+          <Comp />
+        {/await}
+      {:else if currentPath === '/docs'}
+        {#await lazyDocs()}
+          <div class="empty">Chargement…</div>
+        {:then mod}
+          {@const Comp = mod.default}
+          <Comp />
+        {/await}
+      {/if}
+    </main>
+  </div>
 </div>
 
-<div class="toast-layer" aria-live="polite">
+<div class="toast-region" aria-live="polite" aria-relevant="additions">
   {#each store.toasts as t (t.id)}
+    <!-- svelte-ignore a11y_click_events_have_key_events -->
+    <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
     <div class="toast {t.kind}" role="status" onclick={() => dismissToast(t.id)}>
-      {t.message}
+      <span class="t-ico {t.kind}">
+        <Icon name={t.kind === 'error' ? 'warn' : t.kind === 'success' ? 'check' : 'arrowR'} size={16} />
+      </span>
+      <div class="t-msg">{t.message}</div>
     </div>
   {/each}
 </div>
 
-<style>
-  /* Titre de section sidebar : même apparence que l'ancien h1 (via app.css .sidebar h1) */
-  .sidebar-section-title {
-    font-size: 13px;
-    font-weight: 700;
-    margin: 16px 0 8px;
-    color: var(--fg-dim);
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
-  }
-
-  .skip-link {
-    position: absolute;
-    left: -9999px;
-    top: auto;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    background: var(--accent, #7c3aed);
-    color: #fff;
-    padding: 8px 16px;
-    border-radius: 4px;
-    font-size: 14px;
-    font-weight: 600;
-    text-decoration: none;
-    z-index: 9999;
-  }
-  .skip-link:focus {
-    position: absolute;
-    left: 8px;
-    top: 8px;
-    width: auto;
-    height: auto;
-    overflow: visible;
-  }
-</style>
+<TweaksPanel bind:this={tweaksPanel} />

--- a/cli/kanban/client/src/app.css
+++ b/cli/kanban/client/src/app.css
@@ -1,194 +1,615 @@
+/* ============================================================
+   claude-craft · Kanban — Design System (refonte Claude Design)
+   Dark, opinionated. Acid-lime brand accent (distinct des six
+   teintes de statut). Space Grotesk display + JetBrains Mono.
+   ============================================================ */
+
 :root {
-  color-scheme: light dark;
-  --bg: #fafafa;
-  --bg-elev: #ffffff;
-  --bg-sidebar: #f3f3f5;
-  --fg: #1a1a1a;
-  /* #595f6a sur #f3f3f5 → ratio ~5.1:1 (passe AA) ; sur blanc → ~6.0:1 */
-  --fg-dim: #595f6a;
-  --border: #e4e4e7;
-  --accent: #7c3aed;
-  --accent-fg: #ffffff;
-  --danger: #dc2626;
-  /* Couleurs sémantiques light : ≥ 4.5:1 sur --bg-elev (#ffffff) */
-  --warn: #b45309;
-  --ok: #15803d;
-  --info: #0369a1;
-  /* Texte des badges posés SUR une couleur sémantique (fond plein). En light les
-     sémantiques sont foncées → texte blanc ; en dark elles sont claires → texte sombre. */
-  --badge-fg: #ffffff;
-  --shadow: 0 1px 2px rgba(0, 0, 0, 0.05);
-  --radius: 6px;
-  --font: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
-  --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', monospace;
+  /* --- Surfaces (cool near-black, layered elevation) --- */
+  --bg: oklch(0.165 0.012 264);
+  --bg-sidebar: oklch(0.135 0.012 264);
+  --bg-topbar: oklch(0.155 0.012 264);
+  --bg-elev: oklch(0.205 0.013 264);
+  --bg-elev-2: oklch(0.245 0.014 264);
+  --bg-inset: oklch(0.125 0.012 264);
+
+  /* --- Foreground --- */
+  --fg: oklch(0.965 0.004 264);
+  --fg-dim: oklch(0.72 0.012 264);
+  --fg-faint: oklch(0.55 0.012 264);
+
+  /* --- Lines --- */
+  --border: oklch(0.3 0.012 264);
+  --border-strong: oklch(0.42 0.014 264);
+  --border-faint: oklch(0.24 0.011 264);
+
+  /* --- Brand accent: acid lime (surchargeable par le panneau Tweaks) --- */
+  --accent: oklch(0.88 0.21 126);
+  --accent-dim: oklch(0.72 0.16 126);
+  --accent-fg: oklch(0.22 0.05 126);
+  --accent-soft: oklch(0.88 0.21 126 / 0.12);
+  --accent-ring: oklch(0.88 0.21 126 / 0.55);
+
+  /* --- Semantic --- */
+  --danger: oklch(0.66 0.21 18);
+  --danger-soft: oklch(0.66 0.21 18 / 0.14);
+  --success: oklch(0.76 0.16 156);
+  --success-soft: oklch(0.76 0.16 156 / 0.14);
+  --warning: oklch(0.82 0.15 82);
+
+  /* --- Status palette (6 board columns) --- */
+  --st-backlog: oklch(0.7 0.02 264);
+  --st-ready: oklch(0.74 0.13 236);
+  --st-in-progress: oklch(0.82 0.14 82);
+  --st-review: oklch(0.72 0.16 300);
+  --st-done: oklch(0.76 0.16 156);
+  --st-blocked: oklch(0.67 0.21 18);
+
+  /* --- Priority (MoSCoW) --- */
+  --pri-must: oklch(0.67 0.21 18);
+  --pri-should: oklch(0.82 0.15 82);
+  --pri-could: oklch(0.74 0.13 236);
+  --pri-wont: oklch(0.62 0.02 264);
+
+  /* --- TDD (red / green / refactor) --- */
+  --tdd-red: oklch(0.67 0.21 18);
+  --tdd-green: oklch(0.76 0.16 156);
+  --tdd-refactor: oklch(0.74 0.15 236);
+
+  /* --- Geometry --- */
+  --radius: 12px;
+  --radius-sm: 8px;
+  --radius-lg: 18px;
+  --radius-pill: 999px;
+
+  /* --- Shadows --- */
+  --shadow-sm: 0 1px 2px oklch(0 0 0 / 0.4);
+  --shadow: 0 6px 22px oklch(0 0 0 / 0.45);
+  --shadow-lg: 0 24px 64px oklch(0 0 0 / 0.6);
+  --shadow-pop: 0 18px 50px oklch(0 0 0 / 0.55);
+
+  /* --- Type --- */
+  --sans: 'Space Grotesk', ui-sans-serif, system-ui, sans-serif;
+  --mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, monospace;
+
+  --z-modal: 100;
+
+  /* --- Shim de compatibilité : noms legacy encore consommés par les vues --- */
+  --font: var(--sans);
+  --ok: var(--success);
+  --warn: var(--warning);
+  --info: var(--st-ready);
+  --badge-fg: oklch(0.18 0.02 264);
+
+  color-scheme: dark;
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --bg: #0f0f11;
-    --bg-elev: #1a1a1d;
-    --bg-sidebar: #141417;
-    --fg: #f4f4f5;
-    --fg-dim: #a1a1aa;
-    --border: #27272a;
-    /* #7c3aed sur #141417 → ratio ~5.70 (passe AA/AAA avec texte blanc #ffffff) */
-    --accent: #7c3aed;
-    /* Couleurs sémantiques dark : chacune ≥ 4.5:1 sur --bg-elev (#1a1a1d) */
-    --danger: #f87171;
-    --warn: #fbbf24;
-    --ok: #4ade80;
-    --info: #38bdf8;
-    /* sémantiques claires en dark → texte de badge sombre pour garder le contraste */
-    --badge-fg: #1a1a1d;
-    --shadow: 0 1px 2px rgba(0, 0, 0, 0.3);
-  }
-}
-
-* {
+/* ============================================================ Reset */
+*,
+*::before,
+*::after {
   box-sizing: border-box;
 }
-
+* {
+  margin: 0;
+}
 html,
 body,
 #app {
-  margin: 0;
-  padding: 0;
   height: 100%;
+}
+body {
+  font-family: var(--sans);
   background: var(--bg);
   color: var(--fg);
-  font-family: var(--font);
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
   font-size: 14px;
-  line-height: 1.45;
+  line-height: 1.5;
+  overflow: hidden;
 }
-
 button,
 input,
-select {
+select,
+textarea {
   font: inherit;
   color: inherit;
 }
-
+button {
+  cursor: pointer;
+  background: none;
+  border: none;
+}
+ul,
+ol {
+  list-style: none;
+  padding: 0;
+}
 a {
-  color: var(--accent);
+  color: inherit;
   text-decoration: none;
 }
 
+/* tabular, mono numerals partout où l'on affiche compteurs/points */
+.mono {
+  font-family: var(--mono);
+  font-feature-settings: 'tnum' 1;
+}
+
+/* ============================================================ A11y */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+.skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 999;
+  background: var(--accent);
+  color: var(--accent-fg);
+  padding: 10px 16px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  transform: translateY(-160%);
+  transition: transform 0.15s ease;
+}
+.skip-link:focus {
+  transform: translateY(0);
+}
+
+:where(button, a, input, select, textarea, [tabindex]):focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: var(--radius-sm);
+}
+.card:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 3px;
+}
+
+::selection {
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+
+/* scrollbars */
+* {
+  scrollbar-width: thin;
+  scrollbar-color: var(--border-strong) transparent;
+}
+*::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+*::-webkit-scrollbar-thumb {
+  background: var(--border-strong);
+  border-radius: 99px;
+  border: 3px solid transparent;
+  background-clip: content-box;
+}
+*::-webkit-scrollbar-thumb:hover {
+  background: var(--fg-faint);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  * {
+    animation-duration: 0.001ms !important;
+    transition-duration: 0.001ms !important;
+  }
+}
+
+/* ============================================================ App shell */
 .app-shell {
   display: grid;
-  grid-template-columns: 240px 1fr;
-  grid-template-rows: 48px 1fr;
-  grid-template-areas:
-    'sidebar topbar'
-    'sidebar main';
-  height: 100vh;
+  grid-template-columns: 248px 1fr;
+  grid-template-rows: 100%;
+  height: 100%;
 }
 
+/* ---------- Sidebar ---------- */
 .sidebar {
-  grid-area: sidebar;
   background: var(--bg-sidebar);
-  border-right: 1px solid var(--border);
-  padding: 16px 12px;
-  overflow-y: auto;
+  border-right: 1px solid var(--border-faint);
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
 }
-
-.sidebar h1 {
-  font-size: 13px;
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 20px 20px 18px;
+}
+.brand-mark {
+  width: 34px;
+  height: 34px;
+  flex: none;
+  display: grid;
+  place-items: center;
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-radius: 9px;
   font-weight: 700;
-  margin: 0 0 12px;
-  color: var(--fg-dim);
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
+  box-shadow:
+    0 0 0 1px oklch(0.88 0.21 126 / 0.4),
+    0 6px 18px oklch(0.88 0.21 126 / 0.25);
+}
+.brand-name {
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  font-size: 15px;
+}
+.brand-sub {
+  font-size: 11px;
+  color: var(--fg-faint);
+  font-family: var(--mono);
+  letter-spacing: 0.02em;
 }
 
 .nav {
+  padding: 6px 12px;
   display: flex;
   flex-direction: column;
   gap: 2px;
-  margin-bottom: 20px;
 }
-
-.nav a {
-  padding: 6px 10px;
-  border-radius: var(--radius);
-  color: var(--fg);
+.nav-label {
+  padding: 14px 10px 6px;
+  font-size: 10.5px;
+  font-weight: 600;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+.nav-item {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  padding: 9px 11px;
+  border-radius: var(--radius-sm);
+  color: var(--fg-dim);
   font-weight: 500;
+  font-size: 13.5px;
+  position: relative;
+  transition:
+    background 0.12s,
+    color 0.12s;
+  width: 100%;
+  text-align: left;
 }
-.nav a:hover {
-  background: var(--border);
+.nav-item:hover {
+  background: var(--bg-elev);
+  color: var(--fg);
 }
-/* Indicateur de focus visible explicite (WCAG 2.2 SC 2.4.11) */
-.nav a:focus-visible {
-  outline: 2px solid var(--accent);
-  outline-offset: 2px;
-  border-radius: var(--radius);
+.nav-item .ico {
+  width: 18px;
+  height: 18px;
+  flex: none;
+  opacity: 0.9;
 }
-.nav a[aria-current='page'] {
+.nav-item .nav-count {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  background: var(--bg-elev);
+  padding: 1px 7px;
+  border-radius: var(--radius-pill);
+}
+.nav-item[aria-current='page'] {
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+.nav-item[aria-current='page'] .ico {
+  color: var(--accent);
+  opacity: 1;
+}
+.nav-item[aria-current='page']::before {
+  content: '';
+  position: absolute;
+  left: -12px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 3px;
+  height: 20px;
   background: var(--accent);
-  color: var(--accent-fg);
+  border-radius: 0 3px 3px 0;
+}
+.nav-item[aria-current='page'] .nav-count {
+  color: var(--accent);
+  background: var(--accent-soft);
 }
 
-.topbar {
-  grid-area: topbar;
+.sidebar-foot {
+  margin-top: auto;
+  padding: 12px;
+  border-top: 1px solid var(--border-faint);
+}
+.proj-card {
   background: var(--bg-elev);
-  border-bottom: 1px solid var(--border);
-  padding: 0 20px;
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  padding: 12px;
+}
+.proj-card .row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+.proj-card .pname {
+  font-weight: 600;
+  font-size: 13px;
+}
+.proj-card .pmeta {
+  font-size: 11px;
+  color: var(--fg-faint);
+  font-family: var(--mono);
+  margin-top: 2px;
+}
+.proj-bar {
+  height: 6px;
+  background: var(--bg-inset);
+  border-radius: 99px;
+  margin-top: 10px;
+  overflow: hidden;
+}
+.proj-bar > span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, var(--accent-dim), var(--accent));
+  border-radius: 99px;
+}
+
+/* ---------- Main / Topbar ---------- */
+.main {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  min-height: 0;
+}
+.topbar {
+  height: 60px;
+  flex: none;
   display: flex;
   align-items: center;
   gap: 16px;
+  padding: 0 22px;
+  background: var(--bg-topbar);
+  border-bottom: 1px solid var(--border-faint);
 }
-
-.topbar .title {
+.topbar h1 {
+  font-size: 17px;
   font-weight: 600;
+  letter-spacing: -0.015em;
+}
+.topbar .crumb {
+  color: var(--fg-faint);
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.topbar-spacer {
   flex: 1;
 }
 
-.topbar .status {
-  color: var(--fg-dim);
-  font-size: 12px;
+.search {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-pill);
+  padding: 7px 14px;
+  width: 230px;
+  color: var(--fg-faint);
+  transition:
+    border-color 0.12s,
+    width 0.15s;
+}
+.search:focus-within {
+  border-color: var(--border-strong);
+  width: 280px;
+}
+.search input {
+  background: none;
+  border: none;
+  outline: none;
+  width: 100%;
+  color: var(--fg);
+}
+.search input::placeholder {
+  color: var(--fg-faint);
+}
+.search kbd {
   font-family: var(--mono);
-}
-.topbar .status.connected {
-  color: var(--ok);
-}
-.topbar .status.disconnected {
-  color: var(--danger);
+  font-size: 10.5px;
+  padding: 1px 6px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  color: var(--fg-faint);
 }
 
-.main {
-  grid-area: main;
+.sprint-pill {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-pill);
+  padding: 6px 8px 6px 13px;
+  font-size: 12.5px;
+}
+.sprint-pill .lbl {
+  color: var(--fg-faint);
+}
+.sprint-pill .val {
+  font-weight: 600;
+}
+.sprint-pill .days {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+  background: var(--accent-soft);
+  padding: 2px 8px;
+  border-radius: var(--radius-pill);
+}
+
+.live {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 12px;
+  color: var(--fg-dim);
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  border: 1px solid var(--border-faint);
+  background: var(--bg-elev);
+}
+.live .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--success);
+  position: relative;
+}
+.live.live-on .dot::after {
+  content: '';
+  position: absolute;
+  inset: -4px;
+  border-radius: 50%;
+  background: var(--success);
+  opacity: 0.35;
+  animation: ping 1.8s cubic-bezier(0, 0, 0.2, 1) infinite;
+}
+.live.live-off .dot {
+  background: var(--warning);
+}
+.live.live-off {
+  color: var(--fg-faint);
+}
+@keyframes ping {
+  75%,
+  100% {
+    transform: scale(2.4);
+    opacity: 0;
+  }
+}
+
+.icon-btn {
+  width: 36px;
+  height: 36px;
+  display: grid;
+  place-items: center;
+  border-radius: var(--radius-sm);
+  color: var(--fg-dim);
+  border: 1px solid transparent;
+  transition:
+    background 0.12s,
+    color 0.12s;
+}
+.icon-btn:hover {
+  background: var(--bg-elev);
+  color: var(--fg);
+}
+
+.avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  flex: none;
+  display: grid;
+  place-items: center;
+  font-size: 11px;
+  font-weight: 600;
+  color: oklch(0.18 0.02 264);
+  letter-spacing: 0.02em;
+}
+
+/* ---------- View frame ---------- */
+.view {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.view-pad {
+  padding: 22px;
   overflow: auto;
-  padding: 20px;
+  flex: 1;
+  min-height: 0;
 }
 
 .empty {
   text-align: center;
   padding: 80px 20px;
-  color: var(--fg-dim);
+  color: var(--fg-faint);
 }
 
-.toast-layer {
-  position: fixed;
-  bottom: 20px;
-  right: 20px;
-  display: flex;
-  flex-direction: column;
+/* ---------- Boutons partagés ---------- */
+.btn {
+  display: inline-flex;
+  align-items: center;
   gap: 8px;
-  z-index: 1000;
-}
-.toast {
-  background: var(--bg-elev);
+  padding: 8px 14px;
+  border-radius: var(--radius-sm);
+  font-weight: 600;
+  font-size: 13px;
   border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 10px 14px;
-  box-shadow: var(--shadow);
-  max-width: 360px;
+  background: var(--bg-elev);
+  color: var(--fg);
+  transition:
+    background 0.12s,
+    border-color 0.12s;
 }
-.toast.error {
-  border-left: 3px solid var(--danger);
+.btn:hover {
+  background: var(--bg-elev-2);
+  border-color: var(--border-strong);
 }
-.toast.success {
-  border-left: 3px solid var(--ok);
+.btn-primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+  border-color: transparent;
 }
-.toast.info {
-  border-left: 3px solid var(--info);
+.btn-primary:hover {
+  background: var(--accent-dim);
+}
+.btn-ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--fg-dim);
+}
+.btn-ghost:hover {
+  background: var(--bg-elev);
+  color: var(--fg);
+}
+
+/* read-only lock affordance */
+.ro-lock {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 10.5px;
+  color: var(--fg-faint);
+  font-family: var(--mono);
+}
+
+/* ---------- Responsive shell ---------- */
+@media (max-width: 980px) {
+  .app-shell {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto 1fr;
+  }
+  .sidebar {
+    display: none;
+  }
+  .search {
+    display: none;
+  }
 }

--- a/cli/kanban/client/src/components/Avatar.svelte
+++ b/cli/kanban/client/src/components/Avatar.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { initials, avatarColor } from '../lib/config.js';
+  import Icon from './Icon.svelte';
+
+  /** @type {{ id?: string, size?: number }} */
+  let { id = '', size = 28 } = $props();
+</script>
+
+{#if id}
+  <span
+    class="avatar"
+    title={id}
+    aria-label={`Assigné à : ${id}`}
+    style="width:{size}px; height:{size}px; background:{avatarColor(id)}; font-size:{size * 0.38}px;"
+  >{initials(id)}</span>
+{:else}
+  <span
+    class="avatar avatar-empty"
+    title="Non assigné"
+    aria-label="Non assigné"
+    style="width:{size}px; height:{size}px;"
+  >
+    <Icon name="person" size={size * 0.5} />
+  </span>
+{/if}

--- a/cli/kanban/client/src/components/Icon.svelte
+++ b/cli/kanban/client/src/components/Icon.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { ICONS } from '../lib/icons.js';
+
+  /**
+   * @typedef {Object} Props
+   * @property {string} name  clé dans ICONS
+   * @property {number} [size]
+   * @property {number} [sw]   stroke-width
+   * @property {string} [cls]  classes CSS additionnelles
+   */
+  let { name, size = 18, sw = 1.7, cls = '' } = $props();
+  let inner = $derived(ICONS[name] ?? '');
+</script>
+
+<svg
+  class={cls}
+  viewBox="0 0 24 24"
+  width={size}
+  height={size}
+  fill="none"
+  stroke="currentColor"
+  stroke-width={sw}
+  stroke-linecap="round"
+  stroke-linejoin="round"
+  aria-hidden="true"
+>{@html inner}</svg>

--- a/cli/kanban/client/src/components/Points.svelte
+++ b/cli/kanban/client/src/components/Points.svelte
@@ -1,0 +1,6 @@
+<script>
+  /** @type {{ value?: number }} */
+  let { value } = $props();
+</script>
+
+<span class="points mono" title={`${value} story points`}>{value}</span>

--- a/cli/kanban/client/src/components/PriorityChip.svelte
+++ b/cli/kanban/client/src/components/PriorityChip.svelte
@@ -1,0 +1,15 @@
+<script>
+  import { PRIORITY } from '../lib/config.js';
+
+  /** @type {{ priority?: string }} */
+  let { priority } = $props();
+  let p = $derived(PRIORITY[priority]);
+  let cv = $derived(p ? `var(${p.cssVar})` : 'var(--fg-faint)');
+</script>
+
+{#if p}
+  <span
+    class="chip"
+    style="background: color-mix(in oklch, {cv} 16%, transparent); color: {cv}; border-color: color-mix(in oklch, {cv} 32%, transparent);"
+  >{p.label}</span>
+{/if}

--- a/cli/kanban/client/src/components/ProgressRing.svelte
+++ b/cli/kanban/client/src/components/ProgressRing.svelte
@@ -1,0 +1,27 @@
+<script>
+  /** @type {{ pct?: number, size?: number, sw?: number, color?: string }} */
+  let { pct = 0, size = 40, sw = 4, color = 'var(--accent)' } = $props();
+  let r = $derived((size - sw) / 2);
+  let c = $derived(2 * Math.PI * r);
+  let offset = $derived(c * (1 - Math.max(0, Math.min(100, pct)) / 100));
+</script>
+
+<span class="ring-wrap" style="width:{size}px; height:{size}px;">
+  <svg width={size} height={size} aria-hidden="true">
+    <circle cx={size / 2} cy={size / 2} r={r} fill="none" stroke="var(--bg-inset)" stroke-width={sw} />
+    <circle
+      cx={size / 2}
+      cy={size / 2}
+      r={r}
+      fill="none"
+      stroke={color}
+      stroke-width={sw}
+      stroke-linecap="round"
+      stroke-dasharray={c}
+      stroke-dashoffset={offset}
+      transform="rotate(-90 {size / 2} {size / 2})"
+      style="transition: stroke-dashoffset .5s ease;"
+    />
+  </svg>
+  <span class="ring-txt" style="color:{color};">{Math.round(pct)}</span>
+</span>

--- a/cli/kanban/client/src/components/TaskProgress.svelte
+++ b/cli/kanban/client/src/components/TaskProgress.svelte
@@ -1,0 +1,23 @@
+<script>
+  /**
+   * Tâches au format Svelte : { total, completed }.
+   * @type {{ tasks?: { total?: number, completed?: number } }}
+   */
+  let { tasks } = $props();
+  let total = $derived(tasks?.total ?? 0);
+  let done = $derived(tasks?.completed ?? 0);
+  let pct = $derived(total ? (done / total) * 100 : 0);
+</script>
+
+{#if total > 0}
+  <span
+    class="task-prog"
+    role="progressbar"
+    aria-label={`Tâches : ${done} sur ${total} complétées`}
+    aria-valuenow={done}
+    aria-valuemin={0}
+    aria-valuemax={total}
+  >
+    <span class="bar"><span style="width: {pct}%"></span></span>{done}/{total}
+  </span>
+{/if}

--- a/cli/kanban/client/src/components/TddPip.svelte
+++ b/cli/kanban/client/src/components/TddPip.svelte
@@ -1,0 +1,16 @@
+<script>
+  import { TDD } from '../lib/config.js';
+
+  /** @type {{ phase?: string }} */
+  let { phase } = $props();
+  let t = $derived(TDD[phase]);
+  let cv = $derived(t ? `var(${t.cssVar})` : null);
+</script>
+
+{#if t}
+  <span
+    class="tdd-pip"
+    aria-label={`Phase TDD : ${t.label}`}
+    style="background: color-mix(in oklch, {cv} 15%, transparent); color: {cv};"
+  ><i style="background: {cv};"></i>{t.label}</span>
+{/if}

--- a/cli/kanban/client/src/components/TweaksPanel.svelte
+++ b/cli/kanban/client/src/components/TweaksPanel.svelte
@@ -1,0 +1,127 @@
+<script>
+  import { tweaks, setTweak, ACCENTS, DENSITIES } from '../lib/tweaks.svelte.js';
+  import Icon from './Icon.svelte';
+
+  let dialog = $state(null);
+  let triggerEl = $state(null);
+
+  /** Ouvre le panneau (appelé par le parent via bind:this). */
+  export function open() {
+    triggerEl = document.activeElement;
+    dialog?.showModal();
+  }
+
+  function close() {
+    dialog?.close();
+  }
+
+  function onClose() {
+    if (triggerEl) {
+      triggerEl.focus();
+      triggerEl = null;
+    }
+  }
+
+  const SCHEMES = [
+    ['status', 'Statut'],
+    ['priority', 'Priorité'],
+    ['tdd', 'Phase TDD'],
+    ['epic', 'Epic'],
+  ];
+</script>
+
+<dialog
+  bind:this={dialog}
+  class="tweaks-dialog"
+  aria-labelledby="tweaks-title"
+  onclose={onClose}
+  onclick={(e) => { if (e.target === dialog) close(); }}
+>
+  <div class="tweaks-inner">
+    <header class="tweaks-head">
+      <h2 id="tweaks-title">Réglages d'affichage</h2>
+      <button class="icon-btn" onclick={close} aria-label="Fermer"><Icon name="close" size={18} /></button>
+    </header>
+
+    <section class="tweaks-section">
+      <div class="tweaks-label">Code couleur des cartes</div>
+      <div class="tweaks-grid">
+        {#each SCHEMES as [key, label]}
+          <button
+            class="tweak-opt"
+            class:selected={tweaks.codingScheme === key}
+            aria-pressed={tweaks.codingScheme === key}
+            onclick={() => setTweak('codingScheme', key)}
+          >{label}</button>
+        {/each}
+      </div>
+      <p class="tweaks-hint">Définit la couleur de la barre d'accent gauche de chaque carte du board.</p>
+    </section>
+
+    <section class="tweaks-section">
+      <div class="tweaks-label">Accent</div>
+      <div class="tweaks-swatches">
+        {#each Object.entries(ACCENTS) as [name, ac]}
+          <button
+            class="swatch-btn"
+            class:selected={tweaks.accent === name}
+            aria-pressed={tweaks.accent === name}
+            aria-label={`Accent ${name}`}
+            title={name}
+            style="--sw: {ac.a};"
+            onclick={() => setTweak('accent', name)}
+          ></button>
+        {/each}
+      </div>
+    </section>
+
+    <section class="tweaks-section">
+      <div class="tweaks-label">Densité</div>
+      <div class="tweaks-grid two">
+        {#each DENSITIES as d}
+          <button
+            class="tweak-opt"
+            class:selected={tweaks.density === d}
+            aria-pressed={tweaks.density === d}
+            onclick={() => setTweak('density', d)}
+          >{d === 'compact' ? 'Compacte' : 'Confortable'}</button>
+        {/each}
+      </div>
+    </section>
+  </div>
+</dialog>
+
+<style>
+  .tweaks-dialog {
+    width: min(380px, 94vw); padding: 0;
+    border: 1px solid var(--border-strong); border-radius: var(--radius-lg);
+    background: var(--bg-elev); color: var(--fg); box-shadow: var(--shadow-lg);
+  }
+  .tweaks-dialog::backdrop { background: oklch(0.1 0.01 264 / 0.6); backdrop-filter: blur(3px); }
+  .tweaks-inner { padding: 20px 22px 22px; }
+  .tweaks-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 16px; }
+  .tweaks-head h2 { font-size: 16px; font-weight: 600; }
+  .tweaks-section { margin-bottom: 18px; }
+  .tweaks-section:last-child { margin-bottom: 0; }
+  .tweaks-label {
+    font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.07em;
+    color: var(--fg-faint); font-weight: 600; margin-bottom: 9px;
+  }
+  .tweaks-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 6px; }
+  .tweaks-hint { font-size: 11px; color: var(--fg-faint); margin-top: 9px; line-height: 1.5; }
+  .tweak-opt {
+    padding: 9px 10px; border-radius: 9px; font-size: 12.5px; font-weight: 600; text-align: left;
+    border: 1px solid var(--border); background: var(--bg-elev); color: var(--fg-dim);
+    transition: background .12s, border-color .12s, color .12s;
+  }
+  .tweak-opt:hover { border-color: var(--border-strong); color: var(--fg); }
+  .tweak-opt.selected { border-color: var(--accent-ring); background: var(--accent-soft); color: var(--fg); }
+  .tweaks-swatches { display: flex; gap: 10px; }
+  .swatch-btn {
+    width: 34px; height: 34px; border-radius: 50%; background: var(--sw);
+    border: 2px solid transparent; box-shadow: 0 0 0 1px var(--border-faint);
+    transition: transform .12s;
+  }
+  .swatch-btn:hover { transform: scale(1.08); }
+  .swatch-btn.selected { border-color: var(--bg-elev); box-shadow: 0 0 0 2px var(--sw); }
+</style>

--- a/cli/kanban/client/src/lib/config.js
+++ b/cli/kanban/client/src/lib/config.js
@@ -1,0 +1,97 @@
+/* ============================================================
+   Config + coloration — logique pure, testée (vitest).
+   Utilise les noms de champs Svelte (status, priority,
+   tdd_phase, epic_id, assigned_to), pas ceux du prototype.
+   ============================================================ */
+
+/** Colonnes / statuts du board, avec la variable CSS de teinte. */
+export const STATUS = {
+  backlog: { label: 'Backlog', cssVar: '--st-backlog' },
+  'ready-for-dev': { label: 'Ready for Dev', cssVar: '--st-ready' },
+  'in-progress': { label: 'In Progress', cssVar: '--st-in-progress' },
+  review: { label: 'Review', cssVar: '--st-review' },
+  done: { label: 'Done', cssVar: '--st-done' },
+  blocked: { label: 'Blocked', cssVar: '--st-blocked' },
+};
+
+/** Priorités MoSCoW. */
+export const PRIORITY = {
+  must: { label: 'Must', cssVar: '--pri-must' },
+  should: { label: 'Should', cssVar: '--pri-should' },
+  could: { label: 'Could', cssVar: '--pri-could' },
+  wont: { label: "Won't", cssVar: '--pri-wont' },
+};
+
+/** Phases TDD. */
+export const TDD = {
+  red: { label: 'Red', cssVar: '--tdd-red' },
+  green: { label: 'Green', cssVar: '--tdd-green' },
+  refactor: { label: 'Refactor', cssVar: '--tdd-refactor' },
+  done: { label: 'Done', cssVar: '--success' },
+};
+
+/** Couleurs par type de tâche (modale détail). */
+export const TASK_TYPE = {
+  DB: 'oklch(0.74 0.13 300)',
+  BE: 'oklch(0.74 0.13 236)',
+  FE: 'oklch(0.80 0.14 145)',
+  TEST: 'oklch(0.82 0.14 60)',
+  DOCS: 'oklch(0.70 0.02 264)',
+};
+
+/** Schémas de code couleur proposés par le panneau Tweaks. */
+export const CODING_SCHEMES = ['status', 'priority', 'tdd', 'epic'];
+
+/** Hash de chaîne stable (djb2) → entier positif. */
+export function hashString(str) {
+  let h = 5381;
+  const s = String(str ?? '');
+  for (let i = 0; i < s.length; i++) h = ((h << 5) + h + s.charCodeAt(i)) >>> 0;
+  return h;
+}
+
+/**
+ * Teinte déterministe d'un epic (indépendante de l'ordre du tableau).
+ * Retourne une couleur oklch, ou --fg-faint si l'id est vide.
+ */
+export function epicHue(epicId) {
+  if (!epicId) return 'var(--fg-faint)';
+  const hue = hashString(epicId) % 360;
+  return `oklch(0.78 0.13 ${hue})`;
+}
+
+/**
+ * Couleur de la barre d'accent gauche d'une carte selon le schéma actif.
+ * @param {object} story  story (champs Svelte)
+ * @param {string} scheme status|priority|tdd|epic
+ */
+export function codeColor(story, scheme) {
+  if (!story) return 'var(--border)';
+  if (scheme === 'priority') {
+    return `var(${PRIORITY[story.priority]?.cssVar || '--fg-faint'})`;
+  }
+  if (scheme === 'tdd') {
+    return `var(${TDD[story.tdd_phase]?.cssVar || '--fg-faint'})`;
+  }
+  if (scheme === 'epic') {
+    return epicHue(story.epic_id);
+  }
+  // défaut : statut
+  return `var(${STATUS[story.status]?.cssVar || '--border'})`;
+}
+
+/** Initiales (max 2 lettres majuscules) à partir d'un nom/identifiant. */
+export function initials(name) {
+  const s = String(name ?? '').trim();
+  if (!s) return '?';
+  const parts = s.split(/[\s._-]+/).filter(Boolean);
+  if (parts.length >= 2) return (parts[0][0] + parts[1][0]).toUpperCase();
+  return s.slice(0, 2).toUpperCase();
+}
+
+/** Couleur d'avatar déterministe (fond clair, texte sombre via CSS). */
+export function avatarColor(name) {
+  if (!name) return 'var(--bg-inset)';
+  const hue = hashString(name) % 360;
+  return `oklch(0.78 0.12 ${hue})`;
+}

--- a/cli/kanban/client/src/lib/icons.js
+++ b/cli/kanban/client/src/lib/icons.js
@@ -1,0 +1,33 @@
+/* ============================================================
+   Icônes inline (stroke-based, viewBox 0 0 24 24).
+   Chaque entrée = markup interne du <svg>, rendu par Icon.svelte.
+   Porté depuis le prototype Claude Design (helpers.jsx).
+   ============================================================ */
+
+export const ICONS = {
+  board:
+    '<rect x="3" y="3" width="6" height="18" rx="1.5"/><rect x="9.5" y="3" width="6" height="11" rx="1.5"/><rect x="16" y="3" width="5" height="15" rx="1.5"/>',
+  backlog: '<path d="M4 6h16M4 12h16M4 18h10"/>',
+  sprint: '<path d="M4 12a8 8 0 1 1 8 8"/><path d="M12 8v4l3 2"/><path d="M4 12l-2-2m2 2l2-2"/>',
+  burndown: '<path d="M4 4v16h16"/><path d="M20 7L13 13l-3-2-3 4"/>',
+  deps: '<circle cx="6" cy="6" r="2.4"/><circle cx="18" cy="9" r="2.4"/><circle cx="9" cy="18" r="2.4"/><path d="M8 7.2l7.8 1M8 16.4l8.6-6"/>',
+  docs: '<path d="M6 3h8l4 4v14a1 1 0 0 1-1 1H6a1 1 0 0 1-1-1V4a1 1 0 0 1 1-1z"/><path d="M13 3v5h5M8 13h8M8 17h6"/>',
+  search: '<circle cx="11" cy="11" r="7"/><path d="m20 20-3.2-3.2"/>',
+  lock: '<rect x="5" y="11" width="14" height="9" rx="2"/><path d="M8 11V8a4 4 0 0 1 8 0v3"/>',
+  person: '<circle cx="12" cy="8" r="3.4"/><path d="M5.5 20a6.5 6.5 0 0 1 13 0"/>',
+  check: '<path d="M4 12.5 9 17.5 20 6.5"/>',
+  plus: '<path d="M12 5v14M5 12h14"/>',
+  close: '<path d="M6 6l12 12M18 6 6 18"/>',
+  chevron: '<path d="M9 6l6 6-6 6"/>',
+  down: '<path d="M6 9l6 6 6-6"/>',
+  settings:
+    '<circle cx="12" cy="12" r="3"/><path d="M12 2v3M12 19v3M2 12h3M19 12h3M5 5l2 2M17 17l2 2M19 5l-2 2M7 17l-2 2"/>',
+  bell: '<path d="M6 9a6 6 0 0 1 12 0c0 5 2 6 2 6H4s2-1 2-6z"/><path d="M10 19a2 2 0 0 0 4 0"/>',
+  filter: '<path d="M3 5h18l-7 8v6l-4-2v-4z"/>',
+  warn: '<path d="M12 3 2 20h20z"/><path d="M12 9v5M12 17h.01"/>',
+  arrowR: '<path d="M5 12h14M13 6l6 6-6 6"/>',
+  link: '<path d="M10 14a4 4 0 0 0 6 .5l2-2a4 4 0 0 0-6-6l-1 1"/><path d="M14 10a4 4 0 0 0-6-.5l-2 2a4 4 0 0 0 6 6l1-1"/>',
+  folder: '<path d="M3 7a1 1 0 0 1 1-1h5l2 2h8a1 1 0 0 1 1 1v9a1 1 0 0 1-1 1H4a1 1 0 0 1-1-1z"/>',
+  file: '<path d="M7 3h7l4 4v14H7z"/><path d="M14 3v4h4"/>',
+  copy: '<rect x="9" y="9" width="11" height="11" rx="2"/><path d="M5 15V5a2 2 0 0 1 2-2h8"/>',
+};

--- a/cli/kanban/client/src/lib/tweaks.svelte.js
+++ b/cli/kanban/client/src/lib/tweaks.svelte.js
@@ -1,0 +1,73 @@
+/* ============================================================
+   Panneau Tweaks — état réactif persisté (localStorage).
+   - codingScheme : couleur de la barre des cartes (board)
+   - accent       : surcharge les variables --accent* (runtime)
+   - density      : compact | comfortable (attribut sur .app-shell)
+   ============================================================ */
+import { CODING_SCHEMES } from './config.js';
+
+const STORAGE_KEY = 'cc-kanban-tweaks';
+
+/** Palettes d'accent proposées (a = accent, d = dim, f = foreground). */
+export const ACCENTS = {
+  lime: { a: 'oklch(0.88 0.21 126)', d: 'oklch(0.72 0.16 126)', f: 'oklch(0.22 0.05 126)', hex: '#bdf03d' },
+  cyan: { a: 'oklch(0.83 0.13 200)', d: 'oklch(0.68 0.11 200)', f: 'oklch(0.18 0.04 215)', hex: '#3fd0e0' },
+  violet: { a: 'oklch(0.74 0.17 295)', d: 'oklch(0.62 0.16 295)', f: 'oklch(0.98 0.01 295)', hex: '#a78bfa' },
+  amber: { a: 'oklch(0.84 0.15 75)', d: 'oklch(0.73 0.13 70)', f: 'oklch(0.24 0.05 70)', hex: '#f5c44e' },
+};
+
+export const DENSITIES = ['comfortable', 'compact'];
+
+const DEFAULTS = { codingScheme: 'status', accent: 'lime', density: 'comfortable' };
+
+/** État réactif partagé. */
+export const tweaks = $state({ ...DEFAULTS });
+
+function load() {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+    const saved = JSON.parse(raw);
+    if (CODING_SCHEMES.includes(saved.codingScheme)) tweaks.codingScheme = saved.codingScheme;
+    if (ACCENTS[saved.accent]) tweaks.accent = saved.accent;
+    if (DENSITIES.includes(saved.density)) tweaks.density = saved.density;
+  } catch {
+    /* localStorage corrompu → on garde les défauts */
+  }
+}
+
+function persist() {
+  if (typeof localStorage === 'undefined') return;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ ...tweaks }));
+  } catch {
+    /* quota / mode privé → ignore */
+  }
+}
+
+/** Applique l'accent courant aux variables CSS racine. */
+export function applyAccent() {
+  if (typeof document === 'undefined') return;
+  const ac = ACCENTS[tweaks.accent] || ACCENTS.lime;
+  const root = document.documentElement.style;
+  root.setProperty('--accent', ac.a);
+  root.setProperty('--accent-dim', ac.d);
+  root.setProperty('--accent-fg', ac.f);
+  root.setProperty('--accent-soft', `color-mix(in oklch, ${ac.a} 13%, transparent)`);
+  root.setProperty('--accent-ring', `color-mix(in oklch, ${ac.a} 55%, transparent)`);
+}
+
+/** Met à jour un réglage, persiste, et applique si nécessaire. */
+export function setTweak(key, value) {
+  if (!(key in tweaks)) return;
+  tweaks[key] = value;
+  if (key === 'accent') applyAccent();
+  persist();
+}
+
+/** À appeler une fois au démarrage (onMount). */
+export function initTweaks() {
+  load();
+  applyAccent();
+}

--- a/cli/kanban/client/src/main.js
+++ b/cli/kanban/client/src/main.js
@@ -1,4 +1,16 @@
 import { mount } from 'svelte';
+// Polices auto-hébergées (bundlées par Vite, servies depuis 'self' → CSP-safe).
+// Space Grotesk = display/UI, JetBrains Mono = IDs/points/code/TDD.
+import '@fontsource/space-grotesk/400.css';
+import '@fontsource/space-grotesk/500.css';
+import '@fontsource/space-grotesk/600.css';
+import '@fontsource/space-grotesk/700.css';
+import '@fontsource/jetbrains-mono/400.css';
+import '@fontsource/jetbrains-mono/500.css';
+import '@fontsource/jetbrains-mono/600.css';
+import '@fontsource/jetbrains-mono/700.css';
+import './app.css';
+import './views.css';
 import App from './App.svelte';
 
 const app = mount(App, { target: document.getElementById('app') });

--- a/cli/kanban/client/src/views.css
+++ b/cli/kanban/client/src/views.css
@@ -1,0 +1,1369 @@
+/* ============================================================
+   Styles par vue (globaux) — board, modal, backlog, sprints,
+   burndown, deps, docs, toasts + chips/atomes + densité.
+   Porté du prototype Claude Design (views.css + styles.css).
+   ============================================================ */
+
+/* ================= CHIPS & ATOMES ================= */
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11px;
+  font-weight: 600;
+  padding: 3px 9px;
+  border-radius: var(--radius-pill);
+  line-height: 1.4;
+  border: 1px solid transparent;
+  white-space: nowrap;
+}
+.chip .swatch {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  flex: none;
+}
+.chip-soft {
+  background: var(--bg-elev-2);
+  color: var(--fg-dim);
+  border-color: var(--border-faint);
+}
+
+.points {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  font-weight: 600;
+  min-width: 24px;
+  height: 22px;
+  padding: 0 6px;
+  border-radius: 6px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-inset);
+  color: var(--fg-dim);
+  border: 1px solid var(--border-faint);
+}
+
+.tag {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 5px;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.tdd-pip {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 5px;
+}
+.tdd-pip i {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+}
+
+.task-prog {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--fg-faint);
+}
+.task-prog .bar {
+  width: 46px;
+  height: 4px;
+  background: var(--bg-inset);
+  border-radius: 99px;
+  overflow: hidden;
+}
+.task-prog .bar > span {
+  display: block;
+  height: 100%;
+  background: var(--accent-dim);
+  border-radius: 99px;
+}
+
+.persona {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 11px;
+  color: var(--fg-dim);
+}
+.persona .ico {
+  width: 13px;
+  height: 13px;
+  opacity: 0.8;
+}
+
+.avatar.avatar-empty {
+  background: var(--bg-inset);
+  color: var(--fg-faint);
+  border: 1px dashed var(--border-strong);
+}
+
+.ring-wrap {
+  position: relative;
+  display: inline-grid;
+  place-items: center;
+}
+.ring-wrap .ring-txt {
+  position: absolute;
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+}
+
+/* ================= KANBAN BOARD ================= */
+.board-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 14px 22px;
+  border-bottom: 1px solid var(--border-faint);
+  flex: none;
+  flex-wrap: wrap;
+}
+.board-toolbar .filters {
+  display: flex;
+  gap: 7px;
+  flex-wrap: wrap;
+}
+.filter-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  padding: 6px 12px;
+  border-radius: var(--radius-pill);
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--fg-dim);
+  border: 1px solid var(--border-faint);
+  background: var(--bg-elev);
+  transition: all 0.12s;
+}
+.filter-chip:hover {
+  color: var(--fg);
+  border-color: var(--border-strong);
+}
+.filter-chip[aria-pressed='true'] {
+  background: var(--accent-soft);
+  color: var(--fg);
+  border-color: var(--accent-ring);
+}
+.filter-chip .dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  display: inline-block;
+}
+.coding-legend {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  font-size: 11.5px;
+  color: var(--fg-faint);
+  flex-wrap: wrap;
+}
+.coding-legend .lbl {
+  font-weight: 600;
+  color: var(--fg-dim);
+}
+.coding-legend .key {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+.coding-legend .key i {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  display: inline-block;
+}
+
+.board {
+  flex: 1;
+  min-height: 0;
+  overflow-x: auto;
+  overflow-y: hidden;
+  display: flex;
+  gap: 14px;
+  padding: 18px 22px 22px;
+}
+.column {
+  flex: 0 0 296px;
+  width: 296px;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  transition:
+    background 0.15s,
+    box-shadow 0.15s,
+    border-color 0.15s;
+}
+.column.drop-target {
+  background: var(--accent-soft);
+  border-color: var(--accent-ring);
+  box-shadow: inset 0 0 0 1px var(--accent-ring);
+}
+.col-head {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 14px 15px 11px;
+  flex: none;
+}
+.col-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  flex: none;
+  box-shadow: 0 0 10px currentColor;
+}
+.col-title {
+  font-weight: 600;
+  font-size: 13.5px;
+  letter-spacing: -0.005em;
+  margin: 0;
+}
+.col-count {
+  font-family: var(--mono);
+  font-size: 11.5px;
+  color: var(--fg-faint);
+  background: var(--bg-inset);
+  padding: 1px 8px;
+  border-radius: var(--radius-pill);
+}
+.col-pts {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+}
+
+.col-body {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: 11px 11px 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  margin: 0;
+  list-style: none;
+}
+.col-empty {
+  margin: 6px 4px;
+  padding: 22px 12px;
+  border: 1px dashed var(--border);
+  border-radius: var(--radius);
+  text-align: center;
+  color: var(--fg-faint);
+  font-size: 12px;
+}
+
+/* ---- Card ---- */
+.card {
+  position: relative;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  padding: 13px 14px 12px;
+  cursor: grab;
+  transition:
+    transform 0.12s,
+    box-shadow 0.12s,
+    border-color 0.12s,
+    background 0.12s;
+  overflow: hidden;
+}
+.card::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 3px;
+  background: var(--code-color, var(--border));
+  border-radius: 3px 0 0 3px;
+}
+.card:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-elev-2);
+  box-shadow: var(--shadow-sm);
+  transform: translateY(-1px);
+}
+.card.dragging {
+  opacity: 0.45;
+  cursor: grabbing;
+}
+.card.kbd-grabbed {
+  border-color: var(--accent-ring);
+  box-shadow: 0 0 0 2px var(--accent-ring);
+}
+.card.read-only {
+  cursor: default;
+}
+.card.read-only:active {
+  cursor: default;
+}
+
+.card-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.card-id {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  font-weight: 500;
+  white-space: nowrap;
+}
+.card-epic-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+}
+.card-top .spacer {
+  flex: 1;
+}
+.card-lock {
+  font-size: 12px;
+  line-height: 1;
+}
+.card-title {
+  font-size: 13.5px;
+  font-weight: 600;
+  line-height: 1.38;
+  letter-spacing: -0.005em;
+  text-wrap: pretty;
+  margin: 0;
+}
+.card-meta {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  margin-top: 11px;
+  flex-wrap: wrap;
+}
+.card-meta .spacer {
+  flex: 1;
+}
+.card-blocked {
+  color: var(--danger);
+  font-weight: 600;
+  font-size: 11px;
+}
+
+/* keyboard move hint */
+.kbd-hint {
+  position: fixed;
+  bottom: 18px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-pill);
+  padding: 9px 18px;
+  font-size: 12.5px;
+  color: var(--fg);
+  box-shadow: var(--shadow-lg);
+  z-index: 60;
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.kbd-hint kbd {
+  font-family: var(--mono);
+  font-size: 11px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  padding: 2px 7px;
+  border-radius: 5px;
+}
+
+/* aide clavier visible (toggle) */
+.keyboard-help-visible {
+  position: fixed;
+  bottom: 14px;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 50;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  color: var(--fg-dim);
+  box-shadow: var(--shadow);
+}
+.keyboard-help-visible summary {
+  padding: 6px 14px;
+  cursor: pointer;
+  user-select: none;
+  list-style: none;
+}
+.keyboard-help-visible[open] summary {
+  border-bottom: 1px solid var(--border-faint);
+}
+.keyboard-help-content {
+  padding: 8px 14px 10px;
+  white-space: nowrap;
+}
+.keyboard-help-content kbd,
+.kbd-inline {
+  font-family: var(--mono);
+  font-size: 10px;
+  padding: 1px 5px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+}
+
+/* ================= STORY MODAL ================= */
+dialog.modal {
+  width: min(760px, 94vw);
+  max-height: 88vh;
+  padding: 0;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius-lg);
+  background: var(--bg-elev);
+  color: var(--fg);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+dialog.modal::backdrop {
+  background: oklch(0.1 0.01 264 / 0.66);
+  backdrop-filter: blur(3px);
+}
+.modal-inner {
+  display: flex;
+  flex-direction: column;
+  max-height: 88vh;
+}
+.modal-head {
+  padding: 20px 24px 16px;
+  border-bottom: 1px solid var(--border-faint);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  flex: none;
+  background: linear-gradient(180deg, var(--bg-elev-2), var(--bg-elev));
+}
+.modal-head .row1 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+.modal-head .m-id {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-faint);
+}
+.modal-head .m-close {
+  margin-left: auto;
+}
+.modal-title {
+  font-size: 21px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+  line-height: 1.25;
+  text-wrap: balance;
+  margin: 0;
+}
+.modal-frontmatter {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.modal-body {
+  padding: 20px 24px 26px;
+  overflow-y: auto;
+}
+.fm-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 1px;
+  background: var(--border-faint);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  overflow: hidden;
+  margin-bottom: 22px;
+}
+.fm-cell {
+  background: var(--bg-elev);
+  padding: 11px 14px;
+}
+.fm-cell .k {
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+  color: var(--fg-faint);
+  font-weight: 600;
+}
+.fm-cell .v {
+  margin-top: 5px;
+  font-size: 13px;
+  font-weight: 500;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.section-h {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin: 22px 0 12px;
+}
+.section-h h3 {
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  margin: 0;
+}
+.section-h .n {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  background: var(--bg-inset);
+  padding: 1px 8px;
+  border-radius: 99px;
+}
+.section-h .line {
+  flex: 1;
+  height: 1px;
+  background: var(--border-faint);
+}
+
+table.tasks {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+}
+table.tasks th {
+  text-align: left;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--fg-faint);
+  font-weight: 600;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+table.tasks td {
+  padding: 9px 10px;
+  border-bottom: 1px solid var(--border-faint);
+  vertical-align: middle;
+}
+table.tasks tr:last-child td {
+  border-bottom: none;
+}
+table.tasks .t-type {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 4px;
+}
+table.tasks .t-name {
+  font-weight: 500;
+}
+table.tasks .t-hrs {
+  font-family: var(--mono);
+  color: var(--fg-dim);
+  text-align: right;
+  white-space: nowrap;
+}
+.t-over {
+  color: var(--danger);
+}
+
+.modal-readonly-note {
+  margin: 18px 0 0;
+  padding: 12px 14px;
+  background: var(--bg-inset);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  font-size: 12px;
+  color: var(--fg-dim);
+  line-height: 1.6;
+}
+.modal-readonly-note code {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--accent);
+}
+
+.md-body {
+  color: var(--fg-dim);
+  font-size: 13.5px;
+  line-height: 1.7;
+}
+.md-body p {
+  margin: 0 0 12px;
+}
+.md-body h1,
+.md-body h2,
+.md-body h3,
+.md-body h4 {
+  color: var(--fg);
+  font-size: 14px;
+  margin: 18px 0 8px;
+  font-weight: 600;
+}
+.md-body ul,
+.md-body ol {
+  list-style: disc;
+  padding-left: 20px;
+  margin: 0 0 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.md-body code {
+  font-family: var(--mono);
+  font-size: 12px;
+  background: var(--bg-inset);
+  padding: 1px 6px;
+  border-radius: 5px;
+  color: var(--accent);
+}
+.md-body strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+.md-body blockquote {
+  border-left: 3px solid var(--accent-dim);
+  padding: 4px 0 4px 14px;
+  margin: 0 0 12px;
+  color: var(--fg-faint);
+}
+.md-body pre {
+  background: var(--bg-inset);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  padding: 14px;
+  overflow-x: auto;
+  margin: 0 0 12px;
+}
+.md-body pre code {
+  background: none;
+  padding: 0;
+  color: var(--fg-dim);
+}
+.md-body table {
+  border-collapse: collapse;
+  width: 100%;
+  margin: 0 0 12px;
+  font-size: 12.5px;
+}
+.md-body th,
+.md-body td {
+  border: 1px solid var(--border-faint);
+  padding: 6px 9px;
+  text-align: left;
+}
+
+/* ================= BACKLOG ================= */
+.backlog {
+  max-width: 1040px;
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.epic {
+  background: var(--bg-sidebar);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.epic-head {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 16px 18px;
+  width: 100%;
+  text-align: left;
+  transition: background 0.12s;
+}
+.epic-head:hover {
+  background: var(--bg-elev);
+}
+.epic-chevron {
+  transition: transform 0.18s ease;
+  color: var(--fg-faint);
+  flex: none;
+}
+.epic[data-open='true'] .epic-chevron {
+  transform: rotate(90deg);
+}
+.epic-bar {
+  width: 4px;
+  align-self: stretch;
+  border-radius: 99px;
+  flex: none;
+}
+.epic-id {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  white-space: nowrap;
+}
+.epic-title {
+  font-size: 15px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+}
+.epic-prog {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 14px;
+}
+.epic-prog .ring {
+  flex: none;
+}
+.epic-meta {
+  font-size: 11.5px;
+  color: var(--fg-faint);
+  font-family: var(--mono);
+}
+.epic-stories {
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 0.22s ease;
+}
+.epic[data-open='true'] .epic-stories {
+  grid-template-rows: 1fr;
+}
+.epic-stories > div {
+  overflow: hidden;
+}
+.story-row {
+  display: flex;
+  align-items: center;
+  gap: 13px;
+  padding: 11px 18px 11px 36px;
+  border-top: 1px solid var(--border-faint);
+  width: 100%;
+  text-align: left;
+  transition: background 0.12s;
+}
+.story-row:hover {
+  background: var(--bg-elev);
+}
+.story-row .s-id {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  width: 58px;
+  flex: none;
+}
+.story-row .s-title {
+  font-size: 13px;
+  font-weight: 500;
+  flex: 1;
+}
+.story-row .s-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 11.5px;
+  color: var(--fg-dim);
+  width: 130px;
+  flex: none;
+}
+.story-row .s-status i {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+}
+
+/* ================= SPRINTS ================= */
+.sprints-layout {
+  display: grid;
+  grid-template-columns: 300px 1fr;
+  gap: 18px;
+  height: 100%;
+  min-height: 0;
+}
+.sprint-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  overflow-y: auto;
+  padding-right: 4px;
+}
+.sprint-item {
+  text-align: left;
+  width: 100%;
+  padding: 14px;
+  border-radius: var(--radius);
+  background: var(--bg-elev);
+  border: 1px solid var(--border-faint);
+  transition: all 0.12s;
+}
+.sprint-item:hover {
+  border-color: var(--border-strong);
+}
+.sprint-item[aria-current='true'] {
+  border-color: var(--accent-ring);
+  background: var(--accent-soft);
+}
+.sprint-item .si-top {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+.sprint-item .si-name {
+  font-weight: 600;
+  font-size: 14px;
+}
+.si-state {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 7px;
+  border-radius: 5px;
+}
+.sprint-item .si-state {
+  margin-left: auto;
+}
+.si-state.active {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.si-state.done {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.si-state.planned {
+  background: var(--bg-inset);
+  color: var(--fg-faint);
+}
+.sprint-item .si-goal {
+  font-size: 12px;
+  color: var(--fg-dim);
+  line-height: 1.5;
+  margin-bottom: 10px;
+  text-wrap: pretty;
+}
+.sprint-item .si-stat {
+  display: flex;
+  gap: 14px;
+  font-size: 11px;
+  color: var(--fg-faint);
+  font-family: var(--mono);
+}
+
+.sprint-detail {
+  overflow-y: auto;
+  padding-right: 4px;
+}
+.sd-head {
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+.sd-head h2 {
+  font-size: 23px;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+.sd-goal {
+  font-size: 14px;
+  color: var(--fg-dim);
+  margin-top: 6px;
+  max-width: 60ch;
+  line-height: 1.6;
+  text-wrap: pretty;
+}
+.sd-metrics {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 22px;
+}
+.metric {
+  background: var(--bg-elev);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  padding: 15px 16px;
+}
+.metric .mk {
+  font-size: 11px;
+  color: var(--fg-faint);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  font-weight: 600;
+}
+.metric .mv {
+  font-size: 26px;
+  font-weight: 700;
+  font-family: var(--mono);
+  letter-spacing: -0.02em;
+  margin-top: 7px;
+}
+.metric .mv small {
+  font-size: 14px;
+  color: var(--fg-faint);
+  font-weight: 500;
+}
+.metric .msub {
+  font-size: 11.5px;
+  color: var(--fg-faint);
+  margin-top: 3px;
+}
+.metric.goal-hit {
+  border-color: var(--success);
+}
+.metric.goal-hit .mv {
+  color: var(--success);
+}
+
+.sd-panel {
+  background: var(--bg-elev);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px;
+  margin-bottom: 16px;
+}
+.sd-panel h3 {
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 12px;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.sd-panel h3 .pill {
+  font-family: var(--mono);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  padding: 2px 7px;
+  border-radius: 5px;
+}
+
+.sd-story {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--border-faint);
+  width: 100%;
+  text-align: left;
+}
+.sd-story:last-child {
+  border-bottom: none;
+}
+.sd-story:hover {
+  background: var(--bg-elev-2);
+}
+.sd-story .s-id {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  width: 56px;
+}
+.sd-story .s-t {
+  flex: 1;
+  font-size: 13px;
+}
+.review-md {
+  color: var(--fg-dim);
+  font-size: 13.5px;
+  line-height: 1.7;
+}
+
+/* ================= BURNDOWN (full) ================= */
+.burn-wrap {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+.burn-card {
+  background: var(--bg-elev);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  padding: 22px;
+  min-height: 340px;
+}
+.burn-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+  flex-wrap: wrap;
+}
+.burn-header h2 {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+}
+.burn-header .meta {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+.on-track-badge {
+  padding: 3px 10px;
+  border-radius: var(--radius-pill);
+  font-size: 11px;
+  font-weight: 600;
+}
+.burn-legend {
+  display: flex;
+  gap: 22px;
+  margin-bottom: 18px;
+  font-size: 12.5px;
+  color: var(--fg-dim);
+}
+.burn-legend .k {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.burn-legend .k i {
+  width: 18px;
+  height: 3px;
+  border-radius: 2px;
+}
+
+/* ================= DEPS GRAPH ================= */
+.deps-wrap {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.deps-header {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-dim);
+}
+.deps-header .stat.danger {
+  color: var(--danger);
+}
+.deps-content {
+  display: flex;
+  gap: 12px;
+  flex: 1;
+  min-height: 0;
+}
+.deps-canvas {
+  flex: 1;
+  min-height: 0;
+  position: relative;
+  background:
+    radial-gradient(circle at 1px 1px, var(--border-faint) 1px, transparent 0) 0 0 / 26px 26px,
+    var(--bg-inset);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  overflow: hidden;
+}
+.node-details {
+  width: 280px;
+  flex: none;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius-lg);
+  padding: 16px;
+  overflow-y: auto;
+}
+.node-details .details-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  border-bottom: 1px solid var(--border-faint);
+  padding-bottom: 10px;
+  margin-bottom: 12px;
+}
+.node-details dl {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 8px 14px;
+  font-size: 12.5px;
+  margin: 0;
+}
+.node-details dt {
+  color: var(--fg-faint);
+}
+
+/* ================= DOCS ================= */
+.docs-layout {
+  display: grid;
+  grid-template-columns: 264px 1fr;
+  gap: 20px;
+  height: 100%;
+  min-height: 0;
+}
+.docs-tree {
+  overflow-y: auto;
+  border-right: 1px solid var(--border-faint);
+  padding-right: 8px;
+}
+.tree-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  text-align: left;
+  padding: 6px 9px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  color: var(--fg-dim);
+  transition: background 0.1s;
+}
+.tree-item:hover {
+  background: var(--bg-elev);
+  color: var(--fg);
+}
+.tree-item[aria-current='true'],
+.tree-item.active {
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+.tree-item .ico {
+  width: 15px;
+  height: 15px;
+  flex: none;
+  opacity: 0.8;
+}
+.tree-folder,
+.group-header {
+  font-weight: 600;
+  color: var(--fg);
+}
+.tree-group {
+  margin-bottom: 4px;
+}
+.tree-children,
+.group-children {
+  padding-left: 14px;
+  border-left: 1px solid var(--border-faint);
+  margin-left: 16px;
+}
+
+.doc-view {
+  overflow-y: auto;
+  padding-right: 10px;
+}
+.doc-paper {
+  max-width: 720px;
+}
+.doc-paper h1 {
+  font-size: 28px;
+  font-weight: 700;
+  letter-spacing: -0.025em;
+  margin-bottom: 8px;
+}
+.doc-paper .doc-path {
+  font-family: var(--mono);
+  font-size: 12px;
+  color: var(--fg-faint);
+  margin-bottom: 24px;
+}
+.doc-paper h2 {
+  font-size: 18px;
+  font-weight: 600;
+  margin: 28px 0 12px;
+  padding-bottom: 8px;
+  border-bottom: 1px solid var(--border-faint);
+  letter-spacing: -0.01em;
+}
+.doc-paper h3 {
+  font-size: 14.5px;
+  font-weight: 600;
+  margin: 20px 0 8px;
+}
+.doc-paper p {
+  color: var(--fg-dim);
+  line-height: 1.75;
+  margin-bottom: 14px;
+}
+.doc-paper ul,
+.doc-paper ol {
+  list-style: disc;
+  padding-left: 22px;
+  margin-bottom: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--fg-dim);
+}
+.doc-paper code {
+  font-family: var(--mono);
+  font-size: 12.5px;
+  background: var(--bg-inset);
+  padding: 2px 6px;
+  border-radius: 5px;
+  color: var(--accent);
+}
+.doc-paper pre {
+  background: var(--bg-inset);
+  border: 1px solid var(--border-faint);
+  border-radius: var(--radius);
+  padding: 16px;
+  overflow-x: auto;
+  margin-bottom: 16px;
+}
+.doc-paper pre code {
+  background: none;
+  padding: 0;
+  color: var(--fg-dim);
+  line-height: 1.6;
+}
+.doc-paper strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+.doc-paper blockquote {
+  border-left: 3px solid var(--accent-dim);
+  padding: 8px 0 8px 16px;
+  margin-bottom: 16px;
+  color: var(--fg-faint);
+  font-style: italic;
+}
+.doc-paper a {
+  color: var(--accent);
+}
+
+/* ================= TOASTS ================= */
+.toast-region {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  z-index: 200;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 11px;
+  min-width: 248px;
+  max-width: 360px;
+  background: var(--bg-elev-2);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  padding: 12px 15px;
+  box-shadow: var(--shadow-lg);
+  animation: toast-in 0.25s cubic-bezier(0.2, 0.8, 0.2, 1);
+  cursor: pointer;
+}
+.toast .t-ico {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  display: grid;
+  place-items: center;
+  flex: none;
+}
+.toast.error .t-ico,
+.toast .t-ico.warn {
+  background: var(--danger-soft);
+  color: var(--danger);
+}
+.toast.success .t-ico,
+.toast .t-ico.ok {
+  background: var(--success-soft);
+  color: var(--success);
+}
+.toast.info .t-ico {
+  background: var(--accent-soft);
+  color: var(--accent);
+}
+.toast .t-msg {
+  font-size: 13px;
+  font-weight: 500;
+}
+.toast .t-sub {
+  font-size: 11.5px;
+  color: var(--fg-faint);
+  font-family: var(--mono);
+  margin-top: 1px;
+}
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateX(20px) scale(0.96);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+
+/* ===== densité ===== */
+.app-shell[data-density='compact'] .card {
+  padding: 9px 11px 9px;
+}
+.app-shell[data-density='compact'] .card-title {
+  font-size: 12.5px;
+}
+.app-shell[data-density='compact'] .card-meta {
+  margin-top: 8px;
+}
+.app-shell[data-density='compact'] .col-body {
+  gap: 7px;
+  padding: 9px 9px 11px;
+}
+.app-shell[data-density='compact'] .column {
+  flex-basis: 270px;
+  width: 270px;
+}
+.app-shell[data-density='compact'] .card-top {
+  margin-bottom: 6px;
+}
+
+/* ===== responsive ===== */
+@media (max-width: 980px) {
+  .sprints-layout {
+    grid-template-columns: 1fr;
+  }
+  .docs-layout {
+    grid-template-columns: 1fr;
+  }
+  .docs-tree {
+    display: none;
+  }
+  .deps-content {
+    flex-direction: column;
+  }
+  .node-details {
+    width: 100%;
+  }
+}

--- a/cli/kanban/client/src/views/BacklogView.svelte
+++ b/cli/kanban/client/src/views/BacklogView.svelte
@@ -1,320 +1,115 @@
 <script>
   import { store } from '../lib/store.svelte.js';
   import { groupStoriesByEpic } from '../lib/backlog.js';
+  import { STATUS, epicHue } from '../lib/config.js';
+  import Icon from '../components/Icon.svelte';
+  import Avatar from '../components/Avatar.svelte';
+  import PriorityChip from '../components/PriorityChip.svelte';
+  import Points from '../components/Points.svelte';
+  import ProgressRing from '../components/ProgressRing.svelte';
 
-  // Stories with an unknown epic_id (e.g. BMAD v6 sprint-status.yaml, epic_id="E1" with no
-  // markdown epic) are kept in a synthesized group instead of being dropped — see backlog.js.
+  // Stories with an unknown epic_id (e.g. BMAD v6 sprint-status.yaml) are kept in a
+  // synthesized group instead of being dropped — see backlog.js.
   const epicGroups = $derived(groupStoriesByEpic(store.stories, store.epics));
 
   let expanded = $state(new Set());
 
   function toggleEpic(epicId) {
     const next = new Set(expanded);
-    if (next.has(epicId)) {
-      next.delete(epicId);
-    } else {
-      next.add(epicId);
-    }
+    if (next.has(epicId)) next.delete(epicId);
+    else next.add(epicId);
     expanded = next;
   }
 
   function epicProgress(stories) {
-    const done = stories.filter(s => s.status === 'done').length;
+    const done = stories.filter((s) => s.status === 'done').length;
     const total = stories.length;
     return { done, total, percent: total > 0 ? Math.round((done / total) * 100) : 0 };
   }
 
-  function epicTotalPoints(stories) {
-    return stories.reduce((sum, s) => sum + (s.story_points || 0), 0);
-  }
-
-  function businessValueColor(value) {
-    if (value === 'high') return 'var(--danger)';
-    if (value === 'medium') return 'var(--warn)';
-    if (value === 'low') return 'var(--info)';
-    return 'var(--fg-dim)';
-  }
-
-  function statusColor(status) {
-    if (status === 'done') return 'var(--ok)';
-    if (status === 'blocked') return 'var(--danger)';
-    if (status === 'in-progress') return 'var(--accent)';
-    if (status === 'review') return 'var(--info)';
-    return 'var(--fg-dim)';
-  }
-
-  function tddBadge(phase) {
-    if (phase === 'red') return { char: '●', color: 'var(--danger)', label: 'red' };
-    if (phase === 'green') return { char: '●', color: 'var(--ok)', label: 'green' };
-    if (phase === 'refactor') return { char: '●', color: 'var(--info)', label: 'refactor' };
-    if (phase === 'done') return { char: '✓', color: 'var(--ok)', label: 'done' };
-    return null;
-  }
+  const epicTotalPoints = (stories) => stories.reduce((sum, s) => sum + (s.story_points || 0), 0);
 </script>
 
-<div class="backlog">
-  {#if store.epics.length === 0 && store.stories.length === 0}
-    <div class="empty">No epics or stories yet</div>
-  {:else}
-    {#each epicGroups.groups as { epic, stories } (epic.id)}
-      {@const progress = epicProgress(stories)}
-      {@const totalPoints = epicTotalPoints(stories)}
-      {@const isExpanded = expanded.has(epic.id)}
-
-      <article class="epic-card">
-        <header class="epic-header">
-          <button
-            class="expand-btn"
-            onclick={() => toggleEpic(epic.id)}
-            aria-label={isExpanded ? 'Collapse' : 'Expand'}
-            aria-expanded={isExpanded}
-          >
-            {isExpanded ? '▾' : '▸'}
-          </button>
-          <span class="epic-id">{epic.id}</span>
-          <span class="epic-title">{epic.title}</span>
-          <span class="business-value" style="background: {businessValueColor(epic.business_value)}">
-            {epic.business_value}
-          </span>
-          <span class="story-count">{stories.length} stories</span>
-          <span class="total-points">{totalPoints}p</span>
-        </header>
-
-        <div class="epic-status">
-          <span class="status-badge" style="color: {statusColor(epic.status)}">{epic.status}</span>
-        </div>
-
-        <div class="epic-progress" role="region" aria-label="epic progress">
-          <div class="progress-bar-bg">
-            <div class="progress-bar" style="width: {progress.percent}%"></div>
-          </div>
-          <span class="progress-text">{progress.done}/{progress.total} ({progress.percent}%)</span>
-        </div>
-
-        {#if isExpanded && stories.length > 0}
-          <div class="stories-list">
-            {#each stories as story (story.id)}
-              {@const tdd = tddBadge(story.tdd_phase)}
-
-              <div class="story-item">
-                <span class="story-id">{story.id}</span>
-                <span class="story-title">{story.title}</span>
-                <span class="story-status" style="color: {statusColor(story.status)}">{story.status}</span>
-                <span class="story-points">{story.story_points}p</span>
-                {#if tdd}
-                  <span class="story-tdd" style="color: {tdd.color}" title="TDD: {tdd.label}">{tdd.char}</span>
-                {/if}
+<div class="view-pad">
+  <div class="backlog">
+    {#if store.epics.length === 0 && store.stories.length === 0}
+      <div class="empty">No epics or stories yet</div>
+    {:else}
+      {#each epicGroups.groups as { epic, stories } (epic.id)}
+        {@const progress = epicProgress(stories)}
+        {@const isOpen = expanded.has(epic.id)}
+        {@const color = epicHue(epic.id)}
+        <div class="epic" data-open={isOpen}>
+          <button class="epic-head" aria-expanded={isOpen} onclick={() => toggleEpic(epic.id)}>
+            <Icon name="chevron" cls="epic-chevron" size={16} />
+            <span class="epic-bar" style="background: {color}"></span>
+            <div>
+              <div style="display:flex; align-items:center; gap:9px">
+                <span class="epic-id mono">{epic.id}</span>
+                <span class="epic-title">{epic.title}</span>
               </div>
-            {/each}
-          </div>
-        {/if}
-      </article>
-    {/each}
-
-    {#if epicGroups.orphans.length > 0}
-      <article class="epic-card orphans">
-        <header class="epic-header">
-          <button
-            class="expand-btn"
-            onclick={() => toggleEpic('__orphans__')}
-            aria-label={expanded.has('__orphans__') ? 'Collapse' : 'Expand'}
-            aria-expanded={expanded.has('__orphans__')}
-          >
-            {expanded.has('__orphans__') ? '▾' : '▸'}
+              <div class="epic-meta" style="margin-top:3px">{epic.business_value ? epic.business_value + ' value · ' : ''}{epic.status}</div>
+            </div>
+            <div class="epic-prog">
+              <span class="epic-meta">{stories.length} stories · {epicTotalPoints(stories)} pts</span>
+              <span class="ring"><ProgressRing pct={progress.percent} size={42} color={color} /></span>
+            </div>
           </button>
-          <span class="epic-title">No Epic</span>
-          <span class="story-count">{epicGroups.orphans.length} stories</span>
-          <span class="total-points">{epicTotalPoints(epicGroups.orphans)}p</span>
-        </header>
-
-        {#if expanded.has('__orphans__')}
-          <div class="stories-list">
-            {#each epicGroups.orphans as story (story.id)}
-              {@const tdd = tddBadge(story.tdd_phase)}
-
-              <div class="story-item">
-                <span class="story-id">{story.id}</span>
-                <span class="story-title">{story.title}</span>
-                <span class="story-status" style="color: {statusColor(story.status)}">{story.status}</span>
-                <span class="story-points">{story.story_points}p</span>
-                {#if tdd}
-                  <span class="story-tdd" style="color: {tdd.color}" title="TDD: {tdd.label}">{tdd.char}</span>
-                {/if}
-              </div>
-            {/each}
+          <div class="epic-stories">
+            <div>
+              {#each stories as story (story.id)}
+                <div class="story-row">
+                  <span class="s-id mono">{story.id}</span>
+                  <span class="s-title">{story.title}</span>
+                  {#if story._writable === false}<span class="ro-lock"><Icon name="lock" size={12} /></span>{/if}
+                  <PriorityChip priority={story.priority} />
+                  <Points value={story.story_points} />
+                  <span class="s-status">
+                    <i style="background: var({STATUS[story.status]?.cssVar || '--fg-faint'})"></i>{STATUS[story.status]?.label || story.status}
+                  </span>
+                  <Avatar id={story.assigned_to} size={24} />
+                </div>
+              {/each}
+            </div>
           </div>
-        {/if}
-      </article>
+        </div>
+      {/each}
+
+      {#if epicGroups.orphans.length > 0}
+        {@const isOpen = expanded.has('__orphans__')}
+        <div class="epic" data-open={isOpen}>
+          <button class="epic-head" aria-expanded={isOpen} onclick={() => toggleEpic('__orphans__')}>
+            <Icon name="chevron" cls="epic-chevron" size={16} />
+            <span class="epic-bar" style="background: var(--warning)"></span>
+            <div>
+              <div style="display:flex; align-items:center; gap:9px">
+                <span class="epic-title">No Epic</span>
+              </div>
+              <div class="epic-meta" style="margin-top:3px">Stories sans epic</div>
+            </div>
+            <div class="epic-prog">
+              <span class="epic-meta">{epicGroups.orphans.length} stories · {epicTotalPoints(epicGroups.orphans)} pts</span>
+            </div>
+          </button>
+          <div class="epic-stories">
+            <div>
+              {#each epicGroups.orphans as story (story.id)}
+                <div class="story-row">
+                  <span class="s-id mono">{story.id}</span>
+                  <span class="s-title">{story.title}</span>
+                  {#if story._writable === false}<span class="ro-lock"><Icon name="lock" size={12} /></span>{/if}
+                  <PriorityChip priority={story.priority} />
+                  <Points value={story.story_points} />
+                  <span class="s-status">
+                    <i style="background: var({STATUS[story.status]?.cssVar || '--fg-faint'})"></i>{STATUS[story.status]?.label || story.status}
+                  </span>
+                  <Avatar id={story.assigned_to} size={24} />
+                </div>
+              {/each}
+            </div>
+          </div>
+        </div>
+      {/if}
     {/if}
-  {/if}
+  </div>
 </div>
-
-<style>
-  .backlog {
-    max-width: 1200px;
-    margin: 0 auto;
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-  }
-
-  .epic-card {
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 14px;
-    box-shadow: var(--shadow);
-  }
-
-  .epic-card.orphans {
-    border-left: 3px solid var(--warn);
-  }
-
-  .epic-header {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 8px;
-  }
-
-  .expand-btn {
-    background: transparent;
-    border: none;
-    cursor: pointer;
-    padding: 4px 6px;
-    font-size: 14px;
-    color: var(--fg-dim);
-    border-radius: 3px;
-  }
-
-  .expand-btn:hover {
-    background: var(--border);
-  }
-
-  .expand-btn:focus {
-    outline: 2px solid var(--accent);
-    outline-offset: 1px;
-  }
-
-  .epic-id {
-    font-family: var(--mono);
-    font-weight: 600;
-    font-size: 12px;
-    color: var(--accent);
-  }
-
-  .epic-title {
-    font-weight: 600;
-    flex: 1;
-  }
-
-  .business-value {
-    text-transform: uppercase;
-    font-size: 10px;
-    font-weight: 700;
-    padding: 3px 8px;
-    border-radius: 10px;
-    color: var(--accent-fg);
-  }
-
-  .story-count {
-    font-size: 12px;
-    color: var(--fg-dim);
-    font-family: var(--mono);
-  }
-
-  .total-points {
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--accent);
-    font-family: var(--mono);
-  }
-
-  .epic-status {
-    margin-bottom: 8px;
-  }
-
-  .status-badge {
-    text-transform: uppercase;
-    font-size: 11px;
-    font-weight: 600;
-  }
-
-  .epic-progress {
-    display: flex;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 12px;
-  }
-
-  .progress-bar-bg {
-    flex: 1;
-    background: var(--bg-sidebar);
-    height: 8px;
-    border-radius: 4px;
-    overflow: hidden;
-  }
-
-  .progress-bar {
-    background: var(--accent);
-    height: 100%;
-    transition: width 0.3s ease;
-  }
-
-  .progress-text {
-    font-size: 11px;
-    color: var(--fg-dim);
-    font-family: var(--mono);
-    min-width: 80px;
-    text-align: right;
-  }
-
-  .stories-list {
-    margin-top: 12px;
-    border-top: 1px solid var(--border);
-    padding-top: 12px;
-    display: flex;
-    flex-direction: column;
-    gap: 6px;
-  }
-
-  .story-item {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 6px 10px;
-    background: var(--bg-sidebar);
-    border-radius: var(--radius);
-    font-size: 13px;
-  }
-
-  .story-id {
-    font-family: var(--mono);
-    font-weight: 600;
-    font-size: 11px;
-    color: var(--accent);
-  }
-
-  .story-title {
-    flex: 1;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-
-  .story-status {
-    text-transform: uppercase;
-    font-size: 10px;
-    font-weight: 600;
-  }
-
-  .story-points {
-    font-family: var(--mono);
-    font-size: 11px;
-    color: var(--fg-dim);
-  }
-
-  .story-tdd {
-    font-size: 13px;
-  }
-</style>

--- a/cli/kanban/client/src/views/BurndownView.svelte
+++ b/cli/kanban/client/src/views/BurndownView.svelte
@@ -9,10 +9,9 @@
   const hasData = $derived(store.burndown?.ideal?.length > 0);
 
   const onTrackColor = $derived.by(() => {
-    if (!store.burndown?.on_track) return 'var(--fg-dim)';
-    if (store.burndown.on_track === 'on-track') return 'var(--ok)';
-    if (store.burndown.on_track === 'at-risk') return 'var(--warn)';
-    if (store.burndown.on_track === 'behind') return 'var(--danger)';
+    if (store.burndown?.on_track === 'on-track') return 'var(--success)';
+    if (store.burndown?.on_track === 'at-risk') return 'var(--warning)';
+    if (store.burndown?.on_track === 'behind') return 'var(--danger)';
     return 'var(--fg-dim)';
   });
 
@@ -25,86 +24,52 @@
       return;
     }
 
-    const idealData = store.burndown.ideal.map(p => ({
-      ts: Math.floor(Date.parse(p.date) / 1000),
-      pts: p.points
-    }));
+    // Canvas ne résout pas var(--x) : on lit les valeurs calculées des tokens.
+    const cs = getComputedStyle(chartContainer);
+    const tok = (name, fb) => cs.getPropertyValue(name).trim() || fb;
+    const cFaint = tok('--fg-faint', '#888');
+    const cAccent = tok('--accent', '#bdf03d');
+    const cGrid = tok('--border-faint', '#333');
 
-    const actualData = store.burndown.actual.map(p => ({
-      ts: Math.floor(Date.parse(p.date) / 1000),
-      pts: p.points
-    }));
+    const idealData = store.burndown.ideal.map((p) => ({ ts: Math.floor(Date.parse(p.date) / 1000), pts: p.points }));
+    const actualData = store.burndown.actual.map((p) => ({ ts: Math.floor(Date.parse(p.date) / 1000), pts: p.points }));
 
-    const allTimestamps = new Set([
-      ...idealData.map(p => p.ts),
-      ...actualData.map(p => p.ts)
-    ]);
+    const allTimestamps = new Set([...idealData.map((p) => p.ts), ...actualData.map((p) => p.ts)]);
     const timestamps = Array.from(allTimestamps).sort((a, b) => a - b);
+    const idealValues = timestamps.map((ts) => idealData.find((p) => p.ts === ts)?.pts ?? null);
+    const actualValues = timestamps.map((ts) => actualData.find((p) => p.ts === ts)?.pts ?? null);
 
-    const idealValues = timestamps.map(ts => {
-      const point = idealData.find(p => p.ts === ts);
-      return point ? point.pts : null;
-    });
-
-    const actualValues = timestamps.map(ts => {
-      const point = actualData.find(p => p.ts === ts);
-      return point ? point.pts : null;
-    });
-
-    const data = [
-      timestamps,
-      idealValues,
-      actualValues
-    ];
+    const data = [timestamps, idealValues, actualValues];
 
     const opts = {
       width: chartContainer.clientWidth || 800,
-      height: 300,
-      scales: {
-        x: { time: true }
-      },
+      height: 320,
+      scales: { x: { time: true } },
       axes: [
         {
-          stroke: 'var(--fg-dim)',
-          grid: { stroke: 'var(--border)' },
-          values: (u, vals) => vals.map(v => {
+          stroke: cFaint,
+          grid: { stroke: cGrid },
+          ticks: { stroke: cGrid },
+          values: (u, vals) => vals.map((v) => {
             const d = new Date(v * 1000);
             return `${String(d.getDate()).padStart(2, '0')}/${String(d.getMonth() + 1).padStart(2, '0')}`;
-          })
+          }),
         },
-        {
-          stroke: 'var(--fg-dim)',
-          grid: { stroke: 'var(--border)' }
-        }
+        { stroke: cFaint, grid: { stroke: cGrid }, ticks: { stroke: cGrid } },
       ],
       series: [
         { label: 'Date' },
-        {
-          label: 'Ideal',
-          stroke: 'var(--fg-dim)',
-          width: 2,
-          dash: [5, 5],
-          points: { show: false }
-        },
-        {
-          label: 'Actual',
-          stroke: 'var(--accent)',
-          width: 3,
-          points: { show: true, size: 5, fill: 'var(--accent)' }
-        }
+        { label: 'Ideal', stroke: cFaint, width: 1.5, dash: [5, 5], points: { show: false } },
+        { label: 'Actual', stroke: cAccent, width: 3, points: { show: true, size: 6, fill: cAccent, stroke: cAccent } },
       ],
-      legend: {
-        show: true
-      }
+      legend: { show: true },
     };
 
     if (chart) chart.destroy();
     chart = new uPlot(opts, data, chartContainer);
 
     const resizeObserver = new ResizeObserver(() => {
-      if (chart && chartContainer) {
-        chart.setSize({ width: chartContainer.clientWidth, height: 300 });
-      }
+      if (chart && chartContainer) chart.setSize({ width: chartContainer.clientWidth, height: 320 });
     });
     resizeObserver.observe(chartContainer);
 
@@ -118,116 +83,55 @@
   });
 </script>
 
-<div class="burndown">
-  {#if !store.burndown || !hasData}
-    <div class="empty">No burndown data (sprint not started or no start/end date)</div>
-  {:else}
-    <header class="burndown-header">
-      <h2 class="sprint-name">{store.sprint?.name || 'Current Sprint'}</h2>
-      <div class="meta">
-        <span class="on-track-badge" style="background: {onTrackColor}">
-          {store.burndown.on_track || 'unknown'}
-        </span>
-        <span class="total-points">{store.burndown.total_points}p total</span>
+<div class="view-pad">
+  <div class="burn-wrap">
+    {#if !store.burndown || !hasData}
+      <div class="empty">No burndown data (sprint not started or no start/end date)</div>
+    {:else}
+      <div class="burn-card">
+        <header class="burn-header">
+          <h2>{store.sprint?.name || 'Current Sprint'}</h2>
+          <div class="meta">
+            <span class="on-track-badge" style="background: color-mix(in oklch, {onTrackColor} 16%, transparent); color: {onTrackColor}">
+              {store.burndown.on_track || 'unknown'}
+            </span>
+            <span>{store.burndown.total_points}p total</span>
+          </div>
+        </header>
+
+        <div class="burn-legend">
+          <span class="k"><i style="background: var(--fg-faint)"></i> Idéal</span>
+          <span class="k"><i style="background: var(--accent)"></i> Réel</span>
+        </div>
+
+        <!--
+          role=img + aria-label : alternative accessible pour le canvas uPlot (WCAG SC 1.1.1, 1.4.5).
+          Le tableau sr-only fournit les données brutes aux lecteurs d'écran.
+        -->
+        <div
+          class="chart-wrapper"
+          bind:this={chartContainer}
+          role="img"
+          aria-label="Graphique de burndown du sprint {store.sprint?.name || 'courant'} : idéal vs réel"
+          aria-describedby="burndown-data-table"
+        ></div>
+
+        <table class="sr-only" id="burndown-data-table" aria-label="Données du burndown">
+          <caption>Burndown — idéal vs réel</caption>
+          <thead>
+            <tr><th scope="col">Date</th><th scope="col">Points idéal</th><th scope="col">Points réel</th></tr>
+          </thead>
+          <tbody>
+            {#each store.burndown?.ideal ?? [] as point, i}
+              <tr><td>{point.date}</td><td>{point.points}</td><td>{store.burndown?.actual?.[i]?.points ?? '—'}</td></tr>
+            {/each}
+          </tbody>
+        </table>
       </div>
-    </header>
-
-    <!--
-      role=img + aria-label : alternative accessible pour le canvas uPlot (WCAG SC 1.1.1, 1.4.5).
-      Le tableau sr-only fournit les données brutes aux lecteurs d'écran.
-    -->
-    <div
-      class="chart-wrapper"
-      bind:this={chartContainer}
-      role="img"
-      aria-label="Graphique de burndown du sprint {store.sprint?.name || 'courant'} : idéal vs réel"
-      aria-describedby="burndown-data-table"
-    ></div>
-
-    <!-- Tableau de données sr-only : accès aux valeurs numériques sans graphique -->
-    <table class="sr-only" id="burndown-data-table" aria-label="Données du burndown">
-      <caption>Burndown — idéal vs réel</caption>
-      <thead>
-        <tr>
-          <th scope="col">Date</th>
-          <th scope="col">Points idéal</th>
-          <th scope="col">Points réel</th>
-        </tr>
-      </thead>
-      <tbody>
-        {#each store.burndown?.ideal ?? [] as point, i}
-          <tr>
-            <td>{point.date}</td>
-            <td>{point.points}</td>
-            <td>{store.burndown?.actual?.[i]?.points ?? '—'}</td>
-          </tr>
-        {/each}
-      </tbody>
-    </table>
-  {/if}
+    {/if}
+  </div>
 </div>
 
 <style>
-  .burndown {
-    max-width: 1200px;
-    margin: 0 auto;
-  }
-
-  .burndown-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    margin-bottom: 20px;
-  }
-
-  .sprint-name {
-    font-size: 18px;
-    font-weight: 700;
-    margin: 0;
-    color: var(--fg);
-  }
-
-  .meta {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-  }
-
-  .on-track-badge {
-    text-transform: uppercase;
-    font-size: 11px;
-    font-weight: 700;
-    padding: 4px 10px;
-    border-radius: 12px;
-    color: var(--badge-fg);
-  }
-
-  .total-points {
-    font-family: var(--mono);
-    font-size: 13px;
-    color: var(--fg-dim);
-    font-weight: 600;
-  }
-
-  .chart-wrapper {
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 20px;
-    box-shadow: var(--shadow);
-    min-height: 340px;
-  }
-
-  /* Accessible uniquement aux lecteurs d'écran */
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
-  }
+  .chart-wrapper { min-height: 320px; }
 </style>

--- a/cli/kanban/client/src/views/DepsView.svelte
+++ b/cli/kanban/client/src/views/DepsView.svelte
@@ -1,6 +1,7 @@
 <script>
   import cytoscape from 'cytoscape';
   import dagre from 'cytoscape-dagre';
+  import { STATUS } from '../lib/config.js';
 
   cytoscape.use(dagre);
 
@@ -13,11 +14,10 @@
   let loading = $state(true);
   let error = $state(null);
 
-  const stats = $derived({
-    nodes: nodes.length,
-    edges: edges.length,
-    cycles: cycles.length,
-  });
+  const stats = $derived({ nodes: nodes.length, edges: edges.length, cycles: cycles.length });
+
+  /** Couleur de statut côté DOM (badge) — var() résolu par le navigateur. */
+  const domStatusColor = (status) => `var(${STATUS[status]?.cssVar || '--fg-faint'})`;
 
   async function loadDependencies() {
     loading = true;
@@ -36,18 +36,6 @@
     }
   }
 
-  function getStatusColor(status) {
-    const colors = {
-      backlog: 'var(--fg-dim)',
-      'ready-for-dev': 'var(--info)',
-      'in-progress': 'var(--warn)',
-      review: 'var(--accent)',
-      done: 'var(--ok)',
-      blocked: 'var(--danger)',
-    };
-    return colors[status] || 'var(--fg-dim)';
-  }
-
   function isInCycle(nodeId) {
     return cycles.some((cycle) => cycle.includes(nodeId));
   }
@@ -59,16 +47,21 @@
   $effect(() => {
     if (!graphContainer || nodes.length === 0 || !edges || cyInstance) return;
 
+    // Cytoscape rend sur canvas : on résout les tokens en couleurs réelles.
+    const root = getComputedStyle(document.documentElement);
+    const tok = (n, fb) => root.getPropertyValue(n).trim() || fb;
+    const statusColor = (status) => tok(STATUS[status]?.cssVar || '--fg-faint', '#888');
+    const cBg = tok('--bg-inset', '#111');
+    const cBorder = tok('--border-faint', '#333');
+    const cBorderStrong = tok('--border-strong', '#555');
+    const cDanger = tok('--danger', '#e5484d');
+    const cMono = tok('--mono', 'monospace');
+
     const cycleSet = new Set(cycles.flat());
 
     const elements = [
-      ...nodes.map((n) => ({
-        data: { id: n.id, label: n.id },
-        classes: cycleSet.has(n.id) ? 'in-cycle' : '',
-      })),
-      ...edges.map((e) => ({
-        data: { source: e.from, target: e.to },
-      })),
+      ...nodes.map((n) => ({ data: { id: n.id, label: n.id }, classes: cycleSet.has(n.id) ? 'in-cycle' : '' })),
+      ...edges.map((e) => ({ data: { source: e.from, target: e.to } })),
     ];
 
     const cy = cytoscape({
@@ -82,56 +75,42 @@
             shape: 'round-rectangle',
             'background-color': (ele) => {
               const node = nodes.find((n) => n.id === ele.id());
-              return node ? getStatusColor(node.status) : 'var(--fg-dim)';
+              return node ? statusColor(node.status) : '#888';
             },
-            color: 'var(--bg)',
+            color: cBg,
             'text-valign': 'center',
             'text-halign': 'center',
             'font-size': '11px',
             'font-weight': '600',
-            'font-family': 'var(--mono)',
+            'font-family': cMono,
             width: 'label',
             height: 'label',
-            'padding-left': '8px',
-            'padding-right': '8px',
-            'padding-top': '6px',
-            'padding-bottom': '6px',
+            'padding-left': '10px',
+            'padding-right': '10px',
+            'padding-top': '7px',
+            'padding-bottom': '7px',
             'border-width': 1,
-            'border-color': 'var(--border)',
+            'border-color': cBorder,
           },
         },
-        {
-          selector: 'node.in-cycle',
-          style: {
-            'border-width': 3,
-            'border-color': 'var(--danger)',
-          },
-        },
+        { selector: 'node.in-cycle', style: { 'border-width': 3, 'border-color': cDanger } },
         {
           selector: 'edge',
           style: {
-            width: 1.5,
-            'line-color': 'var(--fg-dim)',
-            'target-arrow-color': 'var(--fg-dim)',
+            width: 1.6,
+            'line-color': cBorderStrong,
+            'target-arrow-color': cBorderStrong,
             'target-arrow-shape': 'triangle',
             'curve-style': 'bezier',
           },
         },
       ],
-      layout: {
-        name: 'dagre',
-        rankDir: 'LR',
-        spacingFactor: 1.3,
-        nodeDimensionsIncludeLabels: true,
-      },
+      layout: { name: 'dagre', rankDir: 'LR', spacingFactor: 1.3, nodeDimensionsIncludeLabels: true },
     });
 
     cy.on('tap', 'node', (evt) => {
-      const nodeId = evt.target.id();
-      const nodeData = nodes.find((n) => n.id === nodeId);
-      if (nodeData) {
-        selectedNode = nodeData;
-      }
+      const nodeData = nodes.find((n) => n.id === evt.target.id());
+      if (nodeData) selectedNode = nodeData;
     });
 
     cyInstance = cy;
@@ -145,190 +124,71 @@
   });
 </script>
 
-{#if loading}
-  <div class="empty">Loading dependencies...</div>
-{:else if error}
-  <div class="empty" style="color: var(--danger)">Error: {error}</div>
-{:else if nodes.length === 0}
-  <div class="empty">No dependencies found</div>
-{:else}
-  <div class="deps-container">
-    <header class="deps-header">
-      <span class="stat">Nodes: {stats.nodes}</span>
-      <span class="stat">Edges: {stats.edges}</span>
-      <span class="stat" class:danger={stats.cycles > 0}>
-        Cycles: {stats.cycles}
-      </span>
-    </header>
+<div class="deps-pad">
+  {#if loading}
+    <div class="empty">Loading dependencies…</div>
+  {:else if error}
+    <div class="empty" style="color: var(--danger)">Error: {error}</div>
+  {:else if nodes.length === 0}
+    <div class="empty">No dependencies found</div>
+  {:else}
+    <div class="deps-wrap">
+      <header class="deps-header">
+        <span class="stat">Nodes: {stats.nodes}</span>
+        <span class="stat">Edges: {stats.edges}</span>
+        <span class="stat" class:danger={stats.cycles > 0}>Cycles: {stats.cycles}</span>
+      </header>
 
-    <div class="deps-content">
-      <div
-        class="graph"
-        bind:this={graphContainer}
-        role="img"
-        aria-label="Dependency graph with {stats.nodes} nodes, {stats.edges} edges, and {stats.cycles} cycles"
-      ></div>
+      <div class="deps-content">
+        <div
+          class="deps-canvas"
+          bind:this={graphContainer}
+          role="img"
+          aria-label="Dependency graph with {stats.nodes} nodes, {stats.edges} edges, and {stats.cycles} cycles"
+        ></div>
 
-      {#if selectedNode}
-        <aside class="node-details">
-          <header class="details-header">
-            <strong>{selectedNode.id}</strong>
-            <button
-              class="close-btn"
-              onclick={() => (selectedNode = null)}
-              aria-label="Close details"
-            >
-              ×
-            </button>
-          </header>
-          <dl>
-            <dt>Title</dt>
-            <dd>{selectedNode.title || 'N/A'}</dd>
-            <dt>Status</dt>
-            <dd>
-              <span
-                class="badge"
-                style="background-color: {getStatusColor(selectedNode.status)}"
-              >
-                {selectedNode.status}
-              </span>
-            </dd>
-            {#if selectedNode.epic_id}
-              <dt>Epic</dt>
-              <dd class="epic">{selectedNode.epic_id}</dd>
-            {/if}
-            {#if isInCycle(selectedNode.id)}
-              <dt>Warning</dt>
-              <dd style="color: var(--danger)">Part of a dependency cycle</dd>
-            {/if}
-          </dl>
-        </aside>
-      {/if}
+        {#if selectedNode}
+          <aside class="node-details">
+            <header class="details-header">
+              <strong class="mono">{selectedNode.id}</strong>
+              <button class="close-btn" onclick={() => (selectedNode = null)} aria-label="Fermer">×</button>
+            </header>
+            <dl>
+              <dt>Titre</dt>
+              <dd>{selectedNode.title || '—'}</dd>
+              <dt>Statut</dt>
+              <dd><span class="chip"><i class="swatch" style="background: {domStatusColor(selectedNode.status)}"></i>{STATUS[selectedNode.status]?.label || selectedNode.status}</span></dd>
+              {#if selectedNode.epic_id}
+                <dt>Epic</dt>
+                <dd class="mono">{selectedNode.epic_id}</dd>
+              {/if}
+              {#if isInCycle(selectedNode.id)}
+                <dt>⚠</dt>
+                <dd style="color: var(--danger)">Fait partie d'un cycle de dépendances</dd>
+              {/if}
+            </dl>
+          </aside>
+        {/if}
+      </div>
+
+      <div class="sr-only">
+        <h2>Dependency edges (text fallback)</h2>
+        <ul>
+          {#each edges as edge}<li>{edge.from} depends on {edge.to}</li>{/each}
+        </ul>
+      </div>
     </div>
-
-    <div class="sr-only">
-      <h2>Dependency edges (text fallback)</h2>
-      <ul>
-        {#each edges as edge}
-          <li>{edge.from} depends on {edge.to}</li>
-        {/each}
-      </ul>
-    </div>
-  </div>
-{/if}
+  {/if}
+</div>
 
 <style>
-  .deps-container {
-    display: flex;
-    flex-direction: column;
-    gap: 12px;
-    height: 100%;
-  }
-
-  .deps-header {
-    display: flex;
-    gap: 16px;
-    font-size: 13px;
-    font-weight: 600;
-    color: var(--fg-dim);
-    font-family: var(--mono);
-  }
-
-  .stat.danger {
-    color: var(--danger);
-  }
-
-  .deps-content {
-    display: flex;
-    gap: 12px;
-    flex: 1;
-    min-height: 0;
-  }
-
-  .graph {
-    flex: 1;
-    min-height: 600px;
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-  }
-
-  .node-details {
-    width: 280px;
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0;
-    overflow-y: auto;
-  }
-
-  .details-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 12px;
-    border-bottom: 1px solid var(--border);
-    font-weight: 600;
-  }
-
+  .deps-pad { padding: 22px; height: 100%; min-height: 0; display: flex; flex-direction: column; }
+  .deps-pad .deps-wrap { flex: 1; min-height: 0; }
   .close-btn {
-    background: none;
-    border: none;
-    font-size: 24px;
-    line-height: 1;
-    cursor: pointer;
-    color: var(--fg-dim);
-    padding: 0;
-    width: 24px;
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: center;
+    background: none; border: none; font-size: 22px; line-height: 1; cursor: pointer;
+    color: var(--fg-faint); width: 28px; height: 28px; display: grid; place-items: center; border-radius: var(--radius-sm);
   }
-
-  .close-btn:hover {
-    color: var(--fg);
-  }
-
-  dl {
-    padding: 12px;
-    margin: 0;
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 8px 12px;
-    font-size: 13px;
-  }
-
-  dt {
-    font-weight: 600;
-    color: var(--fg-dim);
-  }
-
-  dd {
-    margin: 0;
-  }
-
-  .badge {
-    display: inline-block;
-    padding: 2px 8px;
-    border-radius: 4px;
-    font-size: 11px;
-    font-weight: 600;
-    color: var(--bg);
-    font-family: var(--mono);
-    text-transform: uppercase;
-  }
-
-  .epic {
-    font-family: var(--mono);
-    font-size: 12px;
-  }
-
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    overflow: hidden;
-    clip: rect(0 0 0 0);
-  }
+  .close-btn:hover { color: var(--fg); background: var(--bg-elev-2); }
+  .node-details dl { margin-top: 4px; }
+  .node-details dd { margin: 0; }
 </style>

--- a/cli/kanban/client/src/views/DocsView.svelte
+++ b/cli/kanban/client/src/views/DocsView.svelte
@@ -1,6 +1,7 @@
 <script>
   import { marked } from 'marked';
   import DOMPurify from 'dompurify';
+  import Icon from '../components/Icon.svelte';
 
   let docs = $state([]);
   let selectedDoc = $state(null);
@@ -13,20 +14,16 @@
   const tree = $derived.by(() => {
     const root = [];
     const groups = {};
-
     for (const doc of docs) {
       const parts = doc.rel.split('/');
       if (parts.length === 1) {
         root.push(doc);
       } else {
         const topLevel = parts[0];
-        if (!groups[topLevel]) {
-          groups[topLevel] = { name: topLevel, children: [] };
-        }
+        if (!groups[topLevel]) groups[topLevel] = { name: topLevel, children: [] };
         groups[topLevel].children.push(doc);
       }
     }
-
     return { root, groups: Object.values(groups) };
   });
 
@@ -62,28 +59,27 @@
   const renderedContent = $derived.by(() => {
     if (!docContent) return '';
     try {
-      const html = marked.parse(docContent);
-      return DOMPurify.sanitize(html);
+      return DOMPurify.sanitize(marked.parse(docContent));
     } catch {
       return '<p>Error rendering markdown</p>';
     }
   });
 
+  let copied = $state(false);
   function copyContent() {
     if (docContent && navigator.clipboard) {
       navigator.clipboard.writeText(docContent).then(() => {
-        // Success - could show a toast but we don't have access to store here
+        copied = true;
+        setTimeout(() => (copied = false), 1500);
       });
     }
   }
 
-  $effect(() => {
-    loadDocs();
-  });
+  $effect(() => { loadDocs(); });
 
+  // Réécrit les liens US-xxx vers le board (navigation interne).
   $effect(() => {
     if (!contentContainer || !renderedContent) return;
-
     const links = contentContainer.querySelectorAll('a');
     for (const link of links) {
       const text = link.textContent?.trim() || '';
@@ -99,76 +95,35 @@
   });
 
   let expandedGroups = $state(new Set());
-
   function toggleGroup(groupName) {
-    if (expandedGroups.has(groupName)) {
-      expandedGroups.delete(groupName);
-    } else {
-      expandedGroups.add(groupName);
-    }
+    if (expandedGroups.has(groupName)) expandedGroups.delete(groupName);
+    else expandedGroups.add(groupName);
     expandedGroups = new Set(expandedGroups);
   }
 </script>
 
-<div class="docs-container">
-  <aside class="docs-sidebar">
-    {#if loading}
-      <div class="sidebar-loading">Loading...</div>
-    {:else if error}
-      <div class="sidebar-error">Error: {error}</div>
-    {:else}
-      <nav class="docs-tree" aria-label="Document navigation">
+<div class="docs-pad">
+  <div class="docs-layout">
+    <aside class="docs-tree" aria-label="Navigation des documents">
+      {#if loading}
+        <div class="empty" style="padding:20px 8px">Chargement…</div>
+      {:else if error}
+        <div class="empty" style="padding:20px 8px; color: var(--danger)">Erreur : {error}</div>
+      {:else}
         {#each tree.root as doc}
-          <button
-            class="tree-item"
-            class:active={selectedDoc?.rel === doc.rel}
-            onclick={() => selectDoc(doc)}
-            tabindex="0"
-            onkeydown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                e.preventDefault();
-                selectDoc(doc);
-              }
-            }}
-          >
-            {doc.rel}
+          <button class="tree-item" class:active={selectedDoc?.rel === doc.rel} onclick={() => selectDoc(doc)}>
+            <Icon name="file" cls="ico" size={15} />{doc.rel}
           </button>
         {/each}
-
         {#each tree.groups as group}
           <div class="tree-group">
-            <button
-              class="group-header"
-              onclick={() => toggleGroup(group.name)}
-              aria-expanded={expandedGroups.has(group.name)}
-              tabindex="0"
-              onkeydown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  toggleGroup(group.name);
-                }
-              }}
-            >
-              <span class="group-icon">
-                {expandedGroups.has(group.name) ? '▼' : '▶'}
-              </span>
-              {group.name}/
+            <button class="tree-item group-header" onclick={() => toggleGroup(group.name)} aria-expanded={expandedGroups.has(group.name)}>
+              <span class="group-icon">{expandedGroups.has(group.name) ? '▼' : '▶'}</span>{group.name}/
             </button>
             {#if expandedGroups.has(group.name)}
               <div class="group-children">
                 {#each group.children as doc}
-                  <button
-                    class="tree-item nested"
-                    class:active={selectedDoc?.rel === doc.rel}
-                    onclick={() => selectDoc(doc)}
-                    tabindex="0"
-                    onkeydown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault();
-                        selectDoc(doc);
-                      }
-                    }}
-                  >
+                  <button class="tree-item nested" class:active={selectedDoc?.rel === doc.rel} onclick={() => selectDoc(doc)}>
                     {doc.rel.split('/').slice(1).join('/')}
                   </button>
                 {/each}
@@ -176,283 +131,33 @@
             {/if}
           </div>
         {/each}
-      </nav>
-    {/if}
-  </aside>
-
-  <!-- div+role=region remplace <main> imbriqué (interdit par HTML : un seul <main> visible, WCAG SC 1.3.6) -->
-  <div class="docs-content" role="region" aria-label="Contenu du document">
-    {#if !selectedDoc}
-      <div class="empty">Select a document</div>
-    {:else}
-      <header class="content-header">
-        <h1>{selectedDoc.rel}</h1>
-        <button class="copy-btn" onclick={copyContent} aria-label="Copier le contenu">
-          Copy
-        </button>
-      </header>
-
-      {#if loadingContent}
-        <div class="content-loading">Loading document...</div>
-      {:else}
-        <div class="markdown-body" bind:this={contentContainer}>
-          {@html renderedContent}
-        </div>
       {/if}
-    {/if}
+    </aside>
+
+    <div class="doc-view" role="region" aria-label="Contenu du document">
+      {#if !selectedDoc}
+        <div class="empty">Sélectionnez un document</div>
+      {:else}
+        <div class="doc-toolbar">
+          <span class="doc-path mono">{selectedDoc.rel}</span>
+          <button class="btn btn-ghost" onclick={copyContent} aria-label="Copier le contenu">
+            <Icon name="copy" size={15} />{copied ? 'Copié !' : 'Copier'}
+          </button>
+        </div>
+        {#if loadingContent}
+          <div class="empty">Chargement du document…</div>
+        {:else}
+          <div class="doc-paper" bind:this={contentContainer}>{@html renderedContent}</div>
+        {/if}
+      {/if}
+    </div>
   </div>
 </div>
 
 <style>
-  .docs-container {
-    display: flex;
-    gap: 0;
-    height: 100%;
-    overflow: hidden;
-  }
-
-  .docs-sidebar {
-    width: 220px;
-    background: var(--bg-sidebar);
-    border-right: 1px solid var(--border);
-    overflow-y: auto;
-    padding: 12px 8px;
-  }
-
-  .sidebar-loading,
-  .sidebar-error {
-    padding: 12px;
-    text-align: center;
-    font-size: 12px;
-    color: var(--fg-dim);
-  }
-
-  .sidebar-error {
-    color: var(--danger);
-  }
-
-  .docs-tree {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .tree-item,
-  .group-header {
-    background: none;
-    border: none;
-    padding: 6px 10px;
-    text-align: left;
-    cursor: pointer;
-    border-radius: var(--radius);
-    font-size: 13px;
-    width: 100%;
-    transition: background 0.1s;
-  }
-
-  .tree-item {
-    color: var(--fg);
-  }
-
-  .tree-item:hover,
-  .group-header:hover {
-    background: var(--border);
-  }
-
-  .tree-item.active {
-    background: var(--accent);
-    color: var(--accent-fg);
-    font-weight: 600;
-  }
-
-  .tree-item:focus,
-  .group-header:focus {
-    outline: 2px solid var(--accent);
-    outline-offset: -2px;
-  }
-
-  .tree-item.nested {
-    padding-left: 24px;
-    font-size: 12px;
-  }
-
-  .group-header {
-    display: flex;
-    align-items: center;
-    gap: 4px;
-    font-weight: 600;
-    color: var(--fg-dim);
-  }
-
-  .group-icon {
-    font-size: 10px;
-    width: 12px;
-    display: inline-block;
-  }
-
-  .group-children {
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
-  }
-
-  .docs-content {
-    flex: 1;
-    overflow-y: auto;
-    padding: 20px;
-    background: var(--bg);
-  }
-
-  .content-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: 20px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .content-header h1 {
-    font-size: 20px;
-    font-weight: 600;
-    margin: 0;
-    color: var(--fg);
-  }
-
-  .copy-btn {
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    padding: 6px 12px;
-    border-radius: var(--radius);
-    cursor: pointer;
-    font-size: 12px;
-    font-weight: 600;
-    color: var(--fg);
-    transition: background 0.1s;
-  }
-
-  .copy-btn:hover {
-    background: var(--border);
-  }
-
-  /* Indicateur de focus visible explicite (WCAG 2.2 SC 2.4.11) */
-  .copy-btn:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-
-  .copy-btn:active {
-    transform: translateY(1px);
-  }
-
-  .content-loading {
-    text-align: center;
-    padding: 40px;
-    color: var(--fg-dim);
-  }
-
-  .markdown-body {
-    line-height: 1.7;
-  }
-
-  .markdown-body :global(h1) {
-    font-size: 28px;
-    font-weight: 700;
-    margin: 24px 0 16px;
-    color: var(--fg);
-    border-bottom: 1px solid var(--border);
-    padding-bottom: 8px;
-  }
-
-  .markdown-body :global(h2) {
-    font-size: 22px;
-    font-weight: 600;
-    margin: 20px 0 12px;
-    color: var(--fg);
-  }
-
-  .markdown-body :global(h3) {
-    font-size: 18px;
-    font-weight: 600;
-    margin: 16px 0 10px;
-    color: var(--fg);
-  }
-
-  .markdown-body :global(p) {
-    margin: 0 0 12px;
-    color: var(--fg);
-  }
-
-  .markdown-body :global(code) {
-    background: var(--bg-sidebar);
-    padding: 2px 4px;
-    border-radius: 3px;
-    font-family: var(--mono);
-    font-size: 0.9em;
-  }
-
-  .markdown-body :global(pre) {
-    background: var(--bg-sidebar);
-    padding: 12px;
-    border-radius: var(--radius);
-    overflow-x: auto;
-    margin: 0 0 12px;
-    border: 1px solid var(--border);
-  }
-
-  .markdown-body :global(pre code) {
-    background: none;
-    padding: 0;
-  }
-
-  .markdown-body :global(a) {
-    color: var(--accent);
-    text-decoration: underline;
-  }
-
-  .markdown-body :global(a:hover) {
-    opacity: 0.8;
-  }
-
-  .markdown-body :global(ul),
-  .markdown-body :global(ol) {
-    margin: 0 0 12px;
-    padding-left: 24px;
-  }
-
-  .markdown-body :global(li) {
-    margin: 4px 0;
-  }
-
-  .markdown-body :global(table) {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 0 0 12px;
-  }
-
-  .markdown-body :global(th),
-  .markdown-body :global(td) {
-    border: 1px solid var(--border);
-    padding: 8px 12px;
-    text-align: left;
-  }
-
-  .markdown-body :global(th) {
-    background: var(--bg-sidebar);
-    font-weight: 600;
-  }
-
-  .markdown-body :global(blockquote) {
-    border-left: 3px solid var(--accent);
-    padding-left: 12px;
-    margin: 0 0 12px;
-    color: var(--fg-dim);
-    font-style: italic;
-  }
-
-  .markdown-body :global(hr) {
-    border: none;
-    border-top: 1px solid var(--border);
-    margin: 20px 0;
-  }
+  .docs-pad { padding: 22px; height: 100%; min-height: 0; display: flex; flex-direction: column; }
+  .docs-pad .docs-layout { flex: 1; min-height: 0; }
+  .group-icon { font-size: 9px; width: 12px; display: inline-block; }
+  .doc-toolbar { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 18px; }
+  .doc-toolbar .doc-path { font-size: 12px; color: var(--fg-faint); }
 </style>

--- a/cli/kanban/client/src/views/KanbanView.svelte
+++ b/cli/kanban/client/src/views/KanbanView.svelte
@@ -2,7 +2,15 @@
   import { store, patchStatus, toast } from '../lib/store.svelte.js';
   import { onMount, tick } from 'svelte';
   import PromptDialog from '../components/PromptDialog.svelte';
+  import Icon from '../components/Icon.svelte';
+  import Avatar from '../components/Avatar.svelte';
+  import PriorityChip from '../components/PriorityChip.svelte';
+  import TddPip from '../components/TddPip.svelte';
+  import Points from '../components/Points.svelte';
+  import TaskProgress from '../components/TaskProgress.svelte';
   import { locateCard, reduceKey, buildCardDetails } from '../lib/kanban-nav.js';
+  import { STATUS, PRIORITY, TDD, TASK_TYPE, codeColor, epicHue } from '../lib/config.js';
+  import { tweaks } from '../lib/tweaks.svelte.js';
 
   let promptDialog = $state(null);
   /** Référence au <dialog> natif du menu de déplacement */
@@ -36,25 +44,40 @@
   let showMoveMenu = $state(false);
   let liveRegion = $state('');
 
+  // Board UI state
+  let dragId = $state(null);
+  let dragOverCol = $state(null);
+  /** Filtre de priorité (vide = tout afficher). */
+  let priFilter = $state([]);
+
+  function togglePri(p) {
+    priFilter = priFilter.includes(p) ? priFilter.filter((x) => x !== p) : [...priFilter, p];
+  }
+  const visible = (s) => priFilter.length === 0 || priFilter.includes(s.priority);
+
   const storiesByStatus = $derived.by(() => {
     const map = Object.fromEntries(COLUMNS.map((c) => [c.key, []]));
-    for (const s of store.stories) (map[s.status] ??= []).push(s);
+    for (const s of store.stories) {
+      if (!visible(s)) continue;
+      (map[s.status] ??= []).push(s);
+    }
     return map;
   });
 
-  function tddBadge(phase) {
-    if (phase === 'red') return { char: '●', color: 'var(--danger)', label: 'red' };
-    if (phase === 'green') return { char: '●', color: 'var(--ok)', label: 'green' };
-    if (phase === 'refactor') return { char: '●', color: 'var(--info)', label: 'refactor' };
-    if (phase === 'done') return { char: '✓', color: 'var(--ok)', label: 'done' };
-    return null;
-  }
+  const colPoints = (key) => storiesByStatus[key].reduce((a, s) => a + (s.story_points || 0), 0);
 
-  function priorityColor(p) {
-    return p === 'must' ? 'var(--danger)' : p === 'should' ? 'var(--warn)' : p === 'could' ? 'var(--info)' : 'var(--fg-dim)';
-  }
-
-  let dragId = $state(null);
+  /** Légende du code couleur selon le schéma actif. */
+  const schemeLegend = $derived.by(() => {
+    const sc = tweaks.codingScheme;
+    if (sc === 'priority') return Object.values(PRIORITY).map((v) => [v.label, `var(${v.cssVar})`]);
+    if (sc === 'tdd') return [['Red', 'var(--tdd-red)'], ['Green', 'var(--tdd-green)'], ['Refactor', 'var(--tdd-refactor)']];
+    if (sc === 'epic') {
+      const seen = new Map();
+      for (const s of store.stories) if (s.epic_id && !seen.has(s.epic_id)) seen.set(s.epic_id, epicHue(s.epic_id));
+      return [...seen.entries()];
+    }
+    return COLUMNS.map((c) => [c.label, `var(${STATUS[c.key].cssVar})`]);
+  });
 
   function onDragStart(e, id) {
     dragId = id;
@@ -66,6 +89,7 @@
 
   async function onDrop(e, targetStatus) {
     e.preventDefault();
+    dragOverCol = null;
     const id = e.dataTransfer.getData('text/plain') || dragId;
     dragId = null;
     if (!id) return;
@@ -100,7 +124,7 @@
       const { state, action } = reduceKey(
         { focusedColumnIndex, focusedCardIndex, showMoveMenu },
         { key: e.key, altKey: e.altKey },
-        ctx
+        ctx,
       );
 
       // Empêche le scroll/typeahead du navigateur uniquement pour les touches gérées.
@@ -183,15 +207,15 @@
   }
 
   function announceMove(cardId, targetStatus) {
-    const targetCol = COLUMNS.find(c => c.key === targetStatus);
+    const targetCol = COLUMNS.find((c) => c.key === targetStatus);
     liveRegion = `Card ${cardId} moved to ${targetCol?.label || targetStatus}`;
-    setTimeout(() => liveRegion = '', 2000);
+    setTimeout(() => (liveRegion = ''), 2000);
   }
 
   /** Story issue de .bmad/sprint-status.yaml : statut non modifiable depuis le board. */
   function announceReadOnly(cardId) {
     liveRegion = `Card ${cardId} is read-only (managed by .bmad/sprint-status.yaml — use team:/qa: commands)`;
-    setTimeout(() => liveRegion = '', 3000);
+    setTimeout(() => (liveRegion = ''), 3000);
     // Feedback VISIBLE pour les utilisateurs voyants (au-delà de l'annonce sr-only).
     toast({
       kind: 'info',
@@ -202,15 +226,13 @@
 
   function announceCardDetails(card) {
     liveRegion = `Card ${card.id}: ${card.title}. Status: ${card.status}. Priority: ${card.priority}. ${card.story_points} story points.`;
-    setTimeout(() => liveRegion = '', 3000);
+    setTimeout(() => (liveRegion = ''), 3000);
   }
 
   /** Ouvre le menu de déplacement via l'élément <dialog> natif. */
   async function openMoveMenu() {
-    // Mémorise l'élément déclencheur pour y retourner le focus à la fermeture
     moveMenuTriggerEl = document.activeElement;
     showMoveMenu = true;
-    // Attend que Svelte ait rendu le dialog (bind:this résolu) avant showModal()
     await tick();
     moveMenuDialog?.showModal();
   }
@@ -219,7 +241,6 @@
   function closeMoveMenu() {
     showMoveMenu = false;
     moveMenuDialog?.close();
-    // Retour de focus à la carte ayant déclenché l'ouverture (WCAG SC 2.4.3)
     if (moveMenuTriggerEl) {
       moveMenuTriggerEl.focus();
       moveMenuTriggerEl = null;
@@ -228,6 +249,8 @@
 
   /** Détails normalisés de la carte affichée (null si modale fermée). */
   const detailFields = $derived(detailCard ? buildCardDetails(detailCard) : null);
+  const detailEstTotal = $derived(detailTasks.reduce((a, t) => a + (t.estimation_hours || 0), 0));
+  const detailActTotal = $derived(detailTasks.reduce((a, t) => a + (t.actual_hours || 0), 0));
 
   /** Ouvre la modale de détail (clic ou Entrée). */
   async function openDetail(card) {
@@ -235,7 +258,7 @@
     detailCard = card;
     detailTasks = [];
     detailBody = '';
-    announceCardDetails(card); // annonce sr-only en plus du visuel
+    announceCardDetails(card);
     await tick();
     detailDialog?.showModal();
     loadDetailExtras(card.id);
@@ -251,7 +274,6 @@
       const res = await fetch(`/api/stories/${encodeURIComponent(id)}`);
       if (!res.ok) return;
       const data = await res.json();
-      // La story affichée peut avoir changé entre-temps : on ignore une réponse périmée.
       if (detailCard?.id !== id) return;
       detailTasks = data.tasks ?? [];
       if (data.body) {
@@ -279,23 +301,45 @@
   }
 </script>
 
+<div class="board-toolbar">
+  <div class="filters">
+    {#each Object.entries(PRIORITY) as [key, v]}
+      <button class="filter-chip" aria-pressed={priFilter.includes(key)} onclick={() => togglePri(key)}>
+        <i class="dot" style="background: var({v.cssVar})"></i>{v.label}
+      </button>
+    {/each}
+    {#if priFilter.length > 0}
+      <button class="filter-chip" style="border:none" onclick={() => (priFilter = [])}>Clear</button>
+    {/if}
+  </div>
+  <span class="topbar-spacer"></span>
+  <div class="coding-legend" aria-label={`Cartes colorées par ${tweaks.codingScheme}`}>
+    <span class="lbl">Codé par {tweaks.codingScheme} :</span>
+    {#each schemeLegend as [label, color]}
+      <span class="key"><i style="background: {color}"></i>{label}</span>
+    {/each}
+  </div>
+</div>
+
 <div class="board">
   {#each COLUMNS as col}
+    {@const cv = `var(${STATUS[col.key].cssVar})`}
     <section
       class="column"
+      class:drop-target={dragOverCol === col.key}
       aria-labelledby="col-{col.key}"
-      ondragover={onDragOver}
+      ondragover={(e) => { onDragOver(e); if (dragId) dragOverCol = col.key; }}
+      ondragleave={(e) => { if (!e.currentTarget.contains(e.relatedTarget)) dragOverCol = null; }}
       ondrop={(e) => onDrop(e, col.key)}
     >
-      <header class="column-header">
-        <!-- h2 pour une navigation par titres (touche H dans NVDA/JAWS) -->
-        <h2 class="column-label" id="col-{col.key}">{col.label}</h2>
-        <span class="count" aria-label="{storiesByStatus[col.key].length} cartes">{storiesByStatus[col.key].length}</span>
+      <header class="col-head">
+        <i class="col-dot" style="background: {cv}; color: {cv}"></i>
+        <h2 class="col-title" id="col-{col.key}">{col.label}</h2>
+        <span class="col-count mono" aria-label="{storiesByStatus[col.key].length} cartes">{storiesByStatus[col.key].length}</span>
+        <span class="col-pts mono" title="story points dans la colonne">{colPoints(col.key)} pts</span>
       </header>
-      <!-- ul/li remplace article role=button (conflit sémantique) -->
-      <ul class="column-body" role="list">
+      <ul class="col-body" role="list">
         {#each storiesByStatus[col.key] as s (s.id)}
-          {@const tdd = tddBadge(s.tdd_phase)}
           <!-- Enter (détails) est géré par le handler clavier global du board ; onclick couvre la souris. -->
           <!-- svelte-ignore a11y_click_events_have_key_events -->
           <!-- svelte-ignore a11y_no_noninteractive_element_interactions -->
@@ -303,6 +347,8 @@
           <li
             class="card"
             class:read-only={s._writable === false}
+            class:dragging={dragId === s.id}
+            style="--code-color: {codeColor(s, tweaks.codingScheme)}"
             draggable={s._writable !== false}
             ondragstart={(e) => onDragStart(e, s.id)}
             onfocus={() => syncFocus(s.id)}
@@ -314,49 +360,30 @@
             aria-describedby="keyboard-help"
           >
             <div class="card-top">
-              <span class="id">{s.id}</span>
+              {#if s.epic_id}<i class="card-epic-dot" style="background: {epicHue(s.epic_id)}" title={s.epic_id}></i>{/if}
+              <span class="card-id mono">{s.id}</span>
               {#if s._writable === false}
-                <span class="readonly" aria-label="Lecture seule — gérée par .bmad/sprint-status.yaml" role="img">🔒</span>
+                <span class="card-lock" aria-label="Lecture seule — gérée par .bmad/sprint-status.yaml" role="img">🔒</span>
               {/if}
-              <span class="priority" style="color: {priorityColor(s.priority)}">{s.priority}</span>
-              <span class="points">{s.story_points}p</span>
-              {#if tdd}
-                <!-- aria-label remplace title (title non annoncé par NVDA/VoiceOver) -->
-                <span class="tdd" style="color: {tdd.color}" aria-label="TDD phase : {tdd.label}" role="img">{tdd.char}</span>
-              {/if}
+              <span class="spacer"></span>
+              <TddPip phase={s.tdd_phase} />
+              <PriorityChip priority={s.priority} />
             </div>
-            <div class="title">{s.title}</div>
-            <div class="meta">
-              {#if s.epic_id}<span class="epic">{s.epic_id}</span>{/if}
-              {#if s.persona}<span class="persona">{s.persona}</span>{/if}
-            </div>
-            {#if s.tasks?.total > 0}
-              <!-- role=progressbar + aria-valuenow/min/max (WCAG SC 4.1.2) -->
-              <div
-                class="progress"
-                role="progressbar"
-                aria-label="Tâches : {s.tasks.completed} sur {s.tasks.total} complétées"
-                aria-valuenow={s.tasks.completed}
-                aria-valuemin={0}
-                aria-valuemax={s.tasks.total}
-              >
-                <div class="bar" style="width: {(s.tasks.completed / s.tasks.total) * 100}%"></div>
-                <span class="progress-label" aria-hidden="true">{s.tasks.completed}/{s.tasks.total}</span>
-              </div>
-            {/if}
-            <footer class="card-foot">
-              {#if s.assigned_to}
-                <!-- aria-label expose le nom complet (WCAG SC 1.3.1, SC 4.1.2) -->
-                <span class="assignee" aria-label="Assigné à : {s.assigned_to}">{s.assigned_to.slice(0, 2).toUpperCase()}</span>
-              {/if}
+            <h3 class="card-title">{s.title}</h3>
+            <div class="card-meta">
+              <Points value={s.story_points} />
+              {#if s.persona}<span class="persona"><Icon name="person" cls="ico" size={13} />{s.persona}</span>{/if}
+              <span class="spacer"></span>
               {#if s.status === 'blocked' && s.blocked_reason}
-                <span class="blocked" aria-label="Bloqué : {s.blocked_reason}">⚠ blocked</span>
+                <span class="card-blocked" title={s.blocked_reason}>⚠ blocked</span>
               {/if}
-            </footer>
+              <TaskProgress tasks={s.tasks} />
+              <Avatar id={s.assigned_to} size={24} />
+            </div>
           </li>
         {:else}
           {#if col.emptyHint}
-            <li class="empty-hint" aria-label="Colonne vide" role="listitem">{col.emptyHint}</li>
+            <li class="col-empty" role="listitem">{col.emptyHint}</li>
           {/if}
         {/each}
       </ul>
@@ -366,36 +393,23 @@
 
 <PromptDialog bind:this={promptDialog} />
 
-<!-- Aide clavier : sr-only pour les lecteurs d'écran, accessible au clavier -->
+<!-- Aide clavier : sr-only pour les lecteurs d'écran -->
 <div id="keyboard-help" class="sr-only">
   Flèches pour naviguer. Alt+M pour ouvrir le menu de déplacement. Chiffres 1 à 6 pour déplacer dans une colonne. Échap pour fermer. Entrée pour les détails.
 </div>
 
 <!-- Région live pour les annonces d'accessibilité -->
-<div aria-live="polite" aria-atomic="true" class="sr-only">
-  {liveRegion}
-</div>
+<div aria-live="polite" aria-atomic="true" class="sr-only">{liveRegion}</div>
 
 <!-- Aide clavier visible pour les utilisateurs voyants au clavier (WCAG SC 3.3.2) -->
 <details class="keyboard-help-visible">
   <summary aria-label="Raccourcis clavier du tableau Kanban">⌨ Raccourcis</summary>
   <div class="keyboard-help-content">
-    <kbd>↑↓</kbd> Naviguer les cartes &ensp;
-    <kbd>←→</kbd> Changer de colonne &ensp;
-    <kbd>Alt+M</kbd> Menu déplacement &ensp;
-    <kbd>1–6</kbd> Déplacer vers colonne &ensp;
-    <kbd>Échap</kbd> Fermer &ensp;
-    <kbd>Entrée</kbd> Détails
+    <kbd>↑↓</kbd> Naviguer &ensp;<kbd>←→</kbd> Colonne &ensp;<kbd>Alt+M</kbd> Déplacer &ensp;<kbd>1–6</kbd> Vers colonne &ensp;<kbd>Échap</kbd> Fermer &ensp;<kbd>Entrée</kbd> Détails
   </div>
 </details>
 
-<!--
-  Menu de déplacement : élément <dialog> natif pour :
-  - Piège de focus automatique (Tab/Shift+Tab confinés au dialog)
-  - aria-modal géré nativement par le navigateur
-  - Retour de focus géré dans closeMoveMenu()
-  (WCAG SC 1.3.2, 2.1.2, 4.1.2)
--->
+<!-- Menu de déplacement : <dialog> natif (piège de focus + aria-modal natifs) -->
 {#if showMoveMenu}
   <dialog
     bind:this={moveMenuDialog}
@@ -420,481 +434,109 @@
   </dialog>
 {/if}
 
-<!--
-  Modale de détail de carte : <dialog> natif (piège de focus + aria-modal natifs).
-  Ouverte au clic ou via Entrée (WCAG SC 1.3.2, 2.1.2, 2.4.3).
--->
+<!-- Modale de détail : <dialog> natif, style design (dialog.modal) -->
 {#if detailFields}
   <dialog
     bind:this={detailDialog}
-    class="detail-dialog"
+    class="modal"
     aria-labelledby="detail-title"
     onclose={() => { if (detailCard) closeDetail(); }}
+    onclick={(e) => { if (e.target === detailDialog) closeDetail(); }}
   >
-    <div class="detail-content">
-      <header class="detail-header">
-        <span class="detail-id">{detailFields.id}</span>
-        {#if detailFields.readOnly}
-          <span class="detail-lock" aria-label="Lecture seule" role="img">🔒</span>
-        {/if}
-        <button class="detail-close" onclick={() => closeDetail()} aria-label="Fermer">✕</button>
+    <div class="modal-inner">
+      <header class="modal-head">
+        <div class="row1">
+          <span class="m-id mono">{detailFields.id}</span>
+          {#if detailFields.epicId}
+            <span style="color: var(--fg-faint)">·</span>
+            <span style="display:inline-flex; align-items:center; gap:7px; font-size:12.5px; color: var(--fg-dim)">
+              <i style="width:8px; height:8px; border-radius:50%; background: {epicHue(detailFields.epicId)}; display:inline-block"></i>
+              {detailFields.epicId}
+            </span>
+          {/if}
+          {#if detailFields.readOnly}
+            <span class="ro-lock" style="margin-left:8px"><Icon name="lock" size={13} /> read-only</span>
+          {/if}
+          <button class="icon-btn m-close" onclick={() => closeDetail()} aria-label="Fermer"><Icon name="close" size={18} /></button>
+        </div>
+        <h2 class="modal-title" id="detail-title">{detailFields.title}</h2>
+        <div class="modal-frontmatter">
+          <span class="chip chip-soft"><i class="swatch" style="background: var({STATUS[detailFields.status]?.cssVar || '--border'})"></i>{STATUS[detailFields.status]?.label || detailFields.status}</span>
+          <PriorityChip priority={detailFields.priority} />
+          <TddPip phase={detailFields.tddPhase} />
+        </div>
       </header>
-      <h3 id="detail-title">{detailFields.title}</h3>
 
-      <dl class="detail-grid">
-        <dt>Statut</dt><dd>{detailFields.status}</dd>
-        <dt>Priorité</dt><dd>{detailFields.priority || '—'}</dd>
-        <dt>Points</dt><dd>{detailFields.storyPoints}</dd>
-        {#if detailFields.epicId}<dt>Epic</dt><dd>{detailFields.epicId}</dd>{/if}
-        {#if detailFields.persona}<dt>Persona</dt><dd>{detailFields.persona}</dd>{/if}
-        {#if detailFields.assignedTo}<dt>Assigné à</dt><dd>{detailFields.assignedTo}</dd>{/if}
-        {#if detailFields.tddPhase}<dt>TDD</dt><dd>{detailFields.tddPhase}</dd>{/if}
-        {#if detailFields.tasks.total > 0}
-          <dt>Tâches</dt><dd>{detailFields.tasks.completed}/{detailFields.tasks.total}</dd>
+      <div class="modal-body">
+        <div class="fm-grid">
+          <div class="fm-cell"><div class="k">Points</div><div class="v"><span class="points mono">{detailFields.storyPoints}</span></div></div>
+          <div class="fm-cell"><div class="k">Assigné</div><div class="v">{#if detailFields.assignedTo}<Avatar id={detailFields.assignedTo} size={22} />{detailFields.assignedTo}{:else}<span style="color: var(--fg-faint)">—</span>{/if}</div></div>
+          <div class="fm-cell"><div class="k">Persona</div><div class="v">{detailFields.persona || '—'}</div></div>
+          <div class="fm-cell"><div class="k">Phase TDD</div><div class="v"><TddPip phase={detailFields.tddPhase} />{#if !detailFields.tddPhase || !TDD[detailFields.tddPhase]}<span style="color: var(--fg-faint)">—</span>{/if}</div></div>
+          <div class="fm-cell"><div class="k">Tâches</div><div class="v mono">{detailFields.tasks.completed}/{detailFields.tasks.total}</div></div>
+          {#if detailEstTotal > 0}
+            <div class="fm-cell"><div class="k">Heures est / réel</div><div class="v mono">{detailEstTotal} / <span class={detailActTotal > detailEstTotal ? 't-over' : ''}>{detailActTotal}</span></div></div>
+          {/if}
+        </div>
+
+        {#if detailFields.blockedReason}
+          <div class="modal-readonly-note" style="border-color: var(--danger); color: var(--danger)">⚠ Bloqué : {detailFields.blockedReason}</div>
         {/if}
-        {#if detailFields.blockedReason}<dt>Bloqué</dt><dd>{detailFields.blockedReason}</dd>{/if}
-      </dl>
 
-      {#if detailTasks.length > 0}
-        <h4 class="detail-subtitle">Tâches ({detailFields.tasks.completed}/{detailFields.tasks.total})</h4>
-        <table class="detail-tasks">
-          <thead>
-            <tr><th>ID</th><th>Type</th><th>Statut</th><th>Est.</th><th>Réel</th><th>Assigné</th></tr>
-          </thead>
-          <tbody>
-            {#each detailTasks as t}
-              <tr>
-                <td>{t.id}</td>
-                <td>{t.type}</td>
-                <td>{t.status}</td>
-                <td>{t.estimation_hours ?? '—'}</td>
-                <td>{t.actual_hours ?? '—'}</td>
-                <td>{t.assigned_to || '—'}</td>
-              </tr>
-            {/each}
-          </tbody>
-        </table>
-      {:else if detailLoading}
-        <p class="detail-muted">Chargement des tâches…</p>
-      {/if}
+        {#if detailTasks.length > 0}
+          <div class="section-h"><h3>Tâches</h3><span class="n mono">{detailFields.tasks.completed}/{detailFields.tasks.total}</span><span class="line"></span></div>
+          <table class="tasks">
+            <thead><tr><th style="width:54px">Type</th><th>Tâche</th><th>Statut</th><th style="text-align:right">Est</th><th style="text-align:right">Réel</th></tr></thead>
+            <tbody>
+              {#each detailTasks as t}
+                <tr>
+                  <td><span class="t-type" style="background: color-mix(in oklch, {TASK_TYPE[t.type] || 'var(--fg-faint)'} 16%, transparent); color: {TASK_TYPE[t.type] || 'var(--fg-dim)'}">{t.type}</span></td>
+                  <td class="t-name">{t.id}</td>
+                  <td>{t.status}</td>
+                  <td class="t-hrs">{t.estimation_hours ?? '—'}</td>
+                  <td class="t-hrs {(t.actual_hours || 0) > (t.estimation_hours || 0) ? 't-over' : ''}">{t.actual_hours ?? '—'}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {:else if detailLoading}
+          <p style="color: var(--fg-faint); font-size:12px; margin-top:12px">Chargement des tâches…</p>
+        {/if}
 
-      {#if detailBody}
-        <h4 class="detail-subtitle">Description</h4>
-        <div class="detail-body markdown-body">{@html detailBody}</div>
-      {/if}
+        {#if detailBody}
+          <div class="section-h"><h3>Description</h3><span class="line"></span></div>
+          <div class="md-body">{@html detailBody}</div>
+        {/if}
 
-      {#if detailFields.readOnly}
-        <p class="detail-readonly-note">
-          Carte en lecture seule — gérée par <code>.bmad/sprint-status.yaml</code> (BMAD v6 single-writer).
-          Changez son statut via les commandes <code>team:</code> / <code>qa:</code>.
-        </p>
-      {/if}
+        {#if detailFields.readOnly}
+          <p class="modal-readonly-note">
+            Carte en lecture seule — gérée par <code>.bmad/sprint-status.yaml</code> (BMAD v6 single-writer).
+            Changez son statut via les commandes <code>team:</code> / <code>qa:</code>.
+          </p>
+        {/if}
+      </div>
     </div>
   </dialog>
 {/if}
 
 <style>
-  .board {
-    display: flex;
-    gap: 12px;
-    min-height: 100%;
-    overflow-x: auto;
-  }
-  .column {
-    flex: 0 0 280px;
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    display: flex;
-    flex-direction: column;
-  }
-  .column-header {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 10px 12px;
-    border-bottom: 1px solid var(--border);
-  }
-  /* h2 en colonne : reset pour conserver le style visuel précédent */
-  .column-label {
-    margin: 0;
-    font-weight: 600;
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    color: var(--fg-dim);
-  }
-  .count {
-    background: var(--bg-elev);
-    border-radius: 10px;
-    padding: 2px 8px;
-    font-size: 11px;
-  }
-  /* ul reset (remplace la div column-body) */
-  .column-body {
-    list-style: none;
-    margin: 0;
-    padding: 8px;
-    display: flex;
-    flex-direction: column;
-    gap: 8px;
-    min-height: 120px;
-  }
-  /* li reset — même apparence que l'ancien article */
-  .card {
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 10px;
-    cursor: grab;
-    box-shadow: var(--shadow);
-  }
-  .card:active { cursor: grabbing; }
-  /* Message discret affiché quand la colonne est vide (DX-10) */
-  .empty-hint {
-    padding: 10px 8px;
-    font-size: 11px;
-    color: var(--fg-dim);
-    font-style: italic;
-    text-align: center;
-    list-style: none;
-    opacity: 0.7;
-  }
-  /* Story issue de .bmad/sprint-status.yaml : non déplaçable depuis le board */
-  .card.read-only { cursor: default; opacity: 0.85; }
-  .card.read-only:active { cursor: default; }
-  .card-top .readonly { font-size: 12px; }
-  /* Focus visible explicite (WCAG 2.2 SC 2.4.11) */
-  .card:focus,
-  .card:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-  .card-top {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-    margin-bottom: 4px;
-  }
-  .card-top .id {
-    font-family: var(--mono);
-    font-weight: 600;
-  }
-  .card-top .priority { text-transform: uppercase; font-weight: 600; }
-  .card-top .points {
-    margin-left: auto;
-    font-family: var(--mono);
-    color: var(--fg-dim);
-  }
-  .card-top .tdd { font-size: 14px; }
-  .title { font-weight: 500; margin-bottom: 4px; }
-  .meta {
-    display: flex;
-    gap: 6px;
-    font-size: 11px;
-    color: var(--fg-dim);
-    font-family: var(--mono);
-    margin-bottom: 6px;
-  }
-  .progress {
-    position: relative;
-    background: var(--bg-sidebar);
-    height: 6px;
-    border-radius: 3px;
-    overflow: hidden;
-    margin-bottom: 6px;
-  }
-  .bar { background: var(--accent); height: 100%; }
-  .progress-label {
-    position: absolute;
-    right: 0;
-    top: -14px;
-    font-size: 10px;
-    color: var(--fg-dim);
-  }
-  .card-foot {
-    display: flex;
-    align-items: center;
-    gap: 6px;
-    font-size: 11px;
-  }
-  .assignee {
-    width: 20px;
-    height: 20px;
-    border-radius: 50%;
-    background: var(--accent);
-    color: var(--accent-fg);
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    font-size: 10px;
-    font-weight: 600;
-  }
-  .blocked {
-    color: var(--danger);
-    font-weight: 600;
-    margin-left: auto;
-  }
-
-  /* Accessible uniquement aux lecteurs d'écran */
-  .sr-only {
-    position: absolute;
-    width: 1px;
-    height: 1px;
-    padding: 0;
-    margin: -1px;
-    overflow: hidden;
-    clip: rect(0, 0, 0, 0);
-    white-space: nowrap;
-    border-width: 0;
-  }
-
-  /* Aide clavier visible pour les utilisateurs voyants au clavier (WCAG SC 3.3.2) */
-  .keyboard-help-visible {
-    position: fixed;
-    bottom: 12px;
-    left: 50%;
-    transform: translateX(-50%);
-    z-index: 50;
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    font-size: 11px;
-    color: var(--fg-dim);
-    box-shadow: var(--shadow);
-  }
-  .keyboard-help-visible summary {
-    padding: 4px 10px;
-    cursor: pointer;
-    user-select: none;
-    list-style: none;
-  }
-  .keyboard-help-visible summary:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-  .keyboard-help-content {
-    padding: 6px 10px 8px;
-    white-space: nowrap;
-  }
-  kbd {
-    display: inline-block;
-    padding: 1px 4px;
-    font-size: 10px;
-    font-family: var(--mono);
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: 3px;
-  }
-
-  /* Dialog natif pour le menu de déplacement (piège de focus automatique) */
+  /* Menu de déplacement — spécifique au board (hors design system global) */
   .move-menu-dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0;
-    min-width: 300px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-    color: var(--fg);
+    background: var(--bg-elev); border: 1px solid var(--border-strong);
+    border-radius: var(--radius-lg); padding: 0; min-width: 300px;
+    box-shadow: var(--shadow-lg); color: var(--fg);
   }
-  .move-menu-dialog::backdrop {
-    background: rgba(0, 0, 0, 0.5);
-  }
-
-  .move-menu-content {
-    padding: 20px;
-  }
-
-  .move-menu-content h3 {
-    margin: 0 0 12px;
-    font-size: 16px;
-  }
-
+  .move-menu-dialog::backdrop { background: oklch(0.1 0.01 264 / 0.6); backdrop-filter: blur(3px); }
+  .move-menu-content { padding: 20px; }
+  .move-menu-content h3 { margin: 0 0 12px; font-size: 15px; font-weight: 600; }
   .move-menu-content button {
-    display: block;
-    width: 100%;
-    padding: 10px;
-    margin: 4px 0;
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    color: var(--fg);
-    cursor: pointer;
-    text-align: left;
-    font-size: 14px;
+    display: block; width: 100%; padding: 10px 12px; margin: 4px 0;
+    background: var(--bg-inset); border: 1px solid var(--border-faint);
+    border-radius: var(--radius-sm); color: var(--fg); cursor: pointer;
+    text-align: left; font-size: 13px;
   }
-
   .move-menu-content button:hover,
   .move-menu-content button:focus-visible {
-    background: var(--accent);
-    color: var(--accent-fg);
-    outline: 2px solid var(--accent);
-    outline-offset: 1px;
-  }
-
-  /* Modale de détail de carte */
-  .detail-dialog {
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    padding: 0;
-    min-width: 340px;
-    max-width: 480px;
-    box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
-    color: var(--fg);
-  }
-  .detail-dialog::backdrop {
-    background: rgba(0, 0, 0, 0.5);
-  }
-  .detail-content {
-    padding: 20px;
-  }
-  .detail-header {
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    margin-bottom: 4px;
-  }
-  .detail-id {
-    font-family: var(--mono);
-    font-weight: 600;
-    font-size: 13px;
-    color: var(--accent);
-  }
-  .detail-lock {
-    font-size: 13px;
-  }
-  .detail-close {
-    margin-left: auto;
-    background: transparent;
-    border: none;
-    color: var(--fg-dim);
-    cursor: pointer;
-    font-size: 16px;
-    line-height: 1;
-    padding: 4px;
-    border-radius: 4px;
-  }
-  .detail-close:hover,
-  .detail-close:focus-visible {
-    background: var(--bg-sidebar);
-    outline: 2px solid var(--accent);
-    outline-offset: 1px;
-  }
-  .detail-content h3 {
-    margin: 0 0 14px;
-    font-size: 16px;
-  }
-  .detail-grid {
-    display: grid;
-    grid-template-columns: auto 1fr;
-    gap: 6px 14px;
-    margin: 0;
-    font-size: 13px;
-  }
-  .detail-grid dt {
-    color: var(--fg-dim);
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.04em;
-    align-self: center;
-  }
-  .detail-grid dd {
-    margin: 0;
-  }
-  .detail-readonly-note {
-    margin: 14px 0 0;
-    padding: 10px 12px;
-    background: var(--bg-sidebar);
-    border: 1px solid var(--border);
-    border-radius: var(--radius);
-    font-size: 12px;
-    color: var(--fg-dim);
-    line-height: 1.5;
-  }
-  .detail-readonly-note code {
-    font-family: var(--mono);
-    font-size: 11px;
-  }
-
-  .detail-subtitle {
-    margin: 18px 0 8px;
-    font-size: 13px;
-    font-weight: 700;
-    color: var(--fg-dim);
-    text-transform: uppercase;
-    letter-spacing: 0.03em;
-  }
-
-  .detail-muted {
-    font-size: 12px;
-    color: var(--fg-dim);
-    margin: 8px 0 0;
-  }
-
-  .detail-tasks {
-    border-collapse: collapse;
-    width: 100%;
-    font-size: 12px;
-  }
-  .detail-tasks th,
-  .detail-tasks td {
-    border: 1px solid var(--border);
-    padding: 5px 8px;
-    text-align: left;
-  }
-  .detail-tasks th {
-    background: var(--bg-sidebar);
-    font-weight: 600;
-  }
-
-  .detail-body {
-    font-size: 13px;
-    line-height: 1.6;
-    color: var(--fg);
-  }
-  .detail-body :global(h1),
-  .detail-body :global(h2),
-  .detail-body :global(h3) {
-    font-size: 15px;
-    font-weight: 600;
-    margin: 14px 0 8px;
-  }
-  .detail-body :global(p) {
-    margin: 0 0 10px;
-  }
-  .detail-body :global(ul),
-  .detail-body :global(ol) {
-    margin: 0 0 10px;
-    padding-left: 20px;
-  }
-  .detail-body :global(code) {
-    background: var(--bg-sidebar);
-    padding: 2px 4px;
-    border-radius: 3px;
-    font-family: var(--mono);
-    font-size: 0.9em;
-  }
-  .detail-body :global(pre) {
-    background: var(--bg-sidebar);
-    padding: 10px;
-    border-radius: var(--radius);
-    overflow-x: auto;
-    border: 1px solid var(--border);
-  }
-  .detail-body :global(pre code) {
-    background: none;
-    padding: 0;
-  }
-  .detail-body :global(table) {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 0 0 10px;
-  }
-  .detail-body :global(th),
-  .detail-body :global(td) {
-    border: 1px solid var(--border);
-    padding: 6px 8px;
+    background: var(--accent-soft); border-color: var(--accent-ring);
   }
 </style>

--- a/cli/kanban/client/src/views/SprintsView.svelte
+++ b/cli/kanban/client/src/views/SprintsView.svelte
@@ -3,6 +3,7 @@
   import DOMPurify from 'dompurify';
   import { route, navigate } from '../lib/router.svelte.js';
   import { sortSprints } from '../lib/sprints.js';
+  import { STATUS } from '../lib/config.js';
 
   let sprints = $state([]);
   let loadingList = $state(true);
@@ -13,6 +14,14 @@
   let detailError = $state(null);
 
   const selectedId = $derived(route.parts[1] ?? null);
+
+  /** État dérivé d'un sprint depuis sa progression en points. */
+  function sprintState(s) {
+    if (s.total_points > 0 && s.done_points >= s.total_points) return 'done';
+    if (s.done_points > 0) return 'active';
+    return 'planned';
+  }
+  const pct = (s) => (s.total_points ? Math.round((s.done_points / s.total_points) * 100) : 0);
 
   async function loadList() {
     loadingList = true;
@@ -60,10 +69,16 @@
   // Group a detail's tasks under their parent story for the stories table.
   const tasksByStory = $derived.by(() => {
     const map = {};
-    for (const t of detail?.tasks ?? []) {
-      (map[t.us_id] ??= []).push(t);
-    }
+    for (const t of detail?.tasks ?? []) (map[t.us_id] ??= []).push(t);
     return map;
+  });
+
+  // Métriques agrégées du sprint courant.
+  const detailTotals = $derived.by(() => {
+    const ss = detail?.stories ?? [];
+    const total = ss.reduce((a, s) => a + (s.story_points || 0), 0);
+    const done = ss.filter((s) => s.status === 'done').reduce((a, s) => a + (s.story_points || 0), 0);
+    return { total, done, count: ss.length, pct: total ? Math.round((done / total) * 100) : 0 };
   });
 
   let expanded = $state(new Set());
@@ -73,363 +88,148 @@
     expanded = new Set(expanded);
   }
 
-  $effect(() => {
-    loadList();
-  });
-
-  $effect(() => {
-    loadDetail(selectedId);
-  });
+  $effect(() => { loadList(); });
+  $effect(() => { loadDetail(selectedId); });
 </script>
 
-<div class="sprints-container">
-  <aside class="sprints-sidebar" aria-label="Liste des sprints">
-    {#if loadingList}
-      <div class="muted">Loading…</div>
-    {:else if listError}
-      <div class="error">Error: {listError}</div>
-    {:else if sprints.length === 0}
-      <div class="muted">Aucun sprint</div>
-    {:else}
-      <nav class="sprint-list" aria-label="Sprints">
+<div class="view-pad">
+  <div class="sprints-layout">
+    <aside class="sprint-list" aria-label="Liste des sprints">
+      {#if loadingList}
+        <div class="empty">Chargement…</div>
+      {:else if listError}
+        <div class="empty">Erreur : {listError}</div>
+      {:else if sprints.length === 0}
+        <div class="empty">Aucun sprint</div>
+      {:else}
         {#each sprints as s}
-          <button
-            class="sprint-item"
-            class:active={selectedId === s.id}
-            onclick={() => navigate(`/sprints/${s.id}`)}
-          >
-            <span class="sprint-id">{s.id}</span>
-            <span class="sprint-meta">{s.story_count} US · {s.done_points}/{s.total_points} pts</span>
-            <span class="badges">
-              {#if s.has_goal}<span class="badge" title="Sprint goal">goal</span>{/if}
-              {#if s.has_review}<span class="badge review" title="Sprint review">review</span>{/if}
-              {#if s.has_retro}<span class="badge retro" title="Retrospective">retro</span>{/if}
-            </span>
+          {@const state = sprintState(s)}
+          <button class="sprint-item" aria-current={selectedId === s.id} onclick={() => navigate(`/sprints/${s.id}`)}>
+            <div class="si-top">
+              <span class="si-name">{s.id}</span>
+              <span class="si-state {state}">{state}</span>
+            </div>
+            <div class="si-stat">
+              <span>{s.story_count} US</span>
+              <span>{s.done_points}/{s.total_points} pts</span>
+            </div>
+            <div class="proj-bar" style="margin-top:9px"><span style="width: {pct(s)}%"></span></div>
+            {#if s.has_goal || s.has_review || s.has_retro}
+              <div class="si-tags">
+                {#if s.has_goal}<span class="tag-mini">goal</span>{/if}
+                {#if s.has_review}<span class="tag-mini">review</span>{/if}
+                {#if s.has_retro}<span class="tag-mini">retro</span>{/if}
+              </div>
+            {/if}
           </button>
         {/each}
-      </nav>
-    {/if}
-  </aside>
-
-  <div class="sprints-content" role="region" aria-label="Détail du sprint">
-    {#if !selectedId}
-      <div class="empty">Sélectionnez un sprint</div>
-    {:else if loadingDetail}
-      <div class="empty">Loading…</div>
-    {:else if detailError}
-      <div class="error">Error: {detailError}</div>
-    {:else if detail}
-      <header class="content-header">
-        <h1>{detail.sprint.id}</h1>
-      </header>
-
-      {#if detail.goal}
-        <section class="md-section">
-          <h2>Goal</h2>
-          <div class="markdown-body">{@html render(detail.goal)}</div>
-        </section>
       {/if}
+    </aside>
 
-      <section class="md-section">
-        <h2>Stories &amp; Tasks</h2>
-        {#if detail.stories.length === 0}
-          <p class="muted">Aucune story dans ce sprint.</p>
-        {:else}
-          <table class="stories-table">
-            <thead>
-              <tr><th></th><th>ID</th><th>Titre</th><th>Statut</th><th>Points</th><th>Assigné</th></tr>
-            </thead>
-            <tbody>
-              {#each detail.stories as st}
-                {@const tasks = tasksByStory[st.id] ?? []}
-                <tr>
-                  <td>
-                    {#if tasks.length}
-                      <button
-                        class="toggle"
-                        aria-expanded={expanded.has(st.id)}
-                        aria-label="Afficher les tâches de {st.id}"
-                        onclick={() => toggleStory(st.id)}
-                      >{expanded.has(st.id) ? '▼' : '▶'}</button>
-                    {/if}
-                  </td>
-                  <td>{st.id}</td>
-                  <td>{st.title}</td>
-                  <td><span class="status status-{st.status}">{st.status}</span></td>
-                  <td>{st.story_points ?? '—'}</td>
-                  <td>{st.assigned_to || '—'}</td>
-                </tr>
-                {#if expanded.has(st.id) && tasks.length}
-                  <tr class="tasks-row">
-                    <td></td>
-                    <td colspan="5">
-                      <table class="tasks-table">
-                        <thead>
-                          <tr><th>Task</th><th>Type</th><th>Statut</th><th>Est.</th><th>Réel</th><th>Assigné</th></tr>
-                        </thead>
-                        <tbody>
-                          {#each tasks as t}
-                            <tr>
-                              <td>{t.id}</td>
-                              <td>{t.type}</td>
-                              <td>{t.status}</td>
-                              <td>{t.estimation_hours ?? '—'}</td>
-                              <td>{t.actual_hours ?? '—'}</td>
-                              <td>{t.assigned_to || '—'}</td>
-                            </tr>
-                          {/each}
-                        </tbody>
-                      </table>
-                    </td>
-                  </tr>
-                {/if}
-              {/each}
-            </tbody>
-          </table>
+    <main class="sprint-detail" aria-label="Détail du sprint">
+      {#if !selectedId}
+        <div class="empty">Sélectionnez un sprint</div>
+      {:else if loadingDetail}
+        <div class="empty">Chargement…</div>
+      {:else if detailError}
+        <div class="empty">Erreur : {detailError}</div>
+      {:else if detail}
+        {@const state = sprintState({ total_points: detailTotals.total, done_points: detailTotals.done })}
+        <div class="sd-head">
+          <div style="flex:1">
+            <div style="display:flex; align-items:center; gap:11px">
+              <h2>{detail.sprint.id}</h2>
+              <span class="si-state {state}" style="font-size:11px">{state}</span>
+            </div>
+          </div>
+        </div>
+
+        <div class="sd-metrics">
+          <div class="metric"><div class="mk">Points</div><div class="mv">{detailTotals.total}<small> pts</small></div></div>
+          <div class="metric"><div class="mk">Complétés</div><div class="mv">{detailTotals.done}<small> pts</small></div><div class="msub">{detailTotals.pct}% du total</div></div>
+          <div class="metric"><div class="mk">Stories</div><div class="mv">{detailTotals.count}</div></div>
+        </div>
+
+        {#if detail.goal}
+          <div class="sd-panel">
+            <h3>Goal</h3>
+            <div class="md-body">{@html render(detail.goal)}</div>
+          </div>
         {/if}
-      </section>
 
-      {#if detail.review}
-        <section class="md-section">
-          <h2>Review</h2>
-          <div class="markdown-body">{@html render(detail.review)}</div>
-        </section>
-      {/if}
+        <div class="sd-panel">
+          <h3>Stories &amp; Tasks <span class="pill" style="background: var(--accent-soft); color: var(--accent)">{detail.stories.length}</span></h3>
+          {#if detail.stories.length === 0}
+            <p style="color: var(--fg-faint); font-size:13px">Aucune story dans ce sprint.</p>
+          {:else}
+            {#each detail.stories as st}
+              {@const tasks = tasksByStory[st.id] ?? []}
+              <div class="sd-story-wrap">
+                <div class="sd-story">
+                  {#if tasks.length}
+                    <button class="toggle" aria-expanded={expanded.has(st.id)} aria-label="Afficher les tâches de {st.id}" onclick={() => toggleStory(st.id)}>{expanded.has(st.id) ? '▼' : '▶'}</button>
+                  {:else}
+                    <span class="toggle-spacer"></span>
+                  {/if}
+                  <span class="s-id mono">{st.id}</span>
+                  <span class="s-t">{st.title}</span>
+                  <span class="s-status">
+                    <i style="width:8px;height:8px;border-radius:50%;background: var({STATUS[st.status]?.cssVar || '--fg-faint'});display:inline-block"></i>{STATUS[st.status]?.label || st.status}
+                  </span>
+                  <span class="points mono">{st.story_points ?? '—'}</span>
+                </div>
+                {#if expanded.has(st.id) && tasks.length}
+                  <table class="tasks sprint-tasks">
+                    <thead><tr><th>Task</th><th>Type</th><th>Statut</th><th style="text-align:right">Est</th><th style="text-align:right">Réel</th><th>Assigné</th></tr></thead>
+                    <tbody>
+                      {#each tasks as t}
+                        <tr>
+                          <td class="t-name mono">{t.id}</td>
+                          <td>{t.type}</td>
+                          <td>{t.status}</td>
+                          <td class="t-hrs">{t.estimation_hours ?? '—'}</td>
+                          <td class="t-hrs">{t.actual_hours ?? '—'}</td>
+                          <td>{t.assigned_to || '—'}</td>
+                        </tr>
+                      {/each}
+                    </tbody>
+                  </table>
+                {/if}
+              </div>
+            {/each}
+          {/if}
+        </div>
 
-      {#if detail.retro}
-        <section class="md-section">
-          <h2>Retro</h2>
-          <div class="markdown-body">{@html render(detail.retro)}</div>
-        </section>
+        {#if detail.review}
+          <div class="sd-panel">
+            <h3>Review <span class="pill" style="background: var(--success-soft); color: var(--success)">review</span></h3>
+            <div class="md-body review-md">{@html render(detail.review)}</div>
+          </div>
+        {/if}
+        {#if detail.retro}
+          <div class="sd-panel">
+            <h3>Retro <span class="pill" style="background: var(--accent-soft); color: var(--accent)">team</span></h3>
+            <div class="md-body review-md">{@html render(detail.retro)}</div>
+          </div>
+        {/if}
       {/if}
-    {/if}
+    </main>
   </div>
 </div>
 
 <style>
-  .sprints-container {
-    display: flex;
-    height: 100%;
-    overflow: hidden;
+  .si-tags { display: flex; gap: 5px; margin-top: 9px; }
+  .tag-mini {
+    font-family: var(--mono); font-size: 9.5px; font-weight: 600; text-transform: uppercase;
+    letter-spacing: 0.04em; padding: 2px 6px; border-radius: 5px;
+    background: var(--bg-inset); color: var(--fg-faint);
   }
-
-  .sprints-sidebar {
-    width: 240px;
-    background: var(--bg-sidebar);
-    border-right: 1px solid var(--border);
-    overflow-y: auto;
-    padding: 12px 8px;
-  }
-
-  .sprint-list {
-    display: flex;
-    flex-direction: column;
-    gap: 4px;
-  }
-
-  .sprint-item {
-    background: none;
-    border: none;
-    text-align: left;
-    cursor: pointer;
-    border-radius: var(--radius);
-    padding: 8px 10px;
-    width: 100%;
-    display: flex;
-    flex-direction: column;
-    gap: 3px;
-    color: var(--fg);
-    transition: background 0.1s;
-  }
-
-  .sprint-item:hover {
-    background: var(--border);
-  }
-
-  .sprint-item.active {
-    background: var(--accent);
-    color: var(--accent-fg);
-  }
-
-  .sprint-item:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: -2px;
-  }
-
-  .sprint-id {
-    font-weight: 600;
-    font-size: 13px;
-  }
-
-  .sprint-meta {
-    font-size: 11px;
-    color: var(--fg-dim);
-  }
-
-  .sprint-item.active .sprint-meta {
-    color: var(--accent-fg);
-  }
-
-  .badges {
-    display: flex;
-    gap: 4px;
-    flex-wrap: wrap;
-  }
-
-  .badge {
-    font-size: 10px;
-    padding: 1px 6px;
-    border-radius: 10px;
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-    color: var(--fg-dim);
-  }
-
-  .badge.review {
-    border-color: var(--accent);
-    color: var(--accent);
-  }
-
-  .badge.retro {
-    border-color: var(--success, #16a34a);
-    color: var(--success, #16a34a);
-  }
-
-  .sprints-content {
-    flex: 1;
-    overflow-y: auto;
-    padding: 20px;
-    background: var(--bg);
-  }
-
-  .content-header {
-    margin-bottom: 16px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid var(--border);
-  }
-
-  .content-header h1 {
-    margin: 0;
-    font-size: 20px;
-    font-weight: 600;
-    color: var(--fg);
-  }
-
-  .md-section {
-    margin-bottom: 28px;
-  }
-
-  .md-section h2 {
-    font-size: 16px;
-    font-weight: 600;
-    color: var(--fg);
-    margin: 0 0 10px;
-  }
-
-  .stories-table,
-  .tasks-table {
-    border-collapse: collapse;
-    width: 100%;
-    font-size: 13px;
-  }
-
-  .stories-table th,
-  .stories-table td,
-  .tasks-table th,
-  .tasks-table td {
-    border: 1px solid var(--border);
-    padding: 6px 10px;
-    text-align: left;
-  }
-
-  .stories-table th,
-  .tasks-table th {
-    background: var(--bg-sidebar);
-    font-weight: 600;
-  }
-
-  .tasks-row td {
-    background: var(--bg-sidebar);
-    padding: 6px;
-  }
-
   .toggle {
-    background: none;
-    border: none;
-    cursor: pointer;
-    color: var(--fg-dim);
-    font-size: 10px;
+    background: none; border: none; cursor: pointer; color: var(--fg-faint);
+    font-size: 10px; width: 16px; flex: none;
   }
-
-  .toggle:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-  }
-
-  .status {
-    font-size: 11px;
-    padding: 1px 6px;
-    border-radius: 10px;
-    background: var(--bg-elev);
-    border: 1px solid var(--border);
-  }
-
-  .empty,
-  .muted {
-    color: var(--fg-dim);
-    padding: 12px;
-  }
-
-  .error {
-    color: var(--danger);
-    padding: 12px;
-  }
-
-  .markdown-body {
-    line-height: 1.7;
-  }
-
-  .markdown-body :global(h1) {
-    font-size: 22px;
-    margin: 16px 0 12px;
-  }
-
-  .markdown-body :global(h2) {
-    font-size: 18px;
-    margin: 14px 0 10px;
-  }
-
-  .markdown-body :global(table) {
-    border-collapse: collapse;
-    width: 100%;
-    margin: 0 0 12px;
-  }
-
-  .markdown-body :global(th),
-  .markdown-body :global(td) {
-    border: 1px solid var(--border);
-    padding: 8px 12px;
-    text-align: left;
-  }
-
-  .markdown-body :global(th) {
-    background: var(--bg-sidebar);
-    font-weight: 600;
-  }
-
-  .markdown-body :global(blockquote) {
-    border-left: 3px solid var(--accent);
-    padding-left: 12px;
-    margin: 0 0 12px;
-    color: var(--fg-dim);
-    font-style: italic;
-  }
-
-  .markdown-body :global(code) {
-    background: var(--bg-sidebar);
-    padding: 2px 4px;
-    border-radius: 3px;
-    font-family: var(--mono);
-    font-size: 0.9em;
-  }
+  .toggle:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
+  .toggle-spacer { width: 16px; flex: none; }
+  .sprint-tasks { margin: 4px 0 8px 28px; width: calc(100% - 28px); }
+  .sd-story .points { margin-left: 0; }
 </style>

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -63,6 +63,7 @@ export default [
         window: 'readonly',
         document: 'readonly',
         fetch: 'readonly',
+        localStorage: 'readonly',
         EventSource: 'readonly',
         setTimeout: 'readonly',
         clearTimeout: 'readonly',

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,6 +24,8 @@
         "@commitlint/cli": "21.0.2",
         "@commitlint/config-conventional": "21.0.2",
         "@eslint/js": "^10.0.0",
+        "@fontsource/jetbrains-mono": "^5.2.8",
+        "@fontsource/space-grotesk": "^5.2.10",
         "@stryker-mutator/core": "9.6.1",
         "@stryker-mutator/vitest-runner": "9.6.1",
         "@sveltejs/vite-plugin-svelte": "^7.1.2",
@@ -41,7 +43,7 @@
         "vitest": "4.1.8"
       },
       "engines": {
-        "node": ">=20.0.0",
+        "node": ">=22.0.0",
         "os": [
           "linux",
           "darwin"
@@ -1022,6 +1024,26 @@
       },
       "engines": {
         "node": "^20.19.0 || ^22.13.0 || >=24"
+      }
+    },
+    "node_modules/@fontsource/jetbrains-mono": {
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/@fontsource/jetbrains-mono/-/jetbrains-mono-5.2.8.tgz",
+      "integrity": "sha512-6w8/SG4kqvIMu7xd7wt6x3idn1Qux3p9N62s6G3rfldOUYHpWcc2FKrqf+Vo44jRvqWj2oAtTHrZXEP23oSKwQ==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource/space-grotesk": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource/space-grotesk/-/space-grotesk-5.2.10.tgz",
+      "integrity": "sha512-XNXEbT74OIITPqw2H6HXwPDp85fy43uxfBwFR5PU+9sLnjuLj12KlhVM9nZVN6q6dlKjkuN8JisW/OBxwxgUew==",
+      "dev": true,
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
       }
     },
     "node_modules/@hono/node-server": {

--- a/package.json
+++ b/package.json
@@ -72,6 +72,8 @@
     "@commitlint/cli": "21.0.2",
     "@commitlint/config-conventional": "21.0.2",
     "@eslint/js": "^10.0.0",
+    "@fontsource/jetbrains-mono": "^5.2.8",
+    "@fontsource/space-grotesk": "^5.2.10",
     "@stryker-mutator/core": "9.6.1",
     "@stryker-mutator/vitest-runner": "9.6.1",
     "@sveltejs/vite-plugin-svelte": "^7.1.2",

--- a/tests/kanban/config.test.js
+++ b/tests/kanban/config.test.js
@@ -1,0 +1,102 @@
+import { describe, it, expect } from 'vitest';
+import {
+  STATUS,
+  PRIORITY,
+  TDD,
+  hashString,
+  epicHue,
+  codeColor,
+  initials,
+  avatarColor,
+} from '../../cli/kanban/client/src/lib/config.js';
+
+describe('hashString', () => {
+  it('est déterministe', () => {
+    expect(hashString('US-114')).toBe(hashString('US-114'));
+  });
+  it('diffère selon l\'entrée', () => {
+    expect(hashString('EPIC-01')).not.toBe(hashString('EPIC-02'));
+  });
+  it('gère null/undefined sans crash', () => {
+    expect(hashString(null)).toBe(hashString(''));
+    expect(typeof hashString(undefined)).toBe('number');
+  });
+});
+
+describe('epicHue', () => {
+  it('retourne --fg-faint quand epicId est vide', () => {
+    expect(epicHue('')).toBe('var(--fg-faint)');
+    expect(epicHue(null)).toBe('var(--fg-faint)');
+  });
+  it('produit une couleur oklch stable par id', () => {
+    const a = epicHue('EPIC-01');
+    expect(a).toMatch(/^oklch\(0\.78 0\.13 \d+\)$/);
+    expect(epicHue('EPIC-01')).toBe(a);
+  });
+  it('varie selon l\'epic', () => {
+    expect(epicHue('EPIC-01')).not.toBe(epicHue('EPIC-07'));
+  });
+});
+
+describe('codeColor', () => {
+  const story = {
+    status: 'in-progress',
+    priority: 'must',
+    tdd_phase: 'green',
+    epic_id: 'EPIC-03',
+  };
+
+  it('schéma status → variable de statut', () => {
+    expect(codeColor(story, 'status')).toBe(`var(${STATUS['in-progress'].cssVar})`);
+  });
+  it('schéma priority → variable de priorité', () => {
+    expect(codeColor(story, 'priority')).toBe(`var(${PRIORITY.must.cssVar})`);
+  });
+  it('schéma tdd → variable TDD', () => {
+    expect(codeColor(story, 'tdd')).toBe(`var(${TDD.green.cssVar})`);
+  });
+  it('schéma epic → teinte d\'epic', () => {
+    expect(codeColor(story, 'epic')).toBe(epicHue('EPIC-03'));
+  });
+  it('défaut (schéma inconnu) → statut', () => {
+    expect(codeColor(story, 'wat')).toBe(`var(${STATUS['in-progress'].cssVar})`);
+  });
+  it('statut inconnu → --border', () => {
+    expect(codeColor({ status: 'zzz' }, 'status')).toBe('var(--border)');
+  });
+  it('tdd manquant → --fg-faint', () => {
+    expect(codeColor({ tdd_phase: null }, 'tdd')).toBe('var(--fg-faint)');
+  });
+  it('story null → --border', () => {
+    expect(codeColor(null, 'status')).toBe('var(--border)');
+  });
+});
+
+describe('initials', () => {
+  it('deux mots → première lettre de chaque', () => {
+    expect(initials('Alice Martin')).toBe('AM');
+  });
+  it('séparateurs variés (. _ -)', () => {
+    expect(initials('jean.dupont')).toBe('JD');
+    expect(initials('back_end')).toBe('BE');
+  });
+  it('un seul mot → deux premières lettres', () => {
+    expect(initials('claude')).toBe('CL');
+  });
+  it('vide → ?', () => {
+    expect(initials('')).toBe('?');
+    expect(initials(null)).toBe('?');
+  });
+});
+
+describe('avatarColor', () => {
+  it('déterministe par nom', () => {
+    expect(avatarColor('Alice')).toBe(avatarColor('Alice'));
+  });
+  it('couleur oklch valide', () => {
+    expect(avatarColor('Bob')).toMatch(/^oklch\(0\.78 0\.12 \d+\)$/);
+  });
+  it('vide → fond inset', () => {
+    expect(avatarColor('')).toBe('var(--bg-inset)');
+  });
+});


### PR DESCRIPTION
## Contexte

Refonte visuelle complète de la SPA Kanban (`cli/kanban/client/`) d'après une maquette **Claude Design** (bundle de handoff HTML/CSS/JS). Direction validée : thème **dark-only**, accent **acid-lime** oklch, typo **Space Grotesk + JetBrains Mono**, panneau **Tweaks** complet. Couvre les 6 vues.

## Changements

- **Design system** : tokens oklch dark-only + shim de compat (`--font/--ok/--warn/--info/--badge-fg`) → `app.css` ; nouvelle feuille globale `views.css`.
- **Polices auto-hébergées** via `@fontsource/space-grotesk` + `@fontsource/jetbrains-mono` (CSP `font-src` retombe sur `'self'`, Google Fonts bloqué) — bundlées par Vite.
- **Shell** refait : sidebar brandée + nav à icônes + proj-card sprint ; topbar (recherche, sprint-pill, indicateur Live SSE, gear Tweaks) ; toasts.
- **Board** : barre d'accent gauche colorée par `codeColor`, chips priorité/TDD, avatars, légende — **DnD, nav clavier, menu de déplacement, modale détail, read-only et aria-live préservés**.
- **5 autres vues** réalignées (Backlog accordéon, Sprints, Burndown/uPlot, Deps/Cytoscape, Docs) — couleurs canvas résolues via `getComputedStyle` (`var()` non honoré sur canvas).
- **Coloration en JS pur testé** : `lib/config.js` (+ `tests/kanban/config.test.js`, 21 tests) ; `lib/icons.js` ; 8 composants présentational.
- **Tweaks** : schéma couleur / accent / densité persistés en `localStorage`, appliqués aux vars CSS au runtime.

## Vérification

- ✅ `npm run kanban:build`
- ✅ `npm test` (**1046 tests**, dont 21 nouveaux + régression `kanban-nav` intacte)
- ✅ `eslint` + `prettier --check` propres
- ✅ Vérifié dans Chrome avec données réelles (fixture `tests/fixtures/bmad-sprint-status`) : board, modale détail, Tweaks (accent/schéma/densité persistés), backlog — 0 erreur console, CSP respectée, polices chargées depuis `'self'`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)