### PR TITLE
fix(refs): align stack references with verified 2026 versions (freshness audit)

### DIFF
--- a/.claude/agents/csharp-reviewer.md
+++ b/.claude/agents/csharp-reviewer.md
@@ -496,6 +496,9 @@ await context.Orders.Where(o => o.Id == id)
 | **FluentAssertions** | Assertions lisibles et expressives |
 | **FluentValidation** | Validation des Commands/Queries |
 | **MediatR** | CQRS et pipeline de behaviors |
+
+> ⚠️ **Licence** : MediatR et AutoMapper sont passés sous licence commerciale à partir de la v13 (annoncé 2024/2025 par Jimmy Bogard). Usage gratuit limité (RPL) ; licence payante requise au-delà de certains seuils (grande équipe / forts revenus). Vérifier le modèle de licence avant d'utiliser dans un nouveau projet. Alternatives MIT : **Wolverine**, **Cortex.Mediator**, **ConduitR**.
+
 | **WebApplicationFactory** | Tests d'integration ASP.NET Core |
 | **Testcontainers** | Tests d'integration avec vraie DB |
 | **SonarAnalyzer** | Analyse statique C# |

--- a/.claude/agents/devops-engineer.md
+++ b/.claude/agents/devops-engineer.md
@@ -68,7 +68,7 @@ Tu es un **DevOps Engineer Senior** avec 10+ ans d'expérience en CI/CD, contene
 | GCP | Cloud Run, GKE, Cloud SQL |
 | DigitalOcean | App Platform, Kubernetes, Managed DB |
 | Azure | AKS, App Service, Azure DevOps |
-| Hetzner Cloud | VPS, Kubernetes, Load Balancers (location vs datacenter 2026) |
+| Hetzner Cloud | VPS, Kubernetes, Load Balancers (location vs datacenter 2026) | hcloud provider 1.65.0 (juin 2026) |
 | Coolify | Self-hosted PaaS, MCP server natif (read-only), audit logging structuré | v4.1.2 (juin 2026) |
 | OpenTofu | State encryption, OCI registry backends | 1.12.1 (juin 2026) |
 | Ansible | Automation, playbooks, roles | ansible-core 2.21.0 (stable mai 2026) |
@@ -350,7 +350,7 @@ helm template ./chart      # Vérifier le rendu avec Helm 4
 # Parallel jobs
 strategy:
   matrix:
-    version: [18, 20, 22]
+    version: [20, 22, 24]
 ```
 
 ## Patterns Recommandés

--- a/.claude/references/base/documentation.md
+++ b/.claude/references/base/documentation.md
@@ -289,7 +289,7 @@ docs/
 ### OpenAPI (Swagger)
 
 ```yaml
-openapi: 3.0.0
+openapi: 3.1.1
 info:
   title: User API
   version: 1.0.0

--- a/.claude/rules/10-documentation.md
+++ b/.claude/rules/10-documentation.md
@@ -6,7 +6,7 @@ Documentation as Code, à jour, concise et utile.
 |------|--------|-------------|
 | **README** | Markdown | Installation, démarrage rapide, config (10 sections requises) |
 | **Code comments** | Inline | POURQUOI, pas QUOI (décisions non évidentes, workarounds, refs externes) |
-| **API docs** | OpenAPI 3.2 | Endpoints, schemas, exemples, erreurs (RFC 9457), auth, rate limits |
+| **API docs** | OpenAPI 3.1.1 | Endpoints, schemas, exemples, erreurs (RFC 9457), auth, rate limits |
 | **ADR** | Markdown | Statut, Contexte, Décision, Alternatives, Conséquences (Log4brains recommandé) |
 | **Changelog** | Markdown | Keep a Changelog (Added, Changed, Deprecated, Removed, Fixed, Security) |
 

