### PR TITLE
chore(release): 8.15.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.14.0",
+      "version": "8.15.0",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.14.0 | **Languages:** en, fr, es, de, pt
+**Version:** 8.15.0 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.15.0] - 2026-06-15
+
+### Changed
+- **Refonte du design de l'interface web Kanban** (`claude-craft kanban`, SPA Svelte 5) à partir d'une maquette **Claude Design**. Thème **dark-only** opiniâtre, accent **acid-lime** (oklch, distinct des six teintes de statut), typographie **Space Grotesk + JetBrains Mono** auto-hébergée via `@fontsource` (bundlée par Vite, conforme à la CSP `font-src 'self'` — Google Fonts bloqué).
+  - **Design system** en deux feuilles globales : `app.css` (tokens oklch + reset/a11y + shell) et nouvelle `views.css` (board, modale, backlog, sprints, burndown, deps, docs, toasts, chips/atomes, densité, responsive). Shim de compatibilité pour les tokens legacy (`--font/--ok/--warn/--info/--badge-fg`).
+  - **Coloration** extraite en helpers JS purs et testés (`lib/config.js` : `codeColor`, `epicHue`, `avatarColor`, `initials` ; `tests/kanban/config.test.js`, 21 tests) ; icônes inline (`lib/icons.js`) ; 8 composants présentational (Icon, Avatar, PriorityChip, TddPip, Points, TaskProgress, ProgressRing, TweaksPanel).
+  - **Panneau Tweaks** : schéma de code couleur des cartes (statut / priorité / TDD / epic), accent et densité, persistés en `localStorage` et appliqués aux variables CSS au runtime.
+  - **Shell** (sidebar brandée + nav à icônes + carte sprint ; topbar avec recherche, sprint-pill, indicateur Live SSE, panneau Tweaks) et les 6 vues restylés. uPlot (burndown) et Cytoscape (deps) résolvent les tokens via `getComputedStyle` (canvas n'honore pas `var()`).
+  - **Préservé** : drag&drop, navigation clavier, `<dialog>` natifs (piège de focus), annonces `aria-live`, gestion read-only `.bmad/sprint-status.yaml`. Build + suite complète verts. (#81)
+
 ## [8.14.0] - 2026-06-14
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,13 @@ Plus **11 stack-specific reviewers** (@symfony-reviewer, @react-reviewer, @pytho
 
 A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, 48 skills**, all token-optimized via `context: fork` and sub-agent model routing.
 
-## What's New in v8.14.0
+## What's New in v8.15.0
+
+**Refonte du design de l'interface web Kanban (v8.15.0) :**
+
+- **Thème dark-only opiniâtre** d'après une maquette **Claude Design** : accent **acid-lime** (oklch, distinct des six teintes de statut), typographie **Space Grotesk + JetBrains Mono** auto-hébergée via `@fontsource` (CSP `font-src 'self'`).
+- **Panneau Tweaks** : code couleur des cartes (statut / priorité / TDD / epic), accent et densité, persistés en `localStorage`.
+- **Les 6 vues restylées** (board, backlog, sprints, burndown, deps, docs) ; drag&drop, navigation clavier, `<dialog>` natifs et a11y préservés. Coloration en helpers JS purs testés.
 
 **Interface web Kanban — accès à tous les artefacts BMAD v6 (v8.14.0) :**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@the-bearded-bear/claude-craft",
-      "version": "8.14.0",
+      "version": "8.15.0",
       "license": "MIT",
       "dependencies": {
         "@hono/node-server": "^2.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.14.0",
+  "version": "8.15.0",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
Release **8.15.0** (MINOR) — refonte du design de l'interface web Kanban (#81).

Bump : `8.14.0 → 8.15.0` sur les 7 fichiers de release (package.json, package-lock.json, marketplace.json, plugin.json, .claude/CLAUDE.md, CHANGELOG.md, README.md).

Le publish NPM est effectué automatiquement par la CI au tag `v8.15.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)