### PR TITLE
chore(release): 8.15.1

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.15.0",
+      "version": "8.15.1",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.15.0",
+  "version": "8.15.1",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.15.0 | **Languages:** en, fr, es, de, pt
+**Version:** 8.15.1 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.15.1] - 2026-06-15
+
+### Fixed
+- **Audit de fraîcheur 2026-06-15** — alignement des références/agents sur les versions vérifiées (source `Dev/i18n/` 5 langues + couche d'install `.claude/`) :
+  - **infra** : provider `hcloud` épinglé à `1.65.0` (`config/versions.yaml` + `devops-engineer`).
+  - **CI** : matrice de test Node `[18, 20, 22]` → `[20, 22, 24]` (Node 18 EOL depuis avril 2025).
+  - **C#** : ajout d'un avertissement de licence MediatR/AutoMapper (commerciale depuis v13) + alternatives MIT (Wolverine, Cortex.Mediator, ConduitR) dans `csharp-reviewer`.
+  - **docs** : version OpenAPI harmonisée sur `3.1.1` (dernière stable) dans la règle documentation, `references/base`, le skill documentation et le template AGENTS. (#83)
+
+### Security
+- **Dependabot #31 (esbuild GHSA-gv7w-rqvm-qjhr)** — analysé et classé risque tolérable : vecteur RCE spécifique au module Deno (`lib/deno/mod.ts`), non exploitable ici (esbuild via npm/Node, dépendance dev VitePress) ; le patch `0.28.1` n'est encore supporté par aucune release vite. À revoir au prochain bump vite.
+
 ## [8.15.0] - 2026-06-15
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.15.0",
+  "version": "8.15.1",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
Maintenance release **8.15.1** — corrections issues de l'audit de fraîcheur du 2026-06-15 (déjà mergées via #83), bump de version + CHANGELOG.

## Contenu
- Bump `8.15.0` → `8.15.1` : `package.json`, `plugin.json`, `marketplace.json`, `.claude/CLAUDE.md`
- CHANGELOG : section `[8.15.1]` (Fixed : hcloud pin, Node CI 18→24, MediatR licence, OpenAPI 3.1.1 ; Security : note Dependabot #31 esbuild risque tolérable)

## Gates
- `npm run lint:versions` ✅
- Aucun résiduel `8.15.0` (hors README What's New / historique CHANGELOG)

> Le publish NPM est déclenché par la CI sur le tag `v8.15.1` après merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)