--- a/.claude/skills/documentation/REFERENCE.md
+++ b/.claude/skills/documentation/REFERENCE.md
@@ -289,7 +289,7 @@ docs/
 ### OpenAPI (Swagger)
 
 ```yaml
-openapi: 3.0.0
+openapi: 3.1.1
 info:
   title: User API
   version: 1.0.0

--- a/.claude/templates/AGENTS.md.template
+++ b/.claude/templates/AGENTS.md.template
@@ -13,7 +13,7 @@
 
 ### Architecture et design
 
-- `@api-designer` — Conception API REST/GraphQL, OpenAPI 3.2, GraphQL Federation
+- `@api-designer` — Conception API REST/GraphQL, OpenAPI 3.1.1, GraphQL Federation
 - `@database-architect` — Conception et optimisation BDD (PostgreSQL, MySQL, schemas)
 - `@refactoring-specialist` — Refactoring sur, patterns SOLID, extraction methode
 - `@ui-designer` — Design systems, Tailwind, design tokens

--- a/Dev/i18n/de/CSharp/agents/csharp-reviewer.md
+++ b/Dev/i18n/de/CSharp/agents/csharp-reviewer.md
@@ -495,6 +495,9 @@ await context.Orders.Where(o => o.Id == id)
 | **FluentAssertions** | Lesbare und ausdrucksstarke Assertions |
 | **FluentValidation** | Validierung der Commands/Queries |
 | **MediatR** | CQRS und Behavior-Pipeline |
+
+> ⚠️ **Lizenz**: MediatR und AutoMapper wechselten ab v13 zu einer kommerziellen Lizenz (angekündigt 2024/2025 von Jimmy Bogard). Die kostenlose Nutzung ist begrenzt (RPL); bei größeren Teams oder hohem Umsatz ist eine kostenpflichtige Lizenz erforderlich. Das Lizenzmodell vor dem Einsatz in einem neuen Projekt prüfen. MIT-Alternativen: **Wolverine**, **Cortex.Mediator**, **ConduitR**.
+
 | **WebApplicationFactory** | ASP.NET Core Integrationstests |
 | **Testcontainers** | Integrationstests mit echter Datenbank |
 | **SonarAnalyzer** | Statische Analyse für C# |

--- a/Dev/i18n/de/Common/agents/devops-engineer.md
+++ b/Dev/i18n/de/Common/agents/devops-engineer.md
@@ -142,7 +142,7 @@ kubectl rollout history deployment/<name>
 # Parallele Jobs
 strategy:
   matrix:
-    version: [18, 20, 22]
+    version: [20, 22, 24]
 ```
 
 ## Empfohlene Patterns

--- a/Dev/i18n/de/Common/rules/10-documentation.md
+++ b/Dev/i18n/de/Common/rules/10-documentation.md
@@ -289,7 +289,7 @@ docs/
 ### OpenAPI (Swagger)
 
 ```yaml
-openapi: 3.0.0
+openapi: 3.1.1
 info:
   title: User API
   version: 1.0.0

--- a/Dev/i18n/en/CSharp/agents/csharp-reviewer.md
+++ b/Dev/i18n/en/CSharp/agents/csharp-reviewer.md
@@ -495,6 +495,9 @@ await context.Orders.Where(o => o.Id == id)
 | **FluentAssertions** | Readable and expressive assertions |
 | **FluentValidation** | Command/Query validation |
 | **MediatR** | CQRS and behavior pipeline |
+
+> ⚠️ **License**: MediatR and AutoMapper moved to a commercial license from v13 (announced 2024/2025 by Jimmy Bogard). Free use is limited (RPL); a paid license is required beyond certain thresholds (large teams / high revenue). Verify the license model before using in a new project. MIT alternatives: **Wolverine**, **Cortex.Mediator**, **ConduitR**.
+
 | **WebApplicationFactory** | ASP.NET Core integration tests |
 | **Testcontainers** | Integration tests with real DB |
 | **SonarAnalyzer** | C# static analysis |

--- a/Dev/i18n/en/Common/agents/devops-engineer.md
+++ b/Dev/i18n/en/Common/agents/devops-engineer.md
@@ -152,7 +152,7 @@ kubectl rollout history deployment/<name>
 # Parallel jobs
 strategy:
   matrix:
-    version: [18, 20, 22]
+    version: [20, 22, 24]
 ```
 
 ## Recommended Patterns

--- a/Dev/i18n/en/Common/rules/10-documentation.md
+++ b/Dev/i18n/en/Common/rules/10-documentation.md
@@ -289,7 +289,7 @@ docs/
 ### OpenAPI (Swagger)
 
 ```yaml
-openapi: 3.0.0
+openapi: 3.1.1
 info:
   title: User API
   version: 1.0.0

--- a/Dev/i18n/es/CSharp/agents/csharp-reviewer.md
+++ b/Dev/i18n/es/CSharp/agents/csharp-reviewer.md
@@ -495,6 +495,9 @@ await context.Orders.Where(o => o.Id == id)
 | **FluentAssertions** | Aserciones legibles y expresivas |
 | **FluentValidation** | Validación de Commands/Queries |
 | **MediatR** | CQRS y pipeline de behaviors |
+
+> ⚠️ **Licencia**: MediatR y AutoMapper pasaron a licencia comercial a partir de la v13 (anunciado en 2024/2025 por Jimmy Bogard). El uso gratuito está limitado (RPL); se requiere licencia de pago más allá de ciertos umbrales (equipos grandes / altos ingresos). Verificar el modelo de licencia antes de usar en un nuevo proyecto. Alternativas MIT: **Wolverine**, **Cortex.Mediator**, **ConduitR**.
+
 | **WebApplicationFactory** | Tests de integración ASP.NET Core |
 | **Testcontainers** | Tests de integración con BD real |
 | **SonarAnalyzer** | Análisis estático C# |

--- a/Dev/i18n/es/Common/agents/devops-engineer.md
+++ b/Dev/i18n/es/Common/agents/devops-engineer.md
@@ -142,7 +142,7 @@ kubectl rollout history deployment/<name>
 # Jobs paralelos
 strategy:
   matrix:
-    version: [18, 20, 22]
+    version: [20, 22, 24]
 ```
 
 ## Patrones Recomendados

--- a/Dev/i18n/es/Common/rules/10-documentation.md
+++ b/Dev/i18n/es/Common/rules/10-documentation.md
@@ -289,7 +289,7 @@ docs/
 ### OpenAPI (Swagger)
 
 ```yaml
-openapi: 3.0.0
+openapi: 3.1.1
 info:
   title: User API
   version: 1.0.0

--- a/Dev/i18n/fr/CSharp/agents/csharp-reviewer.md
+++ b/Dev/i18n/fr/CSharp/agents/csharp-reviewer.md
@@ -495,6 +495,9 @@ await context.Orders.Where(o => o.Id == id)
 | **FluentAssertions** | Assertions lisibles et expressives |
 | **FluentValidation** | Validation des Commands/Queries |
 | **MediatR** | CQRS et pipeline de behaviors |
+
+> ⚠️ **Licence** : MediatR et AutoMapper sont passés sous licence commerciale à partir de la v13 (annoncé 2024/2025 par Jimmy Bogard). Usage gratuit limité (RPL) ; licence payante requise au-delà de certains seuils (grande équipe / forts revenus). Vérifier le modèle de licence avant d'utiliser dans un nouveau projet. Alternatives MIT : **Wolverine**, **Cortex.Mediator**, **ConduitR**.
+
 | **WebApplicationFactory** | Tests d'intégration ASP.NET Core |
 | **Testcontainers** | Tests d'intégration avec vraie DB |
 | **SonarAnalyzer** | Analyse statique C# |

--- a/Dev/i18n/fr/Common/agents/devops-engineer.md
+++ b/Dev/i18n/fr/Common/agents/devops-engineer.md
@@ -142,7 +142,7 @@ kubectl rollout history deployment/<name>
 # Parallel jobs
 strategy:
   matrix:
-    version: [18, 20, 22]
+    version: [20, 22, 24]
 ```
 
 ## Patterns Recommandés

--- a/Dev/i18n/fr/Common/rules/10-documentation.md
+++ b/Dev/i18n/fr/Common/rules/10-documentation.md
@@ -289,7 +289,7 @@ docs/
 ### OpenAPI (Swagger)
 
 ```yaml
-openapi: 3.0.0
+openapi: 3.1.1
 info:
   title: User API
   version: 1.0.0

--- a/Dev/i18n/pt/CSharp/agents/csharp-reviewer.md
+++ b/Dev/i18n/pt/CSharp/agents/csharp-reviewer.md
@@ -495,6 +495,9 @@ await context.Orders.Where(o => o.Id == id)
 | **FluentAssertions** | Assertivas legiveis e expressivas |
 | **FluentValidation** | Validacao dos Commands/Queries |
 | **MediatR** | CQRS e pipeline de behaviors |
+
+> ⚠️ **Licença**: MediatR e AutoMapper passaram para licença comercial a partir da v13 (anunciado em 2024/2025 por Jimmy Bogard). O uso gratuito é limitado (RPL); licença paga é exigida acima de certos limites (equipes grandes / receitas elevadas). Verificar o modelo de licença antes de usar em um novo projeto. Alternativas MIT: **Wolverine**, **Cortex.Mediator**, **ConduitR**.
+
 | **WebApplicationFactory** | Testes de integracao ASP.NET Core |
 | **Testcontainers** | Testes de integracao com DB real |
 | **SonarAnalyzer** | Analise estatica C# |

--- a/Dev/i18n/pt/Common/agents/devops-engineer.md
+++ b/Dev/i18n/pt/Common/agents/devops-engineer.md
@@ -142,7 +142,7 @@ kubectl rollout history deployment/<name>
 # Jobs paralelos
 strategy:
   matrix:
-    version: [18, 20, 22]
+    version: [20, 22, 24]
 ```
 
 ## Padrões Recomendados

--- a/Dev/i18n/pt/Common/rules/10-documentation.md
+++ b/Dev/i18n/pt/Common/rules/10-documentation.md
@@ -289,7 +289,7 @@ docs/
 ### OpenAPI (Swagger)
 
 ```yaml
-openapi: 3.0.0
+openapi: 3.1.1
 info:
   title: User API
   version: 1.0.0

--- a/config/versions.yaml
+++ b/config/versions.yaml
@@ -12,7 +12,7 @@
 # Dernière mise à jour : 2026-06-12 (bumps audit fraîcheur G4)
 
 meta:
-  lastUpdated: '2026-06-12'
+  lastUpdated: '2026-06-15'
 
 claudeCode:
   minimum: '2.1.97'
@@ -44,6 +44,7 @@ infra:
   kubernetes: '1.36.1'
   opentofu: '1.12.1'
   ansible: '2.21.0'
+  hcloud: '1.65.0'
   frankenphp: '1.12.4'
   pgbouncer: '1.25.2'
   helm: '4.2.0'


### PR DESCRIPTION
## Contexte

Correctifs issus de l'audit de fraîcheur du 2026-06-15 (17 agents, versions + best practices vérifiées via WebSearch). Appliqués sur la **source `Dev/i18n/` (5 langues)** + la couche d'install `.claude/` + le SSOT `config/versions.yaml`.

## Correctifs

| # | Correctif | Détail |
|---|-----------|--------|
| 1 | **hcloud 1.65.0** épinglé | Provider Terraform/OpenTofu non versionné → ajout dans `config/versions.yaml` + `devops-engineer.md` |
| 2 | **Node CI `[18,20,22]` → `[20,22,24]`** | Node 18 EOL depuis avril 2025 |
| 3 | **MediatR** disclaimer licence | MediatR/AutoMapper commerciaux depuis v13 → avertissement + alternatives MIT (Wolverine, Cortex.Mediator, ConduitR), traduit 5 langues |
| 4 | **OpenAPI → 3.1.1** | Source avait `3.0.0`, install `3.2` (non publiée) → harmonisé sur dernière stable 3.1.1 |

## Écartés (vérifiés, pas des défauts)
- **FrankenPHP 1.12.4** et **Helm 4.2.0** : confirmés à jour, inchangés
- Lien cassé `ddd-patterns` : artefact d'install `.claude`, source `Symfony/rules/13-ddd-patterns.md` saine

## Validation
- `npm run lint:versions` ✅
- `verify-i18n-parity.sh` (strict) ✅
- 22 fichiers, aucun résiduel OpenAPI 3.0/3.2

🤖 Generated with [Claude Code](https://claude.com/claude-code)