### PR TITLE
fix(kanban): surface full sprint history and fix screen incoherences

### DIFF
--- a/cli/kanban/client/src/App.svelte
+++ b/cli/kanban/client/src/App.svelte
@@ -3,6 +3,7 @@
   import { route } from './lib/router.svelte.js';
   import { store, loadStories, loadSprint, connectEvents, disconnectEvents, dismissToast } from './lib/store.svelte.js';
   import { tweaks, initTweaks } from './lib/tweaks.svelte.js';
+  import { computeSprintProgress } from './lib/progress.js';
   import Icon from './components/Icon.svelte';
   import TweaksPanel from './components/TweaksPanel.svelte';
   import KanbanView from './views/KanbanView.svelte';
@@ -44,13 +45,21 @@
   let currentPath = $derived('/' + (route.parts[0] ?? 'kanban'));
   let title = $derived(titleMap[currentPath] ?? 'Board');
 
-  // Progression sprint dérivée du board (pas de fetch supplémentaire).
-  let totalPoints = $derived(store.stories.reduce((a, s) => a + (s.story_points || 0), 0));
-  let donePoints = $derived(
-    store.stories.filter((s) => s.status === 'done').reduce((a, s) => a + (s.story_points || 0), 0),
-  );
-  let progressPct = $derived(totalPoints ? (donePoints / totalPoints) * 100 : 0);
+  // Progression du SPRINT ACTIF uniquement (pas toutes les stories, qui
+  // incluent désormais l'historique des sprints clôturés) — cohérent avec le
+  // Burndown.
+  let progress = $derived(computeSprintProgress(store.stories, store.sprint?.sprint_id));
+  let totalPoints = $derived(progress.totalPoints);
+  let donePoints = $derived(progress.donePoints);
+  let progressPct = $derived(progress.pct);
   let sprintName = $derived(store.sprint ? store.sprint.name : null);
+  // Count shown next to "Board" : active-sprint stories (the board is scoped to
+  // the active sprint), falling back to the full set when no active sprint.
+  let boardCount = $derived(
+    store.sprint?.sprint_id
+      ? store.stories.filter((s) => s.sprint_id === store.sprint.sprint_id).length
+      : store.stories.length,
+  );
 </script>
 
 <a href="#main" class="skip-link">Skip to main content</a>
@@ -75,7 +84,7 @@
         >
           <Icon name={item.icon} cls="ico" size={18} />
           {item.label}
-          {#if item.path === '/kanban'}<span class="nav-count mono">{store.stories.length}</span>{/if}
+          {#if item.path === '/kanban'}<span class="nav-count mono">{boardCount}</span>{/if}
         </a>
       {/each}
     </nav>

--- a/cli/kanban/client/src/components/TaskProgress.svelte
+++ b/cli/kanban/client/src/components/TaskProgress.svelte
@@ -1,11 +1,14 @@
 <script>
   /**
    * Tâches au format Svelte : { total, completed }.
-   * @type {{ tasks?: { total?: number, completed?: number } }}
+   * `status` réconcilie le compteur : une story `done` dont le compteur de
+   * tâches n'a pas été recalé (cas BMAD : TT-* terminées avec completed:0)
+   * est affichée comme complète (bug #12) plutôt que trompeusement 0/N.
+   * @type {{ tasks?: { total?: number, completed?: number }, status?: string }}
    */
-  let { tasks } = $props();
+  let { tasks, status = '' } = $props();
   let total = $derived(tasks?.total ?? 0);
-  let done = $derived(tasks?.completed ?? 0);
+  let done = $derived(status === 'done' && total > 0 ? total : (tasks?.completed ?? 0));
   let pct = $derived(total ? (done / total) * 100 : 0);
 </script>
 

--- a/cli/kanban/client/src/lib/burndown.js
+++ b/cli/kanban/client/src/lib/burndown.js
@@ -1,0 +1,21 @@
+// Burndown table join. Pure (no DOM).
+// Bug #8: the sr-only accessible table paired ideal[i] with actual[i] by array
+// index, but the two series have different lengths (actual is event-driven).
+// Join by DATE instead so each row is coherent.
+
+/**
+ * @param {Array<{date:string,points:number}>} ideal
+ * @param {Array<{date:string,points:number}>} actual
+ * @returns {Array<{date:string, ideal:number|null, actual:number|null}>}
+ *   one row per distinct date, ascending.
+ */
+export function alignBurndownByDate(ideal = [], actual = []) {
+  const idealByDate = new Map(ideal.map((p) => [p.date, p.points]));
+  const actualByDate = new Map(actual.map((p) => [p.date, p.points]));
+  const dates = [...new Set([...idealByDate.keys(), ...actualByDate.keys()])].sort((a, b) => a.localeCompare(b));
+  return dates.map((date) => ({
+    date,
+    ideal: idealByDate.has(date) ? idealByDate.get(date) : null,
+    actual: actualByDate.has(date) ? actualByDate.get(date) : null,
+  }));
+}

--- a/cli/kanban/client/src/lib/config.js
+++ b/cli/kanban/client/src/lib/config.js
@@ -30,13 +30,17 @@ export const TDD = {
   done: { label: 'Done', cssVar: '--success' },
 };
 
-/** Couleurs par type de tâche (modale détail). */
+/** Couleurs par type de tâche (modale détail). Clés alignées sur le schéma
+ *  TASK_TYPES = ['DB','BE','FE-WEB','FE-MOB','TEST','DOC','OPS','REV']. */
 export const TASK_TYPE = {
   DB: 'oklch(0.74 0.13 300)',
   BE: 'oklch(0.74 0.13 236)',
-  FE: 'oklch(0.80 0.14 145)',
+  'FE-WEB': 'oklch(0.80 0.14 145)',
+  'FE-MOB': 'oklch(0.80 0.14 175)',
   TEST: 'oklch(0.82 0.14 60)',
-  DOCS: 'oklch(0.70 0.02 264)',
+  DOC: 'oklch(0.70 0.02 264)',
+  OPS: 'oklch(0.74 0.13 30)',
+  REV: 'oklch(0.74 0.13 330)',
 };
 
 /** Schémas de code couleur proposés par le panneau Tweaks. */

--- a/cli/kanban/client/src/lib/events.js
+++ b/cli/kanban/client/src/lib/events.js
@@ -1,0 +1,21 @@
+// SSE event classification for the reactive store. Pure (no DOM).
+// Bug #7: connectEvents() reloaded stories but never the sprint/burndown, so the
+// chart and topbar progress went stale after a card moved. This decides what to
+// refresh for a given event.
+
+const STORY_RELEVANT_CATEGORIES = new Set(['story', 'task', 'epic']);
+
+/**
+ * @param {{event?:string, payload?:{category?:string}}} msg
+ * @returns {{ reloadStories:boolean, reloadSprint:boolean }}
+ */
+export function classifyKanbanEvent(msg) {
+  const event = msg?.event;
+  if (event === 'story:updated') {
+    return { reloadStories: true, reloadSprint: true };
+  }
+  if (event === 'file:changed' && STORY_RELEVANT_CATEGORIES.has(msg?.payload?.category)) {
+    return { reloadStories: true, reloadSprint: true };
+  }
+  return { reloadStories: false, reloadSprint: false };
+}

--- a/cli/kanban/client/src/lib/progress.js
+++ b/cli/kanban/client/src/lib/progress.js
@@ -1,0 +1,16 @@
+// Sprint progress roll-up for the App topbar/sidebar bar. Pure (no DOM).
+// Bug #6: the bar previously summed ALL stories regardless of sprint, inflating
+// the metric and contradicting the Burndown screen. Scope it to the active sprint.
+
+/**
+ * @param {Array<{sprint_id?:string,status?:string,story_points?:number}>} stories
+ * @param {string|null|undefined} sprintId  active sprint id
+ * @returns {{ totalPoints:number, donePoints:number, pct:number }}
+ */
+export function computeSprintProgress(stories, sprintId) {
+  const mine = sprintId ? (stories ?? []).filter((s) => s.sprint_id === sprintId) : [];
+  const totalPoints = mine.reduce((n, s) => n + (s.story_points ?? 0), 0);
+  const donePoints = mine.filter((s) => s.status === 'done').reduce((n, s) => n + (s.story_points ?? 0), 0);
+  const pct = totalPoints > 0 ? Math.round((donePoints / totalPoints) * 100) : 0;
+  return { totalPoints, donePoints, pct };
+}

--- a/cli/kanban/client/src/lib/store.svelte.js
+++ b/cli/kanban/client/src/lib/store.svelte.js
@@ -1,6 +1,8 @@
 // Central store for the Kanban UI, backed by Svelte 5 runes.
 // Normalized caches + SSE-driven invalidation.
 
+import { classifyKanbanEvent } from './events.js';
+
 export const store = $state({
   stories: [],
   epics: [],
@@ -108,18 +110,23 @@ export function connectEvents() {
   es.addEventListener('error', () => {
     store.connected = false;
   });
-  es.addEventListener('story:updated', async () => {
-    await loadStories();
-  });
-  es.addEventListener('file:changed', async (e) => {
+  // Both story moves and relevant file changes must refresh the board AND the
+  // sprint/burndown (bug #7: the chart + topbar progress went stale otherwise).
+  const refresh = async ({ reloadStories, reloadSprint }) => {
+    const jobs = [];
+    if (reloadStories) jobs.push(loadStories());
+    if (reloadSprint) jobs.push(loadSprint());
+    if (jobs.length) await Promise.all(jobs);
+  };
+  es.addEventListener('story:updated', () => refresh(classifyKanbanEvent({ event: 'story:updated' })));
+  es.addEventListener('file:changed', (e) => {
+    let payload;
     try {
-      const { payload } = JSON.parse(e.data);
-      if (payload?.category === 'story' || payload?.category === 'task' || payload?.category === 'epic') {
-        await loadStories();
-      }
+      ({ payload } = JSON.parse(e.data));
     } catch {
-      await loadStories();
+      payload = undefined;
     }
+    return refresh(classifyKanbanEvent({ event: 'file:changed', payload }));
   });
 }
 

--- a/cli/kanban/client/src/views/BurndownView.svelte
+++ b/cli/kanban/client/src/views/BurndownView.svelte
@@ -1,10 +1,19 @@
 <script>
   import { store } from '../lib/store.svelte.js';
+  import { alignBurndownByDate } from '../lib/burndown.js';
   import uPlot from 'uplot';
   import 'uplot/dist/uPlot.min.css';
 
+  // sr-only table rows joined by DATE (bug #8 : was joined by array index, which
+  // mismatched because ideal has one row/day and actual is event-driven).
+  const tableRows = $derived(alignBurndownByDate(store.burndown?.ideal ?? [], store.burndown?.actual ?? []));
+
   let chartContainer = $state(null);
-  let chart = $state(null);
+  // Plain `let` (NOT $state) : the chart instance is read AND written inside the
+  // $effect below. As $state it made the effect depend on its own write → a
+  // reactive loop that spawned duplicate uPlot canvases and starved the event
+  // loop (hashchange could no longer flush, freezing route changes on this view).
+  let chart = null;
 
   const hasData = $derived(store.burndown?.ideal?.length > 0);
 
@@ -122,8 +131,8 @@
             <tr><th scope="col">Date</th><th scope="col">Points idéal</th><th scope="col">Points réel</th></tr>
           </thead>
           <tbody>
-            {#each store.burndown?.ideal ?? [] as point, i}
-              <tr><td>{point.date}</td><td>{point.points}</td><td>{store.burndown?.actual?.[i]?.points ?? '—'}</td></tr>
+            {#each tableRows as row}
+              <tr><td>{row.date}</td><td>{row.ideal ?? '—'}</td><td>{row.actual ?? '—'}</td></tr>
             {/each}
           </tbody>
         </table>

--- a/cli/kanban/client/src/views/DepsView.svelte
+++ b/cli/kanban/client/src/views/DepsView.svelte
@@ -174,7 +174,8 @@
       <div class="sr-only">
         <h2>Dependency edges (text fallback)</h2>
         <ul>
-          {#each edges as edge}<li>{edge.from} depends on {edge.to}</li>{/each}
+          <!-- edge = { from: prerequisite, to: dependent } : "to depends on from". -->
+          {#each edges as edge}<li>{edge.to} depends on {edge.from}</li>{/each}
         </ul>
       </div>
     </div>

--- a/cli/kanban/client/src/views/KanbanView.svelte
+++ b/cli/kanban/client/src/views/KanbanView.svelte
@@ -55,9 +55,18 @@
   }
   const visible = (s) => priFilter.length === 0 || priFilter.includes(s.priority);
 
+  // The board shows the ACTIVE sprint only. store.stories now also carries the
+  // history of closed sprints (read-only) ; without this scope the Done column
+  // would be flooded with dozens of archived stories and the metrics would be
+  // incoherent with the Burndown/topbar (sprint-scoped).
+  const activeSprintId = $derived(store.sprint?.sprint_id ?? null);
+  const boardStories = $derived(
+    activeSprintId ? store.stories.filter((s) => s.sprint_id === activeSprintId) : store.stories,
+  );
+
   const storiesByStatus = $derived.by(() => {
     const map = Object.fromEntries(COLUMNS.map((c) => [c.key, []]));
-    for (const s of store.stories) {
+    for (const s of boardStories) {
       if (!visible(s)) continue;
       (map[s.status] ??= []).push(s);
     }
@@ -73,7 +82,7 @@
     if (sc === 'tdd') return [['Red', 'var(--tdd-red)'], ['Green', 'var(--tdd-green)'], ['Refactor', 'var(--tdd-refactor)']];
     if (sc === 'epic') {
       const seen = new Map();
-      for (const s of store.stories) if (s.epic_id && !seen.has(s.epic_id)) seen.set(s.epic_id, epicHue(s.epic_id));
+      for (const s of boardStories) if (s.epic_id && !seen.has(s.epic_id)) seen.set(s.epic_id, epicHue(s.epic_id));
       return [...seen.entries()];
     }
     return COLUMNS.map((c) => [c.label, `var(${STATUS[c.key].cssVar})`]);
@@ -377,7 +386,7 @@
               {#if s.status === 'blocked' && s.blocked_reason}
                 <span class="card-blocked" title={s.blocked_reason}>⚠ blocked</span>
               {/if}
-              <TaskProgress tasks={s.tasks} />
+              <TaskProgress tasks={s.tasks} status={s.status} />
               <Avatar id={s.assigned_to} size={24} />
             </div>
           </li>

--- a/cli/kanban/client/src/views/SprintsView.svelte
+++ b/cli/kanban/client/src/views/SprintsView.svelte
@@ -138,8 +138,15 @@
         <div class="sd-head">
           <div style="flex:1">
             <div style="display:flex; align-items:center; gap:11px">
-              <h2>{detail.sprint.id}</h2>
+              <h2>{detail.sprint.name || detail.sprint.id}</h2>
               <span class="si-state {state}" style="font-size:11px">{state}</span>
+            </div>
+            <div class="sd-sub">
+              <span class="mono">{detail.sprint.id}</span>
+              {#if detail.sprint.epic}<span class="tag-mini">{detail.sprint.epic}</span>{/if}
+              {#if detail.sprint.start_date}<span>{detail.sprint.start_date} → {detail.sprint.end_date || '…'}</span>
+              {:else if detail.sprint.end_date}<span>clôturé le {detail.sprint.end_date}</span>{/if}
+              {#if detail.sprint.points_delivered != null}<span>{detail.sprint.points_delivered} pts livrés</span>{/if}
             </div>
           </div>
         </div>
@@ -173,6 +180,7 @@
                   {/if}
                   <span class="s-id mono">{st.id}</span>
                   <span class="s-t">{st.title}</span>
+                  {#if st.assigned_to}<span class="s-assignee mono">{st.assigned_to}</span>{/if}
                   <span class="s-status">
                     <i style="width:8px;height:8px;border-radius:50%;background: var({STATUS[st.status]?.cssVar || '--fg-faint'});display:inline-block"></i>{STATUS[st.status]?.label || st.status}
                   </span>
@@ -218,6 +226,14 @@
 </div>
 
 <style>
+  .sd-sub {
+    display: flex; flex-wrap: wrap; gap: 10px; align-items: center;
+    margin-top: 6px; font-size: 12px; color: var(--fg-faint);
+  }
+  .s-assignee {
+    font-size: 11px; color: var(--fg-dim); padding: 1px 6px;
+    background: var(--bg-inset); border-radius: 5px;
+  }
   .si-tags { display: flex; gap: 5px; margin-top: 9px; }
   .tag-mini {
     font-family: var(--mono); font-size: 9.5px; font-weight: 600; text-transform: uppercase;

--- a/cli/kanban/server/app.js
+++ b/cli/kanban/server/app.js
@@ -216,14 +216,55 @@ export function createApp({ repository, port, readonly = false, eventBus = null,
     });
   });
 
+  // Resolve display metadata (name, dates, epic) for a sprint id from
+  // sprint-status.yaml — current sprint via metadata, closed sprints via
+  // archived_sprints. Gives all sprint endpoints a coherent shape.
+  const sprintMeta = (ss, id) => {
+    const base = { name: id, start_date: '', end_date: '', epic: '', points_delivered: null };
+    if (!ss || ss._invalid) return base;
+    if (ss.metadata?.sprint_id === id) {
+      return {
+        name: ss.metadata.name ?? id,
+        start_date: ss.metadata.start_date ?? '',
+        end_date: ss.metadata.end_date ?? '',
+        epic: ss.metadata.epic ?? '',
+        points_delivered: null,
+      };
+    }
+    const a = ss.archived_sprints?.[id];
+    if (a) {
+      return {
+        name: a.name ?? id,
+        start_date: '',
+        end_date: a.closed_date ?? '',
+        epic: a.epic ?? '',
+        points_delivered: a.points_delivered ?? null,
+      };
+    }
+    return base;
+  };
+
+  const loadStatusSafe = async () => {
+    try {
+      return await loadSprintStatus(resolvedProjectRoot);
+    } catch {
+      return null;
+    }
+  };
+
   // List every scanned sprint with rolled-up story/point counts.
   // Declared after /api/sprints/current so :id below never captures "current".
-  app.get('/api/sprints', (c) => {
+  app.get('/api/sprints', async (c) => {
+    const ss = await loadStatusSafe();
     const allStories = repository.listStories();
     const sprints = repository.listSprints().map((s) => {
       const stories = allStories.filter((st) => st.sprint_id === s.id);
+      const meta = sprintMeta(ss, s.id);
       return {
         ...s,
+        name: meta.name,
+        epic: meta.epic,
+        points_delivered: meta.points_delivered,
         story_count: stories.length,
         total_points: stories.reduce((n, st) => n + (st.story_points ?? 0), 0),
         done_points: stories.filter((st) => st.status === 'done').reduce((n, st) => n + (st.story_points ?? 0), 0),
@@ -257,14 +298,26 @@ export function createApp({ repository, port, readonly = false, eventBus = null,
     const reviewFile = sprint.files.find((f) => f.category === 'sprint-review')?.path ?? null;
     const retroFile = sprint.files.find((f) => f.category === 'sprint-retro')?.path ?? null;
 
-    const [goal, review, retro] = await Promise.all([
+    const [goal, review, retro, ss] = await Promise.all([
       readIfExists(goalFile),
       readIfExists(reviewFile),
       readIfExists(retroFile),
+      loadStatusSafe(),
     ]);
+    const meta = sprintMeta(ss, id);
 
     return c.json({
-      sprint: { id, has_goal: !!goalFile, has_review: !!reviewFile, has_retro: !!retroFile },
+      sprint: {
+        id,
+        name: meta.name,
+        start_date: meta.start_date,
+        end_date: meta.end_date,
+        epic: meta.epic,
+        points_delivered: meta.points_delivered,
+        has_goal: !!goalFile,
+        has_review: !!reviewFile,
+        has_retro: !!retroFile,
+      },
       stories: stories.map((s) => ({
         id: s.id,
         title: s.title,

--- a/cli/kanban/server/services/repository.js
+++ b/cli/kanban/server/services/repository.js
@@ -4,12 +4,16 @@ import { scan, groupByCategory } from './file-scanner.js';
 import { parseAndValidate } from './frontmatter.js';
 import { loadSprintStatus } from './sprint-cache.js';
 import { StoryFrontmatterSchema, EpicFrontmatterSchema, TaskFrontmatterSchema } from '../../shared/schemas.js';
+import { mapBmadPriority } from '../../shared/priority.js';
+import { parseDependencyRefs } from '../../shared/deps.js';
 
 /**
  * In-memory cache of parsed project-management/ entities.
  * Rebuilt via refresh() ; individual files can be reloaded via reloadFile(path).
  */
 export class Repository {
+  #statusCache = undefined;
+
   constructor(rootDir) {
     this.rootDir = path.resolve(rootDir);
     this.stories = new Map(); // id -> { data, body, path, mtime, valid, errors? }
@@ -28,6 +32,7 @@ export class Repository {
     this.docs.clear();
     this.sprints.clear();
     this.filesByPath.clear();
+    this.#statusCache = undefined;
 
     const groups = groupByCategory(files);
 
@@ -93,6 +98,21 @@ export class Repository {
     // BMAD v6 single-writer track stores stories only in .bmad/sprint-status.yaml
     // (no individual markdown files). Surface them so the board isn't empty.
     await this.#ingestSprintStatusStories();
+    // Closed sprints live under archived_sprints.* — surface their stories
+    // (read-only history) so Sprints/Backlog/Burndown aren't limited to S-current.
+    await this.#ingestArchivedSprints();
+  }
+
+  /** Cached parse of .bmad/sprint-status.yaml, shared by the two overlay passes. */
+  async #loadStatusOnce() {
+    if (this.#statusCache !== undefined) return this.#statusCache;
+    const projectRoot = path.dirname(this.rootDir);
+    try {
+      this.#statusCache = await loadSprintStatus(projectRoot);
+    } catch {
+      this.#statusCache = null;
+    }
+    return this.#statusCache;
   }
 
   /**
@@ -102,14 +122,7 @@ export class Repository {
    * double source of truth. Synthetic stories are read-only (path === null).
    */
   async #ingestSprintStatusStories() {
-    const projectRoot = path.dirname(this.rootDir);
-    let ss;
-    try {
-      ss = await loadSprintStatus(projectRoot);
-    } catch {
-      // A broken sprint-status.yaml must not break the whole board scan.
-      return;
-    }
+    const ss = await this.#loadStatusOnce();
     if (!ss || ss._invalid || !ss.stories) return;
 
     const sprintId = ss.metadata?.sprint_id ?? null;
@@ -131,14 +144,57 @@ export class Repository {
           tdd_phase: s.tdd_phase ?? '',
           story_points: s.story_points ?? 0,
           epic_id: s.epic_id || epicFromMeta || null,
-          // BMAD priorities are P0..P3 (outside the must/should/could/wont enum),
-          // so we don't map them; the board just needs a valid default.
-          priority: 'should',
+          // Map BMAD P0..P3 onto MoSCoW so PriorityChip/filter aren't all "Should".
+          priority: mapBmadPriority(s.priority),
+          priority_raw: s.priority ?? null,
           sprint_id: sprintId,
+          blocked_reason: s.blocked_reason ?? '',
           tasks: s.tasks ?? { total: 0, completed: 0, list: [] },
-          dependencies: [],
+          // Freeform yaml deps -> resolved id references for the graph.
+          dependencies: parseDependencyRefs(s.dependencies),
         },
       });
+    }
+  }
+
+  /**
+   * Overlay stories from closed sprints (archived_sprints.<sprintKey>.stories).
+   * These are read-only history: status as recorded (done/deferred/…), points
+   * from the compact `points` field, epic from the sprint entry. A story id
+   * already present (current sprint or an earlier-listed archived sprint) wins,
+   * keeping ids globally unique as the board model requires.
+   */
+  async #ingestArchivedSprints() {
+    const ss = await this.#loadStatusOnce();
+    if (!ss || ss._invalid || !ss.archived_sprints) return;
+
+    for (const [sprintKey, sprint] of Object.entries(ss.archived_sprints)) {
+      const epic = sprint?.epic ?? null;
+      const stories = sprint?.stories ?? {};
+      for (const [id, s] of Object.entries(stories)) {
+        if (this.stories.has(id)) continue; // current / earlier sprint wins
+        this.stories.set(id, {
+          path: null, // history -> read-only
+          mtime: 0,
+          ok: true,
+          source: 'archived',
+          data: {
+            id,
+            title: s.note ? `${id} — ${s.note}` : id,
+            status: s.status ?? 'done',
+            previous_status: '',
+            assigned_to: '',
+            tdd_phase: '',
+            story_points: s.points ?? 0,
+            epic_id: epic,
+            priority: 'should',
+            sprint_id: sprintKey,
+            blocked_reason: '',
+            tasks: { total: 0, completed: 0, list: [] },
+            dependencies: [],
+          },
+        });
+      }
     }
   }
 

--- a/cli/kanban/shared/deps.js
+++ b/cli/kanban/shared/deps.js
@@ -1,0 +1,24 @@
+// Extract story-id references from freeform BMAD dependency strings.
+// BMAD v6 yaml writes dependencies as prose, e.g.
+//   "US-E4-02 (modèle compte, S8, done)"
+//   "Config console AuthProvider (Phase 0, NON PRÊTE)"
+// The dependency graph needs the leading id token; non-id sentences yield nothing.
+
+// Accept epic-embedded ids (US-E4-02, US-E2-05a), numeric ids (US-200),
+// technical tasks (TT-20) and task ids (TASK-12).
+const ID_HEAD = /^\s*(US-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*|TT-\d+|TASK-[A-Za-z0-9-]+)\b/;
+
+/**
+ * @param {Array<string>|undefined|null} rawList
+ * @returns {string[]} unique id references, in first-seen order
+ */
+export function parseDependencyRefs(rawList) {
+  if (!Array.isArray(rawList)) return [];
+  const out = [];
+  for (const raw of rawList) {
+    if (typeof raw !== 'string') continue;
+    const m = raw.match(ID_HEAD);
+    if (m && !out.includes(m[1])) out.push(m[1]);
+  }
+  return out;
+}

--- a/cli/kanban/shared/priority.js
+++ b/cli/kanban/shared/priority.js
@@ -1,0 +1,18 @@
+// Map BMAD priorities (P0..P3) onto the board's MoSCoW enum.
+// BMAD v6 stories carry P0..P3 ; the kanban PriorityChip / filter only know
+// must/should/could/wont. Without this map every YAML story rendered "Should".
+
+const P_TO_MOSCOW = { P0: 'must', P1: 'should', P2: 'could', P3: 'wont' };
+const MOSCOW = new Set(['must', 'should', 'could', 'wont']);
+
+/**
+ * @param {string|undefined|null} raw  e.g. "P0", "must"
+ * @returns {'must'|'should'|'could'|'wont'}
+ */
+export function mapBmadPriority(raw) {
+  if (raw === null || raw === undefined) return 'should';
+  const v = String(raw).trim();
+  if (P_TO_MOSCOW[v.toUpperCase()]) return P_TO_MOSCOW[v.toUpperCase()];
+  if (MOSCOW.has(v.toLowerCase())) return v.toLowerCase();
+  return 'should';
+}

--- a/cli/kanban/shared/schemas.js
+++ b/cli/kanban/shared/schemas.js
@@ -80,36 +80,53 @@ export const TaskFrontmatterSchema = z
 export const SprintStatusSchema = z
   .object({
     version: z.string().default('1.0'),
-    metadata: z.object({
-      sprint_id: z.string(),
-      name: z.string(),
-      start_date: z.string(),
-      end_date: z.string(),
-      goal: z.string().default(''),
-      epic: z.string().optional().default(''),
-    }),
+    // metadata is passthrough so optional BMAD fields (capacity_points,
+    // capacity_note, last_sync, …) survive validation and reach the burndown
+    // / sprint screens instead of being silently stripped.
+    metadata: z
+      .object({
+        sprint_id: z.string(),
+        name: z.string(),
+        start_date: z.string(),
+        end_date: z.string(),
+        goal: z.string().default(''),
+        epic: z.string().optional().default(''),
+        capacity_points: z.number().int().min(0).optional(),
+        capacity_note: z.string().optional().default(''),
+      })
+      .passthrough(),
     stories: z
       .record(
-        z.object({
-          title: z.string(),
-          status: StoryStatusSchema,
-          previous_status: z.string().optional().default(''),
-          assigned_to: z.string().optional().default(''),
-          tdd_phase: TddPhaseSchema.optional().default(''),
-          story_points: z.number().int().min(0).default(0),
-          epic_id: z.string().optional().default(''),
-          tasks: z
-            .object({
-              total: z.number().int().min(0).default(0),
-              completed: z.number().int().min(0).default(0),
-              list: z.array(z.string()).default([]),
-            })
-            .optional(),
-          history: z.array(HistoryEntrySchema).optional().default([]),
-        })
+        z
+          .object({
+            title: z.string(),
+            status: StoryStatusSchema,
+            previous_status: z.string().optional().default(''),
+            // Real BMAD v6 yaml uses assigned_to: null for unassigned stories.
+            // Rejecting null here flagged the WHOLE file invalid → empty board.
+            assigned_to: z.string().nullable().optional().default(''),
+            // tdd_phase is loose: BMAD writes "not-started"/"review" outside the
+            // strict enum; the UI tolerates unknown phases. Don't reject the file.
+            tdd_phase: z.string().optional().default(''),
+            story_points: z.number().int().min(0).default(0),
+            epic_id: z.string().optional().default(''),
+            tasks: z
+              .object({
+                total: z.number().int().min(0).default(0),
+                completed: z.number().int().min(0).default(0),
+                list: z.array(z.string()).default([]),
+              })
+              .optional(),
+            history: z.array(HistoryEntrySchema).optional().default([]),
+          })
+          // passthrough keeps priority (P0..P3), platform, dependencies, note…
+          // so the ingestion layer can map/surface them.
+          .passthrough()
       )
       .default({}),
   })
+  // top-level passthrough preserves archived_sprints, routing, gates,
+  // state_machine, last_sync for downstream ingestion.
   .passthrough();
 
 export const TransitionRequestSchema = z.object({

--- a/tests/fixtures/wrandly-anon/.bmad/sprint-status.yaml
+++ b/tests/fixtures/wrandly-anon/.bmad/sprint-status.yaml
@@ -1,0 +1,388 @@
+# BMAD v6 - Sprint Status (ANONYMIZED FIXTURE — product "Atlas")
+# Derived structurally from a real BMAD v6 project, fully anonymized.
+# Purpose: exercise every kanban screen with the full data variety that
+# triggers display bugs (archived sprints, P0-P3 priorities, null/role
+# assignees, 0-point technical tasks, done-with-incomplete-tasks, freeform
+# dependencies, deferred status, carry-over, long accented titles, split story).
+
+version: "1.0"
+last_sync: "2026-06-15T12:00:00Z"
+
+metadata:
+  sprint_id: "sprint-9-auth-premium"
+  name: "Auth (finalisation) + Premium web (E4)"
+  start_date: "2026-07-27"
+  end_date: "2026-08-07"
+  goal: "Finaliser l'authentification fédérée (flux device) et ouvrir la monétisation : l'utilisateur web peut s'abonner Premium (checkout, abonnement actif, annulation, réconciliation webhooks)."
+  capacity_points: 13
+  epic: "E4"
+  capacity_note: "Sous-engagement assumé : 13 SP métier vs vélocité ~21 (moyenne S6-S8). Buffer volontaire car Phase 0 (configs console externes) NON PRÊTE -> flux réels restent stubs sans config externe."
+
+# Sprints clôturés. Détail dans project-management/sprints/*/sprint-review.md
+archived_sprints:
+  sprint-1-infrastructure:
+    name: "Infrastructure & Tokens"
+    epic: "E0"
+    points_delivered: 25
+    closed_date: "2026-06-12"
+    stories:
+      US-E0-01: { status: done, points: 3, commit: "a1b2c3d" }
+      US-E0-02: { status: done, points: 5, commit: "b2c3d4e" }
+      US-E0-03a: { status: done, points: 3, commit: "c3d4e5f" }
+      US-E0-03b: { status: done, points: 3, commit: "d4e5f60" }
+      US-E0-03c: { status: done, points: 2, commit: "e5f6071" }
+      US-E0-03d: { status: done, points: 2, commit: "f607182" }
+      US-E0-04: { status: done, points: 5, commit: "0718293" }
+      US-E0-05: { status: done, points: 2, commit: "18293a4" }
+  sprint-2-design-system:
+    name: "Design System (Foundations)"
+    epic: "E1"
+    points_delivered: 25
+    closed_date: "2026-06-12"
+    review_date: "2026-06-12"
+    retro_date: "2026-06-12"
+    retro_format: "Starfish"
+    stories:
+      US-E1-01: { status: done, points: 3 }
+      US-E1-02: { status: done, points: 8 }
+      US-E1-03: { status: done, points: 3 }
+      US-E1-04: { status: done, points: 8 }
+      US-E1-05: { status: done, points: 3 }
+      TT-01: { status: done, points: 0, note: "couverture 80% CI (rétro #1)" }
+      TT-02: { status: done, points: 0, note: "lint-api (rétro #2)" }
+      TT-03: { status: deferred, points: 0, note: "émulateur cartographie bloqué -> reframe golden tests en S3 (rétro #1)" }
+  sprint-3-generation:
+    name: "Génération + Fiche Détail"
+    epic: "E2"
+    points_delivered: 25
+    closed_date: "2026-06-14"
+    review_date: "2026-06-14"
+    retro_date: "2026-06-14"
+    retro_format: "Starfish"
+    stories:
+      TT-04: { status: done, points: 8, commit: "293a4b5", note: "Bootstrap API + ORM + JWT ES256 + auth anonyme" }
+      US-E2-03: { status: done, points: 8, commit: "3a4b5c6", note: "Backend ProviderAI, 48 tests, rate-limit" }
+      US-E2-01: { status: done, points: 8, commit: "4b5c6d7", note: "Formulaire web+mobile, parité, 52+60 tests" }
+      TT-03: { status: done, points: 1, commit: "5c6d7e8", note: "Golden tests carte offscreen" }
+    deferred:
+      US-E2-04: { note: "Stretch/S4 dès le planning, débloquée par TT-03" }
+  sprint-4-detail-navigation:
+    name: "Fiche Détail + Écran Chargement + Navigation Temps Réel"
+    epic: "E2"
+    points_delivered: 22
+    closed_date: "2026-06-14"
+    review_date: "2026-06-14"
+    retro_date: "2026-06-14"
+    retro_format: "Starfish"
+    stories:
+      TT-05: { status: done, points: 1, note: "Durcir gates lint" }
+      TT-06: { status: done, points: 1, note: "Docker policy par stack" }
+      TT-07: { status: done, points: 2, note: "Refactor mock ProviderAIClient" }
+      US-E2-04: { status: done, points: 8, note: "Fiche détail + carte" }
+      US-E2-02: { status: done, points: 5, note: "Écran chargement IA" }
+      US-E2-05a: { status: done, points: 5, note: "Suivi position temps réel" }
+  sprint-5-navigation-finale:
+    name: "Navigation Finale + Mode Surprise"
+    epic: "E5"
+    points_delivered: 16
+    closed_date: "2026-06-14"
+    review_date: "2026-06-14"
+    retro_date: "2026-06-14"
+    retro_format: "Mad-Sad-Glad"
+    stories:
+      US-E2-05b: { status: done, points: 5, note: "Navigation pas-à-pas" }
+      US-E5-01: { status: done, points: 8, note: "Mode surprise (tirage)" }
+      TT-08: { status: done, points: 3, note: "Stabiliser tests temps réel" }
+  sprint-6-library-gamification:
+    name: "Bibliothèque + Gamification"
+    epic: "E3"
+    points_delivered: 24
+    closed_date: "2026-06-14"
+    review_date: "2026-06-14"
+    retro_date: "2026-06-14"
+    retro_format: "Starfish"
+    merge_commit: "6d7e8f9"
+    stories:
+      US-E3-01: { status: done, points: 8, note: "Bibliothèque (liste + détail)" }
+      US-E3-02: { status: done, points: 8, note: "Points & niveaux" }
+      US-E3-03: { status: done, points: 5, note: "Historique d'activité" }
+      US-E3-04: { status: done, points: 3, note: "Partage social" }
+  sprint-7-badges-leaderboard:
+    name: "Badges + Classement"
+    epic: "E3"
+    points_delivered: 19
+    closed_date: "2026-06-14"
+    review_date: "2026-06-14"
+    retro_date: "2026-06-14"
+    retro_format: "Starfish"
+    merge_commit: "7e8f9a0"
+    stories:
+      US-E3-05: { status: done, points: 8, note: "Badges & succès" }
+      US-E3-06: { status: done, points: 8, note: "Classement (leaderboard)" }
+      TT-09: { status: done, points: 3, note: "Perf requêtes classement" }
+    deferred:
+      US-E3-07: { note: "Notifications succès -> S8" }
+  sprint-8-auth-settings:
+    name: "Auth + Réglages + RGPD"
+    epic: "E4"
+    points_delivered: 21
+    closed_date: "2026-06-15"
+    review_date: "2026-06-15"
+    retro_date: "2026-06-15"
+    retro_format: "Starfish"
+    stories:
+      US-E4-01: { status: done, points: 5, note: "Inscription / connexion email" }
+      US-E4-02: { status: done, points: 5, note: "Modèle compte + RGPD (export/suppression)" }
+      US-E4-04: { status: done, points: 3, note: "Écran réglages" }
+      US-E3-07: { status: done, points: 3, note: "Notifications succès (carry-over S7)" }
+      TT-10: { status: done, points: 0, note: "Audit RGPD" }
+    carry_over:
+      US-E4-03: { note: "Auth fédérée -> S9. Backend+plumbing testés, flux device stub (Phase 0 NON PRÊTE)." }
+    deferred:
+      US-E4-05: { note: "Suppression de compte différée détaillée -> S10" }
+
+# Sprint courant — stories complètes (machine-readable, source de vérité du board)
+stories:
+  TT-20:
+    title: "Verrou couche partagée : 1 seul worker concurrent par couche transverse"
+    status: "done"
+    previous_status: "review"
+    assigned_to: "conductor"
+    story_points: 0
+    priority: "P0"
+    platform: "Process"
+    tdd_phase: "done"
+    current_task: "Action rétro RETRO-S8-1. Verrou implémenté."
+    note: "Tâche technique transverse (0 SP). Compteur de tâches volontairement non recalé."
+    tasks:
+      total: 3
+      completed: 0
+      list:
+        - "Définir la politique de verrou par couche (TT20-01)"
+        - "Implémenter le lock fichier (TT20-02)"
+        - "Tests concurrence (TT20-03)"
+    dependencies: []
+    acceptance_criteria: "Un seul worker modifie une couche transverse à la fois."
+    traceability:
+      implements: "RETRO-S8-1"
+    history: []
+
+  US-E4-03:
+    title: "Auth fédérée AuthProvider A + B (finalisation flux device)"
+    status: "in-progress"
+    previous_status: "review"
+    assigned_to: null
+    story_points: 5
+    priority: "P0"
+    platform: "Web + Mobile"
+    tdd_phase: "green"
+    current_task: "Carry-over S8. Backend POST /auth/oauth/{provider} + plumbing testés. Reste : finaliser flux device réel après Phase 0 config console."
+    carry_over: "Carry-over depuis S8. Repris en S9."
+    note: "ATTENTION Phase 0 NON PRÊTE (config console AuthProvider). Sans Phase 0, flux device reste stub."
+    tasks:
+      total: 5
+      completed: 3
+      list:
+        - "Backend : POST /api/v1/auth/oauth/{provider} - FAIT S8"
+        - "Backend : liaison compte si email existe déjà - FAIT S8"
+        - "Mobile : flux fédéré natif - stub, finaliser post Phase 0"
+        - "Web : flux fédéré redirect - stub, finaliser post Phase 0"
+        - "Tests backend (FAIT) + mobile + web flux réel post Phase 0"
+    dependencies:
+      - "US-E4-02 (modèle compte, S8, done)"
+      - "Config console AuthProvider (Phase 0, NON PRÊTE)"
+    acceptance_criteria: "Flux device fédéré fonctionnels (post Phase 0), liaison compte. Tests >= 80%."
+    traceability:
+      implements: "E4"
+    history: []
+
+  US-E4-07a:
+    title: "Premium web : checkout + abonnement actif"
+    status: "ready-for-dev"
+    previous_status: "backlog"
+    assigned_to: null
+    story_points: 5
+    priority: "P0"
+    platform: "Web + Backend"
+    tdd_phase: "not-started"
+    current_task: "Découpe de US-E4-07 (8 SP) par couche (RETRO-S7-4). Slice checkout + lecture plan actif."
+    note: "ATTENTION Phase 0 NON PRÊTE (compte PaymentProvider + produits/prix). Checkout réel stub sans config."
+    tasks:
+      total: 5
+      completed: 0
+      list:
+        - "Backend : POST /api/v1/subscriptions/checkout (session PaymentProvider)"
+        - "Backend : GET /api/v1/subscriptions/current (plan actif + entitlements)"
+        - "Web : page Premium plans (mensuel/annuel) + redirect"
+        - "Backend : système entitlements unifié"
+        - "Tests backend + web"
+    dependencies:
+      - "US-E4-02 (compte existant, S8, done)"
+      - "Config console PaymentProvider (Phase 0, NON PRÊTE)"
+    acceptance_criteria: "Checkout + plan actif + entitlements. Tests >= 80%."
+    traceability:
+      implements: "E4"
+    history: []
+
+  US-E4-07b:
+    title: "Premium web : annulation + réconciliation webhooks"
+    status: "ready-for-dev"
+    previous_status: "backlog"
+    assigned_to: "dev-worker-1"
+    story_points: 3
+    priority: "P1"
+    platform: "Web + Backend"
+    tdd_phase: "not-started"
+    current_task: "Découpe de US-E4-07 (8 SP) par couche (RETRO-S7-4). Slice annulation + webhooks réconciliation."
+    note: "Dépend US-E4-07a (checkout + entitlements). Webhooks testables en signature mock."
+    tasks:
+      total: 4
+      completed: 0
+      list:
+        - "Backend : POST /api/v1/subscriptions/cancel"
+        - "Backend : webhooks réconciliation"
+        - "Web : écran abonnement (plan, date renouvellement, annulation)"
+        - "Tests backend (cancel, webhooks signature) + web"
+    dependencies:
+      - "US-E4-07a (checkout + entitlements)"
+      - "Config webhooks (Phase 0, NON PRÊTE)"
+    acceptance_criteria: "Annulation fin de période + réconciliation webhooks. Tests >= 80%."
+    traceability:
+      implements: "E4"
+    history: []
+
+  US-E4-06:
+    title: "Blocage applicatif : quota dépassé sans Premium"
+    status: "blocked"
+    previous_status: "in-progress"
+    assigned_to: "claude"
+    story_points: 3
+    priority: "P2"
+    platform: "Web + Backend"
+    tdd_phase: "red"
+    current_task: "Bloquée : dépend de l'entitlements (US-E4-07a) non démarré."
+    blocked_reason: "Attend le système d'entitlements de US-E4-07a (Phase 0 NON PRÊTE)."
+    note: "Démontre le statut blocked + previous_status pour le routing de déblocage."
+    tasks:
+      total: 3
+      completed: 1
+      list:
+        - "Backend : compteur de quota par compte"
+        - "Backend : garde entitlements sur action premium"
+        - "Web : écran upsell quota dépassé"
+    dependencies:
+      - "US-E4-07a (entitlements)"
+    acceptance_criteria: "Quota appliqué, upsell affiché, déblocage à l'abonnement."
+    traceability:
+      implements: "E4"
+    history: []
+
+  US-E4-08:
+    title: "Premium mobile (achat in-app) — backlog non engagé"
+    status: "backlog"
+    previous_status: "backlog"
+    assigned_to: null
+    story_points: 8
+    priority: "P3"
+    platform: "Mobile"
+    tdd_phase: ""
+    current_task: "Reportée S10 (capacité). Présente en backlog pour visibilité."
+    note: "Story 8 SP volontairement hors capacité S9 (capacity 13)."
+    tasks:
+      total: 0
+      completed: 0
+      list: []
+    dependencies:
+      - "US-E4-07a (entitlements web d'abord)"
+    acceptance_criteria: "Achat in-app mobile + restauration. Tests >= 80%."
+    traceability:
+      implements: "E4"
+    history: []
+
+routing:
+  auto_transitions:
+    enabled: true
+    rules:
+      - name: "all_tasks_complete"
+        description: "Transition to review when all tasks are done"
+        when: "tasks.completed == tasks.total && tasks.total > 0"
+        from: "in-progress"
+        to: "review"
+      - name: "review_approved"
+        description: "Transition to done when review is approved"
+        when: "review.approved == true"
+        from: "review"
+        to: "done"
+      - name: "blocked_detection"
+        description: "Transition to blocked when blocker is detected"
+        when: "blocked_reason != null"
+        from: "*"
+        to: "blocked"
+      - name: "unblocked"
+        description: "Return to previous status when unblocked"
+        when: "blocked_reason == null && previous_status != null"
+        from: "blocked"
+        to: "previous_status"
+
+gates:
+  backlog:
+    description: "Story must meet INVEST criteria"
+    checks:
+      - "story_has_title"
+      - "story_has_description"
+  ready_for_dev:
+    description: "Story ready to be picked up by developer"
+    checks:
+      - "acceptance_criteria_defined"
+      - "story_points_estimated"
+      - "tasks_decomposed"
+      - "dependencies_resolved"
+  in_progress:
+    description: "Story is actively being worked on"
+    checks:
+      - "assigned_to_developer"
+      - "branch_created"
+  review:
+    description: "Story ready for code review"
+    checks:
+      - "all_tests_pass"
+      - "code_pushed"
+      - "pr_created"
+  done:
+    description: "Story meets Definition of Done"
+    checks:
+      - "code_reviewed"
+      - "tests_pass"
+      - "documentation_updated"
+      - "dod_satisfied"
+
+state_machine:
+  states:
+    - backlog
+    - ready-for-dev
+    - in-progress
+    - review
+    - done
+    - blocked
+  transitions:
+    - from: backlog
+      to: ready-for-dev
+      gate: ready_for_dev
+    - from: ready-for-dev
+      to: in-progress
+      gate: in_progress
+    - from: in-progress
+      to: review
+      gate: review
+    - from: review
+      to: done
+      gate: done
+    - from: review
+      to: in-progress
+      description: "Changes requested"
+    - from: "*"
+      to: blocked
+      description: "Story blocked"
+    - from: blocked
+      to: previous_status
+      description: "Story unblocked"

--- a/tests/fixtures/wrandly-anon/project-management/architecture/api.md
+++ b/tests/fixtures/wrandly-anon/project-management/architecture/api.md
@@ -1,0 +1,31 @@
+# API Atlas — Référence REST
+
+**Base URL :** `/api/v1`
+**Authentification :** Bearer token JWT ES256
+
+## Endpoints
+
+| Méthode | Chemin | Description |
+|---------|--------|-------------|
+| `POST` | `/auth/register` | Inscription par email |
+| `POST` | `/auth/login` | Connexion par email + mot de passe |
+| `POST` | `/auth/oauth/callback` | Callback OAuth (AuthProvider) |
+| `POST` | `/auth/refresh` | Renouvellement du token JWT |
+| `DELETE` | `/auth/logout` | Révocation du token |
+| `POST` | `/itineraries/generate` | Génération d'un itinéraire via ProviderAI |
+| `GET` | `/itineraries` | Liste des itinéraires de l'utilisateur (paginée) |
+| `GET` | `/itineraries/:id` | Détail d'un itinéraire |
+| `PATCH` | `/itineraries/:id` | Modification d'un itinéraire |
+| `DELETE` | `/itineraries/:id` | Suppression d'un itinéraire |
+| `GET` | `/itineraries/:id/share` | Génération du lien de partage public |
+| `GET` | `/profile` | Profil de l'utilisateur connecté |
+| `PATCH` | `/profile` | Mise à jour du profil |
+| `GET` | `/badges` | Badges de l'utilisateur |
+| `GET` | `/leaderboard` | Classement global (top 100) |
+| `GET` | `/subscriptions/plans` | Liste des offres premium |
+| `POST` | `/subscriptions` | Souscription premium via PaymentProvider |
+| `DELETE` | `/subscriptions/me` | Annulation de l'abonnement |
+
+## Codes d'erreur
+
+Erreurs au format RFC 9457 (`application/problem+json`).

--- a/tests/fixtures/wrandly-anon/project-management/architecture/c4-architecture.md
+++ b/tests/fixtures/wrandly-anon/project-management/architecture/c4-architecture.md
@@ -1,0 +1,34 @@
+# Architecture C4 — Atlas
+
+## Niveau 1 : Contexte
+
+```
+[Utilisateur] --> [Atlas Web / Mobile]
+[Atlas] --> [ProviderAI] : génération d'itinéraires
+[Atlas] --> [AuthProvider] : authentification OAuth
+[Atlas] --> [PaymentProvider] : gestion des abonnements
+```
+
+## Niveau 2 : Conteneurs
+
+| Conteneur | Technologie | Rôle |
+|-----------|------------|------|
+| **Application Web** | React 19 + TypeScript | SPA — interface utilisateur web |
+| **Application Mobile** | React Native 0.86 | App iOS et Android |
+| **API Gateway** | Node.js / Express | Point d'entrée unique, authentification JWT |
+| **Service Génération** | Python 3.14 + FastAPI | Appels ProviderAI, mise en file d'attente |
+| **Base de données** | PostgreSQL 17 | Données persistantes (accounts, items, badges) |
+| **Cache** | Redis 8 | Sessions, rate-limiting, tokens temporaires |
+| **File de messages** | RabbitMQ | Découplage génération asynchrone |
+
+## Niveau 3 : Composants (API Gateway)
+
+- **AuthController** — inscription, connexion, OAuth callback, refresh
+- **ItineraryController** — CRUD itinéraires, génération, partage
+- **ProfileController** — profil, badges, classement
+- **SubscriptionController** — offres, souscription, webhook PaymentProvider
+
+## Décisions architecturales clés
+
+- Séparation stateless entre API Gateway et Service Génération pour scalabilité indépendante
+- Tout secret stocké dans le vault — aucune variable sensible en clair dans les images Docker

--- a/tests/fixtures/wrandly-anon/project-management/architecture/erd.md
+++ b/tests/fixtures/wrandly-anon/project-management/architecture/erd.md
@@ -1,0 +1,59 @@
+# ERD — Atlas
+
+## Entités principales
+
+### Account
+
+| Colonne | Type | Contrainte |
+|---------|------|-----------|
+| `id` | UUID | PK |
+| `email` | VARCHAR(255) | UNIQUE, NOT NULL |
+| `password_hash` | VARCHAR(255) | nullable (OAuth) |
+| `provider` | ENUM('email','oauth') | NOT NULL |
+| `created_at` | TIMESTAMPTZ | NOT NULL |
+
+### Subscription
+
+| Colonne | Type | Contrainte |
+|---------|------|-----------|
+| `id` | UUID | PK |
+| `account_id` | UUID | FK → Account, NOT NULL |
+| `plan` | ENUM('free','premium') | NOT NULL |
+| `status` | ENUM('active','cancelled','expired') | NOT NULL |
+| `renews_at` | TIMESTAMPTZ | nullable |
+| `external_id` | VARCHAR(255) | référence PaymentProvider |
+
+### Item (Itinéraire)
+
+| Colonne | Type | Contrainte |
+|---------|------|-----------|
+| `id` | UUID | PK |
+| `account_id` | UUID | FK → Account |
+| `title` | VARCHAR(255) | NOT NULL |
+| `steps` | JSONB | NOT NULL |
+| `duration_min` | INT | NOT NULL |
+| `is_public` | BOOLEAN | DEFAULT false |
+| `created_at` | TIMESTAMPTZ | NOT NULL |
+
+### Activity (Complétion)
+
+| Colonne | Type | Contrainte |
+|---------|------|-----------|
+| `id` | UUID | PK |
+| `account_id` | UUID | FK → Account |
+| `item_id` | UUID | FK → Item |
+| `completed_at` | TIMESTAMPTZ | NOT NULL |
+| `points_earned` | INT | NOT NULL |
+
+### Badge
+
+| Colonne | Type | Contrainte |
+|---------|------|-----------|
+| `id` | UUID | PK |
+| `account_id` | UUID | FK → Account |
+| `badge_type` | VARCHAR(100) | NOT NULL |
+| `unlocked_at` | TIMESTAMPTZ | NOT NULL |
+
+## Relations
+
+`Account` 1→N `Subscription` | `Account` 1→N `Item` | `Account` 1→N `Activity` | `Item` 1→N `Activity` | `Account` 1→N `Badge`

--- a/tests/fixtures/wrandly-anon/project-management/architecture/security.md
+++ b/tests/fixtures/wrandly-anon/project-management/architecture/security.md
@@ -1,0 +1,37 @@
+# Sécurité — Atlas
+
+## Authentification & Autorisation
+
+- **JWT ES256** (EdDSA recommandé pour une migration future) — expiration 15 min, refresh token HTTP-only cookie
+- **OAuth 2.0 PKCE** via AuthProvider — pas de secret côté client
+- **DPoP** (RFC 9449) envisagé pour les tokens premium
+- Validation des permissions à chaque requête — pas de cache de rôle
+
+## Stockage des mots de passe
+
+- **Argon2id** : 128 MiB RAM, t=3, p=1 (OWASP 2026)
+- Longueur minimale : 12 caractères
+
+## Headers de sécurité HTTP
+
+```
+Content-Security-Policy: default-src 'self'; script-src 'self'
+X-Content-Type-Options: nosniff
+X-Frame-Options: DENY
+Strict-Transport-Security: max-age=31536000; includeSubDomains
+Referrer-Policy: strict-origin-when-cross-origin
+Cross-Origin-Opener-Policy: same-origin
+Cross-Origin-Embedder-Policy: require-corp
+Permissions-Policy: geolocation=(), camera=(), microphone=()
+```
+
+## RGPD
+
+- Consentement explicite collecté à l'inscription
+- Export des données sur demande (délai ≤ 72 h)
+- Suppression irréversible après 30 jours de délai de rétractation
+- DPO désigné, registre de traitement à jour
+
+## Audit & Logging
+
+Chaque accès aux données personnelles est journalisé avec `account_id`, `action`, `timestamp` et `ip_hash`.

--- a/tests/fixtures/wrandly-anon/project-management/backlog/epics/E0-infrastructure-tokens.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/epics/E0-infrastructure-tokens.md
@@ -1,0 +1,92 @@
+# E0 — Infrastructure & Tokens
+
+L'epic E0 pose les fondations techniques d'Atlas : mise en place de l'environnement de développement, configuration des pipelines CI/CD, gestion des tokens d'accès à ProviderAI, et initialisation du schéma de base de données. Sans ces bases solides, aucune fonctionnalité métier ne peut être livrée de manière fiable.
+
+---
+
+### US-E0-01 — Initialisation du dépôt et CI/CD
+
+**SP**: 3
+
+En tant que développeur, je veux disposer d'un pipeline CI/CD fonctionnel afin de livrer les fonctionnalités en continu avec des garanties qualité automatisées.
+
+- **Given** le dépôt est vide **When** je pousse un commit sur `main` **Then** la pipeline s'exécute et publie un rapport de build
+- **Given** un test échoue **When** la CI tourne **Then** le merge est bloqué et une notification est envoyée
+- **Given** le build est vert **When** la CI se termine **Then** l'image Docker est publiée dans le registre
+
+---
+
+### US-E0-02 — Configuration de l'environnement Docker
+
+**SP**: 2
+
+En tant que développeur, je veux un environnement Docker reproductible afin de garantir la parité entre les environnements de développement et de production.
+
+- **Given** le fichier `docker-compose.yml` existe **When** je lance `docker compose up` **Then** l'application et la base de données démarrent sans erreur
+- **Given** une variable d'environnement manque **When** le conteneur démarre **Then** une erreur explicite est levée
+
+---
+
+### US-E0-03a — Intégration API ProviderAI : authentification
+
+**SP**: 2
+
+En tant que service backend, je veux m'authentifier auprès de ProviderAI afin d'obtenir un token d'accès valide pour les appels de génération.
+
+- **Given** les credentials sont présents en variable d'environnement **When** le service démarre **Then** un token est obtenu et mis en cache
+- **Given** le token expire **When** une requête est effectuée **Then** le token est renouvelé automatiquement
+
+---
+
+### US-E0-03b — Intégration API ProviderAI : quota et rate-limiting
+
+**SP**: 2
+
+En tant que service backend, je veux respecter les quotas de ProviderAI afin d'éviter les erreurs 429 en production.
+
+- **Given** le quota journalier est atteint **When** une requête est faite **Then** une erreur métier est renvoyée à l'appelant
+- **Given** le taux de requêtes dépasse la limite **When** plusieurs appels simultanés arrivent **Then** un mécanisme de backoff exponentiel est appliqué
+
+---
+
+### US-E0-03c — Intégration API ProviderAI : logging des appels
+
+**SP**: 1
+
+En tant qu'administrateur, je veux que chaque appel à ProviderAI soit journalisé afin de suivre la consommation et diagnostiquer les anomalies.
+
+- **Given** un appel est effectué **When** la réponse est reçue **Then** la durée, le modèle et le nombre de tokens sont enregistrés
+- **Given** une erreur survient **When** l'appel échoue **Then** le code d'erreur et le message sont loggés sans exposer les credentials
+
+---
+
+### US-E0-03d — Intégration API ProviderAI : mock pour les tests
+
+**SP**: 1
+
+En tant que développeur, je veux un mock de ProviderAI dans les tests afin de ne pas consommer de quota lors des pipelines CI.
+
+- **Given** l'environnement est `test` **When** une génération est demandée **Then** le mock retourne un itinéraire factice prédéfini
+- **Given** le mock est actif **When** les tests s'exécutent **Then** aucun appel réseau réel n'est émis
+
+---
+
+### US-E0-04 — Schéma de base de données initial
+
+**SP**: 3
+
+En tant qu'architecte, je veux un schéma de base de données versionné afin de garantir la cohérence des migrations entre les environnements.
+
+- **Given** le schéma initial est défini **When** les migrations sont appliquées **Then** toutes les tables sont créées sans erreur
+- **Given** une migration est rejouée **When** elle a déjà été appliquée **Then** elle est ignorée sans erreur (idempotence)
+
+---
+
+### US-E0-05 — Monitoring et alertes de base
+
+**SP**: 2
+
+En tant qu'administrateur, je veux des alertes sur les métriques critiques afin d'être prévenu en cas d'incident avant les utilisateurs.
+
+- **Given** le taux d'erreur HTTP dépasse 5 % **When** la fenêtre de 5 minutes s'écoule **Then** une alerte est déclenchée
+- **Given** le temps de réponse médian dépasse 2 s **When** la charge augmente **Then** une notification est envoyée à l'équipe

--- a/tests/fixtures/wrandly-anon/project-management/backlog/epics/E1-design-system.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/epics/E1-design-system.md
@@ -1,0 +1,59 @@
+# E1 — Design System
+
+L'epic E1 établit le design system d'Atlas : tokens visuels, composants de base, documentation Storybook et règles d'accessibilité. Un design system cohérent réduit le temps de développement des epics suivants et garantit une expérience utilisateur homogène sur web et mobile.
+
+---
+
+### US-E1-01 — Tokens de design (couleurs, typographie, espacements)
+
+**SP**: 3
+
+En tant que designer/développeur, je veux un ensemble de tokens de design centralisés afin que toutes les interfaces partagent une identité visuelle cohérente.
+
+- **Given** les tokens sont définis dans un fichier source unique **When** ils sont compilés **Then** ils sont disponibles en CSS variables, JSON et constantes TypeScript
+- **Given** un token est modifié **When** le build est relancé **Then** tous les composants qui l'utilisent reflètent le changement automatiquement
+
+---
+
+### US-E1-02 — Composants atomiques (boutons, champs, badges)
+
+**SP**: 5
+
+En tant que développeur, je veux des composants atomiques accessibles et testés afin de construire les écrans plus rapidement sans réinventer les bases.
+
+- **Given** un composant bouton est rendu **When** il reçoit le focus clavier **Then** un indicateur de focus visible est affiché (WCAG 2.2 AA)
+- **Given** un champ de saisie est invalide **When** l'utilisateur soumet le formulaire **Then** un message d'erreur associé au champ est annoncé par les lecteurs d'écran
+- **Given** le composant est documenté dans Storybook **When** je navigue dans le catalogue **Then** tous les états (default, hover, disabled, error) sont visibles
+
+---
+
+### US-E1-03 — Composants moléculaires (cartes, listes, modales)
+
+**SP**: 5
+
+En tant que développeur, je veux des composants moléculaires réutilisables afin de construire les vues complexes par composition.
+
+- **Given** une carte itinéraire est rendue **When** je la survole **Then** une animation de survol fluide est jouée (60 fps)
+- **Given** une modale est ouverte **When** j'appuie sur Échap **Then** la modale se ferme et le focus retourne à l'élément déclencheur
+
+---
+
+### US-E1-04 — Thème sombre et thème clair
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux pouvoir choisir entre le thème clair et le thème sombre afin de conserver le confort visuel selon mon contexte.
+
+- **Given** le thème système est sombre **When** l'application démarre pour la première fois **Then** le thème sombre est appliqué automatiquement
+- **Given** l'utilisateur change de thème **When** il recharge la page **Then** le thème choisi est conservé
+
+---
+
+### US-E1-05 — Documentation Storybook et guide de contribution
+
+**SP**: 2
+
+En tant que contributeur, je veux une documentation Storybook à jour afin de trouver rapidement le bon composant et comprendre comment l'utiliser.
+
+- **Given** un nouveau composant est créé **When** la PR est fusionnée **Then** une story Storybook est requise comme critère de merge
+- **Given** je consulte Storybook **When** je cherche un composant par nom **Then** je le trouve en moins de 3 clics

--- a/tests/fixtures/wrandly-anon/project-management/backlog/epics/E2-generation-detail.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/epics/E2-generation-detail.md
@@ -1,0 +1,71 @@
+# E2 — Génération & Détail
+
+L'epic E2 couvre le cœur de valeur d'Atlas : la génération d'itinéraires par ProviderAI et la consultation du détail d'un itinéraire. C'est la fonctionnalité différenciante du produit et celle qui doit offrir la meilleure expérience utilisateur.
+
+---
+
+### US-E2-01 — Formulaire de génération d'itinéraire
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux remplir un formulaire simple afin de paramétrer mon itinéraire selon mes préférences (durée, niveau, type d'activité).
+
+- **Given** le formulaire est affiché **When** je sélectionne une durée et un type **Then** le bouton "Générer" devient actif
+- **Given** un champ obligatoire est vide **When** je soumets le formulaire **Then** un message d'erreur contextuel est affiché sous le champ
+- **Given** le formulaire est soumis **When** la génération démarre **Then** un indicateur de progression est affiché
+
+---
+
+### US-E2-02 — Génération IA via ProviderAI
+
+**SP**: 8
+
+En tant qu'utilisateur, je veux que l'itinéraire soit généré par ProviderAI en moins de 10 secondes afin d'obtenir une proposition personnalisée rapidement.
+
+- **Given** les paramètres sont valides **When** j'appuie sur "Générer" **Then** l'itinéraire est renvoyé en moins de 10 secondes dans 95 % des cas
+- **Given** ProviderAI ne répond pas **When** la génération échoue **Then** un message d'erreur convivial est affiché et une option de réessai est proposée
+- **Given** la génération réussit **When** l'itinéraire est reçu **Then** il est sauvegardé automatiquement dans la bibliothèque
+
+---
+
+### US-E2-03 — Page de détail d'un itinéraire
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux consulter le détail complet d'un itinéraire afin de planifier mon activité avec précision.
+
+- **Given** je clique sur un itinéraire **When** la page de détail s'ouvre **Then** les étapes, la durée estimée et le niveau sont affichés
+- **Given** je suis sur la page de détail **When** je clique sur une étape **Then** une vue agrandie de l'étape est affichée
+
+---
+
+### US-E2-04 — Modification manuelle d'un itinéraire généré
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux modifier les étapes d'un itinéraire généré afin d'adapter le parcours à mes contraintes réelles.
+
+- **Given** je suis sur la page de détail **When** je clique sur "Modifier" **Then** le mode édition s'active et les étapes deviennent réorganisables
+- **Given** j'ai réorganisé les étapes **When** je clique sur "Sauvegarder" **Then** la nouvelle version est persistée et une confirmation est affichée
+
+---
+
+### US-E2-05a — Export PDF de l'itinéraire
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux exporter mon itinéraire en PDF afin de l'emporter sans connexion internet.
+
+- **Given** je suis sur la page de détail **When** je clique sur "Exporter en PDF" **Then** un fichier PDF est généré et téléchargé
+- **Given** le PDF est généré **When** je l'ouvre **Then** toutes les étapes et les informations clés sont lisibles
+
+---
+
+### US-E2-05b — Partage d'itinéraire par lien
+
+**SP**: 2
+
+En tant qu'utilisateur, je veux partager mon itinéraire via un lien public afin de le transmettre à des proches.
+
+- **Given** je clique sur "Partager" **When** le lien est généré **Then** il est copié dans le presse-papiers et un message de confirmation est affiché
+- **Given** un visiteur ouvre le lien partagé **When** il n'est pas connecté **Then** l'itinéraire est visible en lecture seule sans nécessiter de compte

--- a/tests/fixtures/wrandly-anon/project-management/backlog/epics/E3-library-gamification.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/epics/E3-library-gamification.md
@@ -1,0 +1,80 @@
+# E3 — Bibliothèque & Gamification
+
+L'epic E3 enrichit Atlas d'une bibliothèque personnelle d'itinéraires et d'un système de gamification (badges, points, classements) destiné à fidéliser les utilisateurs sur le long terme, en particulier le persona "Joueur".
+
+---
+
+### US-E3-01 — Bibliothèque personnelle d'itinéraires
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux accéder à tous mes itinéraires sauvegardés afin de retrouver rapidement mes parcours favoris.
+
+- **Given** j'ai généré au moins un itinéraire **When** j'ouvre la bibliothèque **Then** mes itinéraires sont listés par date de création
+- **Given** j'ai plus de 20 itinéraires **When** je fais défiler la liste **Then** les itinéraires suivants se chargent par pagination (20 par page)
+
+---
+
+### US-E3-02 — Filtres et recherche dans la bibliothèque
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux filtrer et rechercher dans ma bibliothèque afin de retrouver un itinéraire précis sans faire défiler toute la liste.
+
+- **Given** je saisis un mot-clé dans la barre de recherche **When** j'appuie sur Entrée **Then** seuls les itinéraires correspondants sont affichés
+- **Given** j'applique un filtre par type d'activité **When** la liste se rafraîchit **Then** seuls les itinéraires du type sélectionné apparaissent
+
+---
+
+### US-E3-03 — Favoris et collections
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux organiser mes itinéraires en collections afin de les regrouper par thème ou occasion.
+
+- **Given** je clique sur l'icône favori d'un itinéraire **When** l'action est confirmée **Then** l'itinéraire apparaît dans la collection "Favoris"
+- **Given** je crée une nouvelle collection **When** je lui attribue un nom **Then** elle apparaît dans la barre latérale de la bibliothèque
+
+---
+
+### US-E3-04 — Système de points d'expérience
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux gagner des points d'expérience à chaque activité complétée afin de progresser dans mon niveau Atlas.
+
+- **Given** je marque un itinéraire comme "complété" **When** l'action est confirmée **Then** les points sont crédités sur mon profil et un retour visuel est affiché
+- **Given** j'atteins le seuil du niveau suivant **When** les points sont calculés **Then** une animation de montée de niveau est jouée
+
+---
+
+### US-E3-05 — Badges de réussite
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux débloquer des badges afin de matérialiser mes accomplissements et partager mes succès.
+
+- **Given** je complète mon premier itinéraire **When** le badge "Premier Pas" est débloqué **Then** une notification in-app est affichée avec une animation
+- **Given** je consulte mon profil **When** je clique sur un badge verrouillé **Then** les conditions de déblocage sont affichées
+
+---
+
+### US-E3-06 — Classement des utilisateurs
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux voir mon rang dans un classement afin de me comparer à la communauté et rester motivé.
+
+- **Given** je suis connecté **When** j'ouvre la page classement **Then** mon rang, mon score et les 10 premiers utilisateurs sont affichés
+- **Given** mon score change **When** le classement est recalculé **Then** mon rang est mis à jour en temps réel
+
+---
+
+### US-E3-07 — Défis hebdomadaires
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux participer à des défis hebdomadaires afin de diversifier mes activités et gagner des récompenses bonus.
+
+- **Given** la semaine démarre **When** les défis sont générés **Then** trois défis différents sont proposés à chaque utilisateur
+- **Given** je complète un défi **When** la validation est faite **Then** les points bonus sont crédités et le défi est marqué "Accompli"

--- a/tests/fixtures/wrandly-anon/project-management/backlog/epics/E4-auth-settings-premium.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/epics/E4-auth-settings-premium.md
@@ -1,0 +1,103 @@
+# E4 — Auth, Paramètres & Premium
+
+L'epic E4 couvre l'authentification via AuthProvider et email, la gestion du profil utilisateur, les paramètres de l'application et le système d'abonnement premium via PaymentProvider. Note : la story US-E4-07 (8 SP initiaux) a été splitée en US-E4-07a et US-E4-07b pour respecter la contrainte de 5 SP maximum par story.
+
+---
+
+### US-E4-01 — Inscription par email
+
+**SP**: 3
+
+En tant que nouvel utilisateur, je veux m'inscrire avec mon adresse email afin de créer un compte Atlas personnel.
+
+- **Given** je remplis le formulaire d'inscription **When** je clique sur "Créer mon compte" **Then** un email de confirmation est envoyé dans les 30 secondes
+- **Given** l'email de confirmation est reçu **When** je clique sur le lien **Then** mon compte est activé et je suis redirigé vers l'onboarding
+
+---
+
+### US-E4-02 — Connexion via AuthProvider
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux me connecter via AuthProvider afin de ne pas gérer un mot de passe supplémentaire.
+
+- **Given** je clique sur "Connexion avec AuthProvider" **When** l'authentification OAuth réussit **Then** je suis connecté et redirigé vers mon tableau de bord
+- **Given** AuthProvider est indisponible **When** je tente de me connecter **Then** un message d'erreur clair est affiché avec l'option de connexion par email
+
+---
+
+### US-E4-03 — Gestion du profil utilisateur
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux modifier mon profil (pseudo, avatar, préférences) afin de personnaliser mon expérience Atlas.
+
+- **Given** je suis sur la page de profil **When** je modifie mon pseudo et sauvegarde **Then** le nouveau pseudo est visible sur mon profil dans les 2 secondes
+- **Given** je télécharge un nouvel avatar **When** le fichier est accepté (≤ 2 Mo, PNG/JPG) **Then** il remplace l'avatar précédent sur tous les écrans
+
+---
+
+### US-E4-04 — Paramètres de notifications
+
+**SP**: 2
+
+En tant qu'utilisateur, je veux configurer mes préférences de notifications afin de ne recevoir que les alertes pertinentes pour moi.
+
+- **Given** je suis dans les paramètres **When** je désactive les notifications de défis **Then** aucune notification de défi ne m'est plus envoyée
+- **Given** je réactive une notification **When** je sauvegarde **Then** la préférence est prise en compte dès l'événement suivant
+
+---
+
+### US-E4-05 — Page d'abonnement premium
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux consulter les offres premium afin de comprendre la valeur ajoutée avant de m'abonner.
+
+- **Given** je clique sur "Passer Premium" **When** la page s'ouvre **Then** les avantages, le prix et les conditions sont clairement listés
+- **Given** je compare les offres mensuelle et annuelle **When** je sélectionne annuelle **Then** l'économie en pourcentage est mise en évidence
+
+---
+
+### US-E4-06 — Souscription via PaymentProvider
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux souscrire à l'abonnement premium via PaymentProvider afin d'accéder aux fonctionnalités avancées d'Atlas.
+
+- **Given** j'ai choisi une offre **When** je clique sur "S'abonner" **Then** je suis redirigé vers la page de paiement sécurisée de PaymentProvider
+- **Given** le paiement est accepté **When** PaymentProvider notifie Atlas **Then** mon statut premium est activé en moins de 5 secondes
+- **Given** le paiement échoue **When** PaymentProvider renvoie une erreur **Then** un message explicatif et un lien de support sont affichés
+
+---
+
+### US-E4-07a — Gestion de l'abonnement premium (consultation et annulation)
+
+**SP**: 4
+
+En tant qu'abonné premium, je veux consulter et annuler mon abonnement afin de garder le contrôle de mes engagements financiers.
+
+- **Given** je suis abonné **When** j'ouvre "Mon abonnement" **Then** la date de renouvellement, le montant et l'historique sont affichés
+- **Given** je clique sur "Annuler l'abonnement" **When** je confirme **Then** l'accès premium reste actif jusqu'à la fin de la période en cours
+
+---
+
+### US-E4-07b — Gestion de l'abonnement premium (mise à jour du moyen de paiement)
+
+**SP**: 4
+
+En tant qu'abonné premium, je veux mettre à jour mon moyen de paiement afin de ne pas perdre l'accès suite à une carte expirée.
+
+- **Given** ma carte arrive à expiration **When** j'ouvre les paramètres de paiement **Then** une alerte m'invite à mettre à jour mes informations
+- **Given** je saisis une nouvelle carte via PaymentProvider **When** la mise à jour est confirmée **Then** le prochain prélèvement utilisera automatiquement la nouvelle carte
+
+---
+
+### US-E4-08 — Suppression de compte (RGPD)
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux pouvoir supprimer définitivement mon compte afin d'exercer mon droit à l'oubli conformément au RGPD.
+
+- **Given** je demande la suppression **When** je confirme avec mon mot de passe **Then** une demande de suppression est enregistrée et un email de confirmation est envoyé
+- **Given** la suppression est planifiée **When** 30 jours s'écoulent sans annulation **Then** toutes mes données personnelles sont effacées de manière irréversible

--- a/tests/fixtures/wrandly-anon/project-management/backlog/epics/E5-discovery-surprise.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/epics/E5-discovery-surprise.md
@@ -1,0 +1,58 @@
+# E5 — Découverte & Surprise
+
+L'epic E5 ajoute une dimension de découverte spontanée à Atlas : fonctionnalité "Surprise-moi", recommandations contextuelles et exploration thématique. Ces fonctionnalités ciblent principalement l'"Utilisateur curieux" et l'"Explorateur régulier".
+
+---
+
+### US-E5-01 — Fonctionnalité "Surprise-moi"
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux que l'application me génère un itinéraire surprise afin de découvrir des activités auxquelles je n'aurais pas pensé.
+
+- **Given** je clique sur "Surprise-moi" **When** la génération est lancée **Then** un itinéraire aléatoire adapté à mon profil est proposé en moins de 8 secondes
+- **Given** l'itinéraire surprise ne me convient pas **When** je clique sur "Autre surprise" **Then** un nouvel itinéraire différent est généré
+
+---
+
+### US-E5-02 — Recommandations contextuelles
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux recevoir des recommandations basées sur mes activités passées afin de découvrir des itinéraires qui correspondent à mes goûts.
+
+- **Given** j'ai complété au moins 3 itinéraires **When** j'ouvre la page d'accueil **Then** une section "Pour vous" affiche 3 recommandations personnalisées
+- **Given** je rejette une recommandation **When** je clique sur "Pas intéressé" **Then** ce type de contenu est moins fréquent dans mes futures recommandations
+
+---
+
+### US-E5-03 — Exploration thématique
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux parcourir des catégories thématiques afin de trouver l'inspiration selon mon envie du moment.
+
+- **Given** j'ouvre la page "Explorer" **When** les thèmes sont chargés **Then** au moins 6 catégories thématiques sont affichées avec une image représentative
+- **Given** je sélectionne un thème **When** la liste se charge **Then** les itinéraires correspondants sont affichés par popularité
+
+---
+
+### US-E5-04 — Itinéraire du jour
+
+**SP**: 2
+
+En tant qu'utilisateur, je veux voir un itinéraire mis en avant chaque jour afin d'avoir une raison de revenir sur l'application quotidiennement.
+
+- **Given** je me connecte à l'application **When** c'est un nouveau jour **Then** un itinéraire "À la une" différent du jour précédent est affiché en haut de l'écran
+- **Given** je clique sur l'itinéraire du jour **When** la page détail s'ouvre **Then** un bandeau "Sélection du jour" est visible
+
+---
+
+### US-E5-05 — Partage de découverte entre utilisateurs
+
+**SP**: 3
+
+En tant qu'utilisateur, je veux partager mes découvertes avec la communauté Atlas afin d'inspirer d'autres utilisateurs.
+
+- **Given** je consulte un itinéraire **When** je clique sur "Partager à la communauté" **Then** l'itinéraire est soumis pour modération
+- **Given** ma soumission est approuvée **When** elle est publiée **Then** je reçois un badge "Contributeur" et des points bonus

--- a/tests/fixtures/wrandly-anon/project-management/backlog/epics/E6-mobile-polish.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/epics/E6-mobile-polish.md
@@ -1,0 +1,58 @@
+# E6 — Polish Mobile
+
+L'epic E6 améliore l'expérience sur les applications mobiles iOS et Android : performances d'animation, interactions tactiles, mode hors-ligne partiel et adaptation aux différentes tailles d'écran.
+
+---
+
+### US-E6-01 — Animations fluides et transitions
+
+**SP**: 3
+
+En tant qu'utilisateur mobile, je veux des animations fluides entre les écrans afin de bénéficier d'une expérience visuelle premium.
+
+- **Given** je navigue entre deux écrans **When** la transition s'effectue **Then** elle se joue à 60 fps minimum sans saccade visible
+- **Given** une liste d'itinéraires se charge **When** les éléments apparaissent **Then** une animation de décalage progressif (stagger) est jouée
+
+---
+
+### US-E6-02 — Gestes tactiles avancés
+
+**SP**: 3
+
+En tant qu'utilisateur mobile, je veux utiliser des gestes tactiles intuitifs afin de naviguer plus rapidement dans l'application.
+
+- **Given** je suis sur la page de détail **When** je glisse vers la gauche **Then** je reviens à la liste précédente
+- **Given** je maintiens un appui long sur un itinéraire dans la bibliothèque **When** le menu contextuel s'ouvre **Then** les actions rapides (Partager, Supprimer, Renommer) sont disponibles
+
+---
+
+### US-E6-03 — Mode hors-ligne partiel (consultation bibliothèque)
+
+**SP**: 5
+
+En tant qu'utilisateur mobile, je veux consulter ma bibliothèque sans connexion afin de retrouver mes itinéraires même en zone blanche.
+
+- **Given** j'ai consulté un itinéraire en ligne **When** je perds la connexion **Then** l'itinéraire reste accessible en cache local
+- **Given** je suis hors-ligne **When** j'essaie de générer un nouvel itinéraire **Then** un message clair m'indique que cette fonctionnalité nécessite une connexion
+
+---
+
+### US-E6-04 — Adaptation aux tablettes et grands écrans
+
+**SP**: 3
+
+En tant qu'utilisateur sur tablette, je veux une mise en page adaptée afin de profiter de l'espace disponible sur mon appareil.
+
+- **Given** l'application s'ouvre sur une tablette (≥ 768 px) **When** la bibliothèque est affichée **Then** une mise en page en deux colonnes est utilisée
+- **Given** je pivote la tablette **When** l'orientation change **Then** la mise en page s'adapte sans rechargement complet
+
+---
+
+### US-E6-05 — Optimisation des performances de démarrage
+
+**SP**: 3
+
+En tant qu'utilisateur mobile, je veux que l'application démarre rapidement afin de ne pas attendre plus de 2 secondes avant de voir le contenu.
+
+- **Given** l'application est lancée à froid **When** le splash screen disparaît **Then** l'écran principal est interactif en moins de 2 secondes sur un appareil milieu de gamme
+- **Given** l'application est lancée depuis le fond **When** elle reprend l'avant-plan **Then** elle est prête en moins de 500 ms

--- a/tests/fixtures/wrandly-anon/project-management/backlog/epics/E7-i18n-qa-launch.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/epics/E7-i18n-qa-launch.md
@@ -1,0 +1,58 @@
+# E7 — i18n, QA & Lancement
+
+L'epic E7 finalise Atlas avant le lancement public : internationalisation en trois langues (FR, EN, ES), campagne de QA complète, corrections des régressions identifiées et déploiement en production. C'est l'epic qui conditionne la date de lancement.
+
+---
+
+### US-E7-01 — Internationalisation FR/EN/ES
+
+**SP**: 5
+
+En tant qu'utilisateur, je veux utiliser Atlas dans ma langue afin de bénéficier d'une expérience entièrement localisée.
+
+- **Given** mon appareil est configuré en anglais **When** j'ouvre l'application pour la première fois **Then** l'interface s'affiche en anglais
+- **Given** je change la langue dans les paramètres **When** je sélectionne l'espagnol **Then** toute l'interface bascule en espagnol sans rechargement complet
+
+---
+
+### US-E7-02 — Campagne de tests de régression
+
+**SP**: 5
+
+En tant que QA, je veux exécuter une campagne de régression complète afin de valider que toutes les fonctionnalités des epics E0 à E6 fonctionnent correctement ensemble.
+
+- **Given** la suite de tests E2E est configurée **When** la campagne est lancée **Then** les 150 scénarios critiques s'exécutent sans erreur bloquante
+- **Given** une régression est détectée **When** le rapport est généré **Then** elle est classée par sévérité (bloquant, majeur, mineur) et assignée à l'équipe
+
+---
+
+### US-E7-03 — Audit de sécurité et conformité RGPD
+
+**SP**: 3
+
+En tant que responsable produit, je veux un audit de sécurité et de conformité RGPD afin de garantir la conformité légale avant le lancement.
+
+- **Given** l'audit est commandé **When** le rapport est reçu **Then** aucune vulnérabilité critique (CVSS ≥ 9) ne subsiste
+- **Given** la conformité RGPD est vérifiée **When** le DPO valide **Then** la politique de confidentialité et le mécanisme de consentement sont approuvés
+
+---
+
+### US-E7-04 — Déploiement en environnement de staging
+
+**SP**: 3
+
+En tant que DevOps, je veux déployer Atlas sur un environnement de staging identique à la production afin de valider le déploiement avant la mise en ligne.
+
+- **Given** le build est validé **When** le déploiement staging est déclenché **Then** l'application est disponible sur l'URL de staging en moins de 10 minutes
+- **Given** le smoke test staging passe **When** l'équipe valide **Then** le déploiement production peut être déclenché
+
+---
+
+### US-E7-05 — Mise en ligne et monitoring du lancement
+
+**SP**: 3
+
+En tant qu'équipe produit, je veux un lancement progressif avec monitoring renforcé afin de détecter et corriger rapidement les problèmes post-lancement.
+
+- **Given** le déploiement production est déclenché **When** le rollout atteint 100 % **Then** les métriques clés (erreurs, latence, inscriptions) sont surveillées en temps réel
+- **Given** le taux d'erreur dépasse 2 % **When** l'alerte se déclenche **Then** un rollback automatique est initié en moins de 5 minutes

--- a/tests/fixtures/wrandly-anon/project-management/backlog/user-stories/US-200-legacy.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/user-stories/US-200-legacy.md
@@ -1,0 +1,15 @@
+---
+id: US-200
+title: "Story legacy markdown (id numérique valide)"
+epic_id: EPIC-004
+status: in-progress
+story_points: 5
+priority: should
+sprint_id: sprint-9-auth-premium
+assigned_to: alice
+dependencies: []
+---
+
+Cette story a été créée avant la migration vers le format d'ID épic-style (US-E{n}-{seq}). Elle utilise un identifiant purement numérique (`US-200`) qui reste valide selon la convention du scanner : le préfixe `US-` suivi d'un nombre entier est reconnu comme une story legacy.
+
+Le contenu fonctionnel porte sur l'amélioration du tableau de bord utilisateur premium : affichage du récapitulatif mensuel de points, des badges obtenus ce mois-ci et du rang dans le classement. Cette vue est accessible uniquement aux abonnés actifs.

--- a/tests/fixtures/wrandly-anon/project-management/backlog/user-stories/US-E4-09-extra.md
+++ b/tests/fixtures/wrandly-anon/project-management/backlog/user-stories/US-E4-09-extra.md
@@ -1,0 +1,12 @@
+---
+id: US-E4-09
+title: "Story markdown id E-style (cas limite)"
+status: ready-for-dev
+story_points: 3
+---
+
+**Note de test :** Cet fichier sert de cas limite pour le scanner de stories markdown.
+
+L'identifiant `US-E4-09` suit le format épic-style (`US-E{n}-{seq}`), mais ce fichier est placé dans `backlog/user-stories/` et **non** dans un dossier d'epic. Le scanner doit être capable de le détecter via le frontmatter YAML (`id: US-E4-09`) indépendamment du chemin de fichier.
+
+Ce cas vérifie que le parser YAML prend la priorité sur l'inférence du chemin pour l'attribution de l'epic.

--- a/tests/fixtures/wrandly-anon/project-management/prd.md
+++ b/tests/fixtures/wrandly-anon/project-management/prd.md
@@ -1,0 +1,48 @@
+# PRD — Atlas
+
+## Vision
+
+Atlas est une application web et mobile permettant à tout utilisateur de générer, personnaliser et suivre des itinéraires d'activités. Grâce à l'intelligence artificielle de ProviderAI, Atlas propose des parcours adaptés au profil, aux préférences et au niveau de l'utilisateur, tout en gamifiant la progression pour maintenir l'engagement sur le long terme.
+
+---
+
+## Personas
+
+| Persona | Description | Besoins principaux |
+|---------|-------------|-------------------|
+| **Utilisateur curieux** | Découvre l'application, explore sans objectif précis | Onboarding simple, suggestions variées, pas de friction |
+| **Explorateur régulier** | Utilise Atlas plusieurs fois par semaine | Bibliothèque personnelle, historique, recommandations affinées |
+| **Sportif** | Objectifs de performance mesurables | Statistiques détaillées, segments chronométrés, badges d'effort |
+| **Joueur** | Motivé par la compétition et les récompenses | Classements, défis, badges rares, progression visible |
+
+---
+
+## Objectifs
+
+- Permettre la génération d'itinéraires en moins de 10 secondes via ProviderAI
+- Atteindre un taux de rétention J7 ≥ 40 % à la fin du Sprint 6
+- Proposer un abonnement premium (PaymentProvider) avec valeur perçue claire
+- Couvrir les marchés FR, EN et ES dès le lancement (E7)
+
+---
+
+## Périmètre
+
+**Inclus :** génération IA, bibliothèque personnelle, gamification (badges, classement), authentification (AuthProvider + email), abonnement premium, internationalisation FR/EN/ES, application mobile iOS et Android.
+
+**Exclus :** intégration réseaux sociaux tiers, mode hors-ligne complet, marketplace de contenus tiers.
+
+---
+
+## Epics
+
+| Epic | Titre | Priorité |
+|------|-------|---------|
+| E0 | Infrastructure & Tokens | Critique |
+| E1 | Design System | Haute |
+| E2 | Génération & Détail | Haute |
+| E3 | Bibliothèque & Gamification | Haute |
+| E4 | Auth, Paramètres & Premium | Haute |
+| E5 | Découverte & Surprise | Moyenne |
+| E6 | Polish Mobile | Moyenne |
+| E7 | i18n, QA & Lancement | Critique |

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/sprint-backlog.md
@@ -1,0 +1,12 @@
+# Sprint 1 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E0-01 | Initialisation du dépôt et CI/CD | 3 | done |
+| US-E0-02 | Configuration de l'environnement Docker | 2 | done |
+| US-E0-03a | Intégration API ProviderAI : authentification | 2 | done |
+| US-E0-03b | Intégration API ProviderAI : quota et rate-limiting | 2 | done |
+| US-E0-03c | Intégration API ProviderAI : logging des appels | 1 | done |
+| US-E0-03d | Intégration API ProviderAI : mock pour les tests | 1 | done |
+
+**Total :** 11 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 1 — Infrastructure
+
+Mettre en place les fondations techniques d'Atlas : dépôt, CI/CD, environnement Docker et intégration ProviderAI, afin que toutes les équipes disposent d'une base solide pour les sprints suivants.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/sprint-review.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/sprint-review.md
@@ -1,0 +1,26 @@
+# Sprint 1 — Review
+
+| Sprint | Epic | Date | Commit |
+|--------|------|------|--------|
+| Sprint 1 | E0 | 2026-01-16 | a1b2c3d |
+
+**Goal :** Mettre en place les fondations techniques (CI/CD, Docker, ProviderAI).
+**Atteint :** OUI
+
+## Stories livrées
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E0-01 | Initialisation du dépôt et CI/CD | 3 | done |
+| US-E0-02 | Configuration de l'environnement Docker | 2 | done |
+| US-E0-03a | Intégration API ProviderAI : authentification | 2 | done |
+| US-E0-03b | Intégration API ProviderAI : quota et rate-limiting | 2 | done |
+| US-E0-03c | Intégration API ProviderAI : logging des appels | 1 | done |
+| US-E0-03d | Intégration API ProviderAI : mock pour les tests | 1 | done |
+
+## Métriques
+
+- **Vélocité :** 11 SP livrés / 11 SP planifiés
+- **Taux de succès :** 100 %
+- **Bugs bloquants :** 0
+- **Tests verts :** 42/42

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/tasks/US-E0-01-tasks.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/tasks/US-E0-01-tasks.md
@@ -1,0 +1,32 @@
+# Tâches — US-E0-01 : Initialisation du dépôt et CI/CD
+
+**Epic :** E0 — Infrastructure & Tokens
+**Story Points :** 3
+**Sprint :** Sprint 1 — Infrastructure
+
+## Résumé
+
+**En tant que** développeur,
+**je veux** disposer d'un pipeline CI/CD fonctionnel,
+**afin de** livrer les fonctionnalités en continu avec des garanties qualité automatisées.
+
+## Tâches
+
+| ID | Type | Tâche | Estimation | Statut |
+|----|------|-------|------------|--------|
+| T-E0-01-1 | [OPS] | Initialiser le dépôt Git avec les branches `main` et `develop` | 0,5 h | done |
+| T-E0-01-2 | [OPS] | Configurer le fichier `.github/workflows/ci.yml` (lint, test, build) | 1 h | done |
+| T-E0-01-3 | [OPS] | Ajouter la protection de branche `main` (2 approbations requises) | 0,25 h | done |
+| T-E0-01-4 | [OPS] | Configurer le registre Docker et l'étape de publication d'image | 1 h | done |
+| T-E0-01-5 | [TEST] | Vérifier que la pipeline s'exécute correctement sur un commit de test | 0,25 h | done |
+| T-E0-01-6 | [REV] | Revue de la configuration CI par un second développeur | 0,5 h | done |
+
+**Total estimé :** 3,5 h
+
+## Dépendances
+
+- T-E0-01-1 → T-E0-01-2 (le dépôt doit exister avant de configurer la CI)
+- T-E0-01-2 → T-E0-01-3 (la CI doit être configurée avant la protection de branche)
+- T-E0-01-2 → T-E0-01-4 (la CI doit exister avant d'ajouter l'étape Docker)
+- T-E0-01-4 → T-E0-01-5 (la pipeline complète doit être en place avant la vérification)
+- T-E0-01-5 → T-E0-01-6 (la vérification doit passer avant la revue)

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/tasks/US-E0-02-tasks.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-1-infrastructure/tasks/US-E0-02-tasks.md
@@ -1,0 +1,32 @@
+# Tâches — US-E0-02 : Configuration de l'environnement Docker
+
+**Epic :** E0 — Infrastructure & Tokens
+**Story Points :** 2
+**Sprint :** Sprint 1 — Infrastructure
+
+## Résumé
+
+**En tant que** développeur,
+**je veux** un environnement Docker reproductible,
+**afin de** garantir la parité entre les environnements de développement et de production.
+
+## Tâches
+
+| ID | Type | Tâche | Estimation | Statut |
+|----|------|-------|------------|--------|
+| T-E0-02-1 | [OPS] | Rédiger le `Dockerfile` multi-stage (build + runtime) | 1 h | done |
+| T-E0-02-2 | [OPS] | Créer le `docker-compose.yml` avec services app, db et cache | 0,5 h | done |
+| T-E0-02-3 | [OPS] | Créer le fichier `.env.example` avec toutes les variables requises | 0,25 h | done |
+| T-E0-02-4 | [BE] | Ajouter la validation des variables d'environnement au démarrage | 0,5 h | done |
+| T-E0-02-5 | [TEST] | Vérifier que `docker compose up` démarre sans erreur sur macOS et Linux | 0,25 h | done |
+| T-E0-02-6 | [REV] | Revue du Dockerfile (sécurité : utilisateur non-root, layers optimisés) | 0,5 h | done |
+
+**Total estimé :** 3 h
+
+## Dépendances
+
+- T-E0-02-1 → T-E0-02-2 (Dockerfile requis avant docker-compose)
+- T-E0-02-2 → T-E0-02-3 (compose doit référencer les variables)
+- T-E0-02-3 → T-E0-02-4 (variables connues avant d'écrire la validation)
+- T-E0-02-4 → T-E0-02-5 (validation en place avant les tests)
+- T-E0-02-5 → T-E0-02-6 (tests verts avant revue)

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/sprint-backlog.md
@@ -1,0 +1,11 @@
+# Sprint 2 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E0-04 | Schéma de base de données initial | 3 | done |
+| US-E0-05 | Monitoring et alertes de base | 2 | done |
+| US-E1-01 | Tokens de design (couleurs, typographie, espacements) | 3 | done |
+| US-E1-02 | Composants atomiques (boutons, champs, badges) | 5 | done |
+| US-E1-03 | Composants moléculaires (cartes, listes, modales) | 5 | done |
+
+**Total :** 18 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 2 — Design System
+
+Construire le design system d'Atlas (tokens, composants atomiques et moléculaires, Storybook) afin de donner à l'équipe frontend une base de composants cohérente et accessible pour les sprints suivants.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/sprint-retro.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/sprint-retro.md
@@ -1,0 +1,27 @@
+# Sprint 2 — Rétrospective (Mad-Sad-Glad)
+
+## Mad (ce qui a frustré)
+
+- La documentation des tokens manquait d'exemples visuels au démarrage, ce qui a causé des allers-retours inutiles.
+- Les revues de composants ont pris plus de temps que prévu faute de critères d'accessibilité définis à l'avance.
+
+## Sad (ce qui aurait pu mieux se passer)
+
+- La synchro design/développement n'était pas fluide : certains composants ont été implémentés avant la validation des maquettes finales.
+
+## Glad (ce qui a bien fonctionné)
+
+- La vélocité de 18 SP atteinte sans dette technique.
+- La qualité des composants validée dès la première review grâce aux tests d'accessibilité automatisés.
+- L'ambiance de l'équipe reste excellente.
+
+## Actions
+
+| # | Action | Responsable | Deadline |
+|---|--------|-------------|----------|
+| 1 | Définir les critères d'accessibilité avant la création de chaque composant | Équipe design | Sprint 3 J1 |
+| 2 | Synchroniser maquettes finales avant le sprint planning | Designer | Sprint 3 planning |
+
+## ROTI
+
+**Score :** 4/5 — Sprint productif, quelques frictions sur la coordination design/dev à corriger.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/sprint-review.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/sprint-review.md
@@ -1,0 +1,25 @@
+# Sprint 2 — Review
+
+| Sprint | Epic | Date | Commit |
+|--------|------|------|--------|
+| Sprint 2 | E0, E1 | 2026-01-30 | d4e5f6a |
+
+**Goal :** Construire le design system et finaliser l'infrastructure.
+**Atteint :** OUI
+
+## Stories livrées
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E0-04 | Schéma de base de données initial | 3 | done |
+| US-E0-05 | Monitoring et alertes de base | 2 | done |
+| US-E1-01 | Tokens de design | 3 | done |
+| US-E1-02 | Composants atomiques | 5 | done |
+| US-E1-03 | Composants moléculaires | 5 | done |
+
+## Métriques
+
+- **Vélocité :** 18 SP livrés / 18 SP planifiés
+- **Taux de succès :** 100 %
+- **Bugs bloquants :** 0
+- **Stories Storybook :** 24 créées

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/tasks/US-E1-01-tasks.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-2-design-system/tasks/US-E1-01-tasks.md
@@ -1,0 +1,32 @@
+# Tâches — US-E1-01 : Tokens de design (couleurs, typographie, espacements)
+
+**Epic :** E1 — Design System
+**Story Points :** 3
+**Sprint :** Sprint 2 — Design System
+
+## Résumé
+
+**En tant que** designer/développeur,
+**je veux** un ensemble de tokens de design centralisés,
+**afin que** toutes les interfaces partagent une identité visuelle cohérente.
+
+## Tâches
+
+| ID | Type | Tâche | Estimation | Statut |
+|----|------|-------|------------|--------|
+| T-E1-01-1 | [FE-WEB] | Définir la palette de couleurs (primaire, secondaire, neutres, états) en JSON | 0,5 h | done |
+| T-E1-01-2 | [FE-WEB] | Définir la typographie (familles, tailles, graisses, hauteurs de ligne) | 0,5 h | done |
+| T-E1-01-3 | [FE-WEB] | Définir les espacements (grille 4px, échelle de marges et paddings) | 0,25 h | done |
+| T-E1-01-4 | [FE-WEB] | Configurer Style Dictionary pour générer CSS variables + JSON + constantes TS | 1 h | done |
+| T-E1-01-5 | [FE-WEB] | Intégrer les tokens dans le thème de l'application | 0,5 h | done |
+| T-E1-01-6 | [TEST] | Écrire un test de régression snapshot sur les tokens compilés | 0,5 h | done |
+| T-E1-01-7 | [REV] | Revue design : validation de la palette par la designeuse | 0,5 h | done |
+
+**Total estimé :** 3,75 h
+
+## Dépendances
+
+- T-E1-01-1 + T-E1-01-2 + T-E1-01-3 → T-E1-01-4 (tous les tokens définis avant la compilation)
+- T-E1-01-4 → T-E1-01-5 (tokens compilés avant intégration)
+- T-E1-01-5 → T-E1-01-6 (intégration avant snapshot)
+- T-E1-01-6 → T-E1-01-7 (tests verts avant revue design)

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/sprint-backlog.md
@@ -1,0 +1,10 @@
+# Sprint 3 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E1-04 | Thème sombre et thème clair | 3 | done |
+| US-E1-05 | Documentation Storybook et guide de contribution | 2 | done |
+| US-E2-01 | Formulaire de génération d'itinéraire | 5 | done |
+| US-E2-02 | Génération IA via ProviderAI | 8 | done |
+
+**Total :** 18 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 3 — Génération
+
+Livrer le formulaire de génération d'itinéraire et l'intégration ProviderAI afin qu'un utilisateur puisse obtenir son premier itinéraire personnalisé de bout en bout.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/sprint-retro.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/sprint-retro.md
@@ -1,0 +1,34 @@
+# Sprint 3 — Rétrospective (Starfish)
+
+## Continuer
+
+- Les sessions de pair-programming sur l'intégration ProviderAI : très efficaces pour débloquer rapidement les problèmes.
+- Les démonstrations quotidiennes en fin de journée pour garder l'équipe alignée.
+
+## Arrêter
+
+- L'estimation à la volée sans référence aux stories similaires passées.
+
+## Commencer
+
+- Inclure un test de charge sur ProviderAI à chaque sprint qui touche à la génération.
+- Définir un "Definition of Ready" plus strict avant le sprint planning.
+
+## Faire plus
+
+- Automatiser les tests de performance de génération en CI.
+
+## Faire moins
+
+- Les revues de PR tardives en fin de sprint qui créent des embouteillages.
+
+## Actions
+
+| # | Action | Responsable | Deadline |
+|---|--------|-------------|----------|
+| 1 | Ajouter un test de charge ProviderAI en CI | DevOps | Sprint 4 J3 |
+| 2 | Rédiger le "Definition of Ready" | PO | Sprint 4 planning |
+
+## ROTI
+
+**Score :** 4/5 — Bonne vélocité, la qualité de l'intégration ProviderAI dépasse les attentes.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/sprint-review.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/sprint-review.md
@@ -1,0 +1,24 @@
+# Sprint 3 — Review
+
+| Sprint | Epic | Date | Commit |
+|--------|------|------|--------|
+| Sprint 3 | E1, E2 | 2026-02-13 | b7c8d9e |
+
+**Goal :** Livrer le formulaire de génération et l'intégration ProviderAI.
+**Atteint :** OUI
+
+## Stories livrées
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E1-04 | Thème sombre et thème clair | 3 | done |
+| US-E1-05 | Documentation Storybook | 2 | done |
+| US-E2-01 | Formulaire de génération | 5 | done |
+| US-E2-02 | Génération IA via ProviderAI | 8 | done |
+
+## Métriques
+
+- **Vélocité :** 18 SP livrés / 18 SP planifiés
+- **Taux de succès :** 100 %
+- **Temps de génération moyen :** 6,2 s (objectif < 10 s atteint)
+- **Bugs bloquants :** 1 (corrigé en cours de sprint)

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/tasks/US-E2-01-tasks.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-3-generation/tasks/US-E2-01-tasks.md
@@ -1,0 +1,34 @@
+# Tâches — US-E2-01 : Formulaire de génération d'itinéraire
+
+**Epic :** E2 — Génération & Détail
+**Story Points :** 5
+**Sprint :** Sprint 3 — Génération
+
+## Résumé
+
+**En tant qu'** utilisateur,
+**je veux** remplir un formulaire simple,
+**afin de** paramétrer mon itinéraire selon mes préférences (durée, niveau, type d'activité).
+
+## Tâches
+
+| ID | Type | Tâche | Estimation | Statut |
+|----|------|-------|------------|--------|
+| T-E2-01-1 | [FE-WEB] | Créer le composant `GenerationForm` avec les champs durée, niveau et type | 1,5 h | done |
+| T-E2-01-2 | [FE-WEB] | Implémenter la validation côté client (champs requis, valeurs autorisées) | 0,5 h | done |
+| T-E2-01-3 | [FE-WEB] | Afficher les messages d'erreur contextuels sous chaque champ invalide | 0,5 h | done |
+| T-E2-01-4 | [FE-WEB] | Afficher un indicateur de progression lors de la soumission | 0,5 h | done |
+| T-E2-01-5 | [BE] | Créer l'endpoint `POST /api/v1/itineraries/generate` avec validation schema | 1 h | done |
+| T-E2-01-6 | [DB] | Ajouter la table `generation_requests` pour tracer les appels | 0,5 h | done |
+| T-E2-01-7 | [TEST] | Écrire les tests unitaires de validation (cas valides et invalides) | 0,75 h | done |
+| T-E2-01-8 | [TEST] | Écrire le test d'intégration du flux formulaire → API | 0,5 h | done |
+| T-E2-01-9 | [REV] | Revue accessibilité : vérifier les labels, aria et focus management | 0,5 h | done |
+
+**Total estimé :** 6,25 h
+
+## Dépendances
+
+- T-E2-01-1 → T-E2-01-2 → T-E2-01-3 (validation et erreurs après le composant de base)
+- T-E2-01-5 → T-E2-01-6 (endpoint avant la table de traçage)
+- T-E2-01-1 + T-E2-01-5 → T-E2-01-8 (composant et API requis pour le test d'intégration)
+- T-E2-01-4 → T-E2-01-9 (indicateur de progression en place avant la revue accessibilité)

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-4-detail-navigation/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-4-detail-navigation/sprint-backlog.md
@@ -1,0 +1,10 @@
+# Sprint 4 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E2-03 | Page de détail d'un itinéraire | 5 | done |
+| US-E2-04 | Modification manuelle d'un itinéraire généré | 5 | done |
+| US-E2-05a | Export PDF de l'itinéraire | 3 | done |
+| US-E3-01 | Bibliothèque personnelle d'itinéraires | 5 | done |
+
+**Total :** 18 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-4-detail-navigation/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-4-detail-navigation/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 4 — Détail & Navigation
+
+Livrer la page de détail d'un itinéraire et la modification manuelle afin que les utilisateurs puissent consulter et personnaliser leurs parcours générés.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-4-detail-navigation/sprint-retro.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-4-detail-navigation/sprint-retro.md
@@ -1,0 +1,25 @@
+# Sprint 4 — Rétrospective (Mad-Sad-Glad)
+
+## Mad
+
+- La génération de PDF a introduit une dépendance externe non anticipée, causant 4 h de blocage.
+
+## Sad
+
+- Le glisser-déposer pour la modification des étapes n'a pas été testé sur mobile pendant le sprint.
+
+## Glad
+
+- La page de détail est unanimement saluée lors de la démo : l'UX est claire et intuitive.
+- La bibliothèque fonctionne parfaitement dès la première itération.
+
+## Actions
+
+| # | Action | Responsable | Deadline |
+|---|--------|-------------|----------|
+| 1 | Intégrer les tests mobiles dans la DoD | QA | Sprint 5 J1 |
+| 2 | Auditer les dépendances externes avant intégration | Tech Lead | Sprint 5 planning |
+
+## ROTI
+
+**Score :** 4/5 — Bonne livraison, quelques surprises techniques à mieux anticiper.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-4-detail-navigation/sprint-review.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-4-detail-navigation/sprint-review.md
@@ -1,0 +1,24 @@
+# Sprint 4 — Review
+
+| Sprint | Epic | Date | Commit |
+|--------|------|------|--------|
+| Sprint 4 | E2, E3 | 2026-02-27 | e1f2a3b |
+
+**Goal :** Livrer la page de détail et la modification manuelle.
+**Atteint :** OUI
+
+## Stories livrées
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E2-03 | Page de détail d'un itinéraire | 5 | done |
+| US-E2-04 | Modification manuelle d'un itinéraire | 5 | done |
+| US-E2-05a | Export PDF | 3 | done |
+| US-E3-01 | Bibliothèque personnelle | 5 | done |
+
+## Métriques
+
+- **Vélocité :** 18 SP livrés / 18 SP planifiés
+- **Taux de succès :** 100 %
+- **Bugs bloquants :** 0
+- **Score accessibilité Lighthouse :** 92/100

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-5-navigation-finale/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-5-navigation-finale/sprint-backlog.md
@@ -1,0 +1,11 @@
+# Sprint 5 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E2-05b | Partage d'itinéraire par lien | 2 | done |
+| US-E3-02 | Filtres et recherche dans la bibliothèque | 3 | done |
+| US-E3-03 | Favoris et collections | 3 | done |
+| US-E5-01 | Fonctionnalité "Surprise-moi" | 5 | done |
+| US-E5-04 | Itinéraire du jour | 2 | done |
+
+**Total :** 15 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-5-navigation-finale/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-5-navigation-finale/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 5 — Navigation finale
+
+Compléter la navigation de l'application (partage, filtres bibliothèque, favoris) et livrer la fonctionnalité "Surprise-moi" afin que le flux utilisateur de bout en bout soit fonctionnel.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-5-navigation-finale/sprint-retro.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-5-navigation-finale/sprint-retro.md
@@ -1,0 +1,33 @@
+# Sprint 5 — Rétrospective (Starfish)
+
+## Continuer
+
+- Les démos intermédiaires à mi-sprint pour valider les interactions avant la review finale.
+- La collaboration étroite entre UX et développement sur la fonctionnalité "Surprise-moi".
+
+## Arrêter
+
+- Fusionner des PR sans revue d'un second développeur en fin de sprint.
+
+## Commencer
+
+- Ajouter des métriques de satisfaction utilisateur (NPS micro-survey) après chaque sprint.
+
+## Faire plus
+
+- Les tests d'intégration sur les flux de navigation complets.
+
+## Faire moins
+
+- Les estimations en solitaire : préférer le planning poker à 3 minimum.
+
+## Actions
+
+| # | Action | Responsable | Deadline |
+|---|--------|-------------|----------|
+| 1 | Mettre en place une règle de protection de branche : 2 approbations requises | DevOps | Sprint 6 J1 |
+| 2 | Configurer le micro-survey NPS en fin de session | PO | Sprint 6 J5 |
+
+## ROTI
+
+**Score :** 5/5 — Sprint fluide, l'équipe est en rythme et les fonctionnalités sont solides.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-5-navigation-finale/sprint-review.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-5-navigation-finale/sprint-review.md
@@ -1,0 +1,25 @@
+# Sprint 5 — Review
+
+| Sprint | Epic | Date | Commit |
+|--------|------|------|--------|
+| Sprint 5 | E2, E3, E5 | 2026-03-13 | c4d5e6f |
+
+**Goal :** Compléter la navigation et livrer "Surprise-moi".
+**Atteint :** OUI
+
+## Stories livrées
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E2-05b | Partage d'itinéraire par lien | 2 | done |
+| US-E3-02 | Filtres et recherche | 3 | done |
+| US-E3-03 | Favoris et collections | 3 | done |
+| US-E5-01 | "Surprise-moi" | 5 | done |
+| US-E5-04 | Itinéraire du jour | 2 | done |
+
+## Métriques
+
+- **Vélocité :** 15 SP livrés / 15 SP planifiés
+- **Taux de succès :** 100 %
+- **Bugs bloquants :** 0
+- **Temps de réponse "Surprise-moi" :** 7,1 s en médiane

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-6-library-gamification/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-6-library-gamification/sprint-backlog.md
@@ -1,0 +1,10 @@
+# Sprint 6 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E3-04 | Système de points d'expérience | 5 | done |
+| US-E3-05 | Badges de réussite | 5 | done |
+| US-E5-02 | Recommandations contextuelles | 5 | done |
+| US-E5-03 | Exploration thématique | 3 | done |
+
+**Total :** 18 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-6-library-gamification/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-6-library-gamification/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 6 — Bibliothèque & Gamification
+
+Livrer le système de points, les badges et le classement afin que les personas "Joueur" et "Sportif" trouvent une raison de revenir chaque jour sur Atlas.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-6-library-gamification/sprint-retro.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-6-library-gamification/sprint-retro.md
@@ -1,0 +1,25 @@
+# Sprint 6 — Rétrospective (Mad-Sad-Glad)
+
+## Mad
+
+- Le calcul des points a dû être refactorisé en cours de sprint après un désaccord sur la formule métier.
+
+## Sad
+
+- Le taux de rétention J7 à 38 % manque l'objectif de 40 % de 2 points : les badges seuls ne suffisent pas.
+
+## Glad
+
+- Les animations de déblocage de badges sont très appréciées lors de la démo.
+- Zéro bug bloquant pour le deuxième sprint consécutif.
+
+## Actions
+
+| # | Action | Responsable | Deadline |
+|---|--------|-------------|----------|
+| 1 | Définir la formule de points avec le PO avant le sprint planning | PO + Tech Lead | Sprint 7 planning |
+| 2 | Analyser les données de rétention pour identifier les moments de décrochage | Data | Sprint 7 J3 |
+
+## ROTI
+
+**Score :** 4/5 — Bonne livraison, légère déception sur la rétention mais les bases sont solides.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-6-library-gamification/sprint-review.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-6-library-gamification/sprint-review.md
@@ -1,0 +1,24 @@
+# Sprint 6 — Review
+
+| Sprint | Epic | Date | Commit |
+|--------|------|------|--------|
+| Sprint 6 | E3, E5 | 2026-03-27 | f7a8b9c |
+
+**Goal :** Livrer le système de gamification (points, badges).
+**Atteint :** OUI
+
+## Stories livrées
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E3-04 | Système de points d'expérience | 5 | done |
+| US-E3-05 | Badges de réussite | 5 | done |
+| US-E5-02 | Recommandations contextuelles | 5 | done |
+| US-E5-03 | Exploration thématique | 3 | done |
+
+## Métriques
+
+- **Vélocité :** 18 SP livrés / 18 SP planifiés
+- **Taux de succès :** 100 %
+- **Bugs bloquants :** 0
+- **Taux de rétention J7 (beta) :** 38 % (objectif 40 % presque atteint)

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-7-badges-leaderboard/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-7-badges-leaderboard/sprint-backlog.md
@@ -1,0 +1,11 @@
+# Sprint 7 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E3-06 | Classement des utilisateurs | 5 | done |
+| US-E3-07 | Défis hebdomadaires | 3 | done |
+| US-E5-05 | Partage de découverte entre utilisateurs | 3 | done |
+| US-E6-01 | Animations fluides et transitions | 3 | done |
+| US-E6-02 | Gestes tactiles avancés | 3 | done |
+
+**Total :** 17 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-7-badges-leaderboard/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-7-badges-leaderboard/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 7 — Badges & Classement
+
+Livrer le classement des utilisateurs, les défis hebdomadaires et le partage communautaire afin d'atteindre l'objectif de rétention J7 à 40 %.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-7-badges-leaderboard/sprint-retro.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-7-badges-leaderboard/sprint-retro.md
@@ -1,0 +1,33 @@
+# Sprint 7 — Rétrospective (Starfish)
+
+## Continuer
+
+- L'analyse hebdomadaire des métriques de rétention en cours de sprint.
+- Les tests de performance mobile systématiques avant la review.
+
+## Arrêter
+
+- Accepter les stories sans critères de performance définis.
+
+## Commencer
+
+- Mesurer la satisfaction in-app (thumbs up/down) sur chaque nouvelle fonctionnalité.
+
+## Faire plus
+
+- Impliquer les utilisateurs beta plus tôt dans la validation des interactions gamifiées.
+
+## Faire moins
+
+- Les estimations optimistes sur les animations — toujours prévoir 30 % de marge.
+
+## Actions
+
+| # | Action | Responsable | Deadline |
+|---|--------|-------------|----------|
+| 1 | Ajouter des critères de performance dans le template de story | PO | Sprint 8 planning |
+| 2 | Mettre en place le feedback in-app thumbs up/down | FE | Sprint 8 J5 |
+
+## ROTI
+
+**Score :** 5/5 — Objectif de rétention atteint, l'équipe est fière du résultat.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-7-badges-leaderboard/sprint-review.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-7-badges-leaderboard/sprint-review.md
@@ -1,0 +1,25 @@
+# Sprint 7 — Review
+
+| Sprint | Epic | Date | Commit |
+|--------|------|------|--------|
+| Sprint 7 | E3, E5, E6 | 2026-04-10 | d2e3f4a |
+
+**Goal :** Livrer le classement et les défis hebdomadaires.
+**Atteint :** OUI
+
+## Stories livrées
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E3-06 | Classement des utilisateurs | 5 | done |
+| US-E3-07 | Défis hebdomadaires | 3 | done |
+| US-E5-05 | Partage communautaire | 3 | done |
+| US-E6-01 | Animations fluides | 3 | done |
+| US-E6-02 | Gestes tactiles avancés | 3 | done |
+
+## Métriques
+
+- **Vélocité :** 17 SP livrés / 17 SP planifiés
+- **Taux de succès :** 100 %
+- **Bugs bloquants :** 0
+- **Taux de rétention J7 :** 43 % (objectif 40 % ATTEINT)

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-8-auth-settings/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-8-auth-settings/sprint-backlog.md
@@ -1,0 +1,12 @@
+# Sprint 8 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E4-01 | Inscription par email | 3 | done |
+| US-E4-02 | Connexion via AuthProvider | 3 | done |
+| US-E4-03 | Gestion du profil utilisateur | 3 | done |
+| US-E4-04 | Paramètres de notifications | 2 | done |
+| US-E6-03 | Mode hors-ligne partiel | 5 | done |
+| US-E6-04 | Adaptation aux tablettes | 3 | done |
+
+**Total :** 19 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-8-auth-settings/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-8-auth-settings/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 8 — Auth & Paramètres
+
+Livrer l'authentification complète (AuthProvider et email), la gestion de profil, les paramètres de notifications et le polish mobile restant, afin que les utilisateurs puissent créer et gérer leur compte de manière autonome.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-8-auth-settings/sprint-retro.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-8-auth-settings/sprint-retro.md
@@ -1,0 +1,26 @@
+# Sprint 8 — Rétrospective (Mad-Sad-Glad)
+
+## Mad
+
+- Le bug OAuth redirect loop sur iOS n'a été découvert qu'en fin de sprint faute de tests sur device réel.
+
+## Sad
+
+- US-E6-04 (tablettes) reste en review : la mise en page deux colonnes nécessite plus de travail que prévu.
+- La vélocité effective (16 SP) en dessous du planifié (19 SP) pour la première fois.
+
+## Glad
+
+- L'intégration AuthProvider est solide et bien documentée.
+- Le mode hors-ligne livré sans régression sur les fonctionnalités existantes.
+
+## Actions
+
+| # | Action | Responsable | Deadline |
+|---|--------|-------------|----------|
+| 1 | Ajouter des tests sur device réel (iOS + Android) dans la DoD | QA | Sprint 9 J1 |
+| 2 | Finir US-E6-04 en priorité Sprint 9 J1 | FE | Sprint 9 J2 |
+
+## ROTI
+
+**Score :** 3/5 — Sprint difficile, bug OAuth et story non livrée, mais les leçons sont claires.

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-8-auth-settings/sprint-review.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-8-auth-settings/sprint-review.md
@@ -1,0 +1,26 @@
+# Sprint 8 — Review
+
+| Sprint | Epic | Date | Commit |
+|--------|------|------|--------|
+| Sprint 8 | E4, E6 | 2026-04-24 | b5c6d7e |
+
+**Goal :** Livrer l'authentification complète et le polish mobile.
+**Atteint :** PARTIELLEMENT
+
+## Stories livrées
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E4-01 | Inscription par email | 3 | done |
+| US-E4-02 | Connexion via AuthProvider | 3 | done |
+| US-E4-03 | Gestion du profil utilisateur | 3 | done |
+| US-E4-04 | Paramètres de notifications | 2 | done |
+| US-E6-03 | Mode hors-ligne partiel | 5 | done |
+| US-E6-04 | Adaptation aux tablettes | 3 | in-review |
+
+## Métriques
+
+- **Vélocité :** 16 SP livrés / 19 SP planifiés (US-E6-04 reportée en review)
+- **Taux de succès :** 84 %
+- **Bugs bloquants :** 1 (OAuth redirect loop sur iOS, corrigé post-sprint)
+- **Score Lighthouse performance :** 91/100

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-9-auth-premium/phase-0-checklist.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-9-auth-premium/phase-0-checklist.md
@@ -1,0 +1,30 @@
+# Sprint 9 — Checklist Phase 0
+
+Vérifications à compléter avant de démarrer l'implémentation du Sprint 9.
+
+## Environnement
+
+- [x] Accès au tableau de bord PaymentProvider (mode sandbox) confirmé
+- [x] Webhooks PaymentProvider configurés sur l'environnement de développement
+- [ ] Certificats SSL à jour sur l'environnement de staging
+- [x] Variables d'environnement PaymentProvider présentes dans le vault
+
+## Définition de prêt (Definition of Ready)
+
+- [x] US-E4-05 : maquettes validées par le designer
+- [x] US-E4-06 : contrat d'intégration PaymentProvider signé
+- [ ] US-E4-07a : critères d'acceptation relus et approuvés par le PO
+- [ ] US-E4-07b : dépendance sur US-E4-06 documentée
+- [x] US-E4-08 : avis juridique RGPD reçu
+- [x] US-E6-04 : story reportée de Sprint 8, aucune modification du périmètre
+
+## Risques identifiés
+
+- **Moyen :** Délai de validation PaymentProvider côté sandbox (prévoir +2 jours)
+- **Faible :** US-E4-08 (suppression RGPD) nécessite une coordination avec le DPO
+
+## Décision de go/no-go
+
+- [ ] Validation Tech Lead
+- [ ] Validation PO
+- [ ] Validation QA

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-9-auth-premium/sprint-backlog.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-9-auth-premium/sprint-backlog.md
@@ -1,0 +1,14 @@
+# Sprint 9 — Backlog
+
+| ID | Titre | Points | Statut |
+|----|-------|--------|--------|
+| US-E6-04 | Adaptation aux tablettes (report Sprint 8) | 3 | in-progress |
+| US-E6-05 | Optimisation des performances de démarrage | 3 | ready-for-dev |
+| US-E4-05 | Page d'abonnement premium | 3 | in-progress |
+| US-E4-06 | Souscription via PaymentProvider | 5 | in-progress |
+| US-E4-07a | Gestion abonnement : consultation et annulation | 4 | ready-for-dev |
+| US-E4-07b | Gestion abonnement : mise à jour moyen de paiement | 4 | ready-for-dev |
+| US-E4-08 | Suppression de compte (RGPD) | 3 | ready-for-dev |
+| US-200 | Story legacy markdown (id numérique valide) | 5 | in-progress |
+
+**Total :** 30 SP

--- a/tests/fixtures/wrandly-anon/project-management/sprints/sprint-9-auth-premium/sprint-goal.md
+++ b/tests/fixtures/wrandly-anon/project-management/sprints/sprint-9-auth-premium/sprint-goal.md
@@ -1,0 +1,3 @@
+# Sprint 9 — Auth Premium
+
+Livrer le système d'abonnement premium via PaymentProvider et la suppression de compte RGPD afin que le modèle économique d'Atlas soit opérationnel avant le lancement.

--- a/tests/kanban/wrandly-anon-api.test.js
+++ b/tests/kanban/wrandly-anon-api.test.js
@@ -1,0 +1,132 @@
+/**
+ * E2E API tests — full @hono/node-server boot against the anonymized "Atlas"
+ * BMAD v6 fixture, exercising every route that feeds a kanban screen. Asserts
+ * each screen receives COMPLETE and COHERENT data.
+ *
+ * The 6 screens are pure renderers of these payloads, so an end-to-end assertion
+ * at the API boundary directly reproduces "info doesn't show / is incoherent".
+ *
+ * Written BEFORE the fixes (TDD red).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { cp, mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { serve } from '@hono/node-server';
+import { Repository } from '../../cli/kanban/server/services/repository.js';
+import { createApp } from '../../cli/kanban/server/app.js';
+import { EventBus } from '../../cli/kanban/server/services/event-bus.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.resolve(__dirname, '../fixtures/wrandly-anon');
+
+let dir, server, port;
+
+beforeAll(async () => {
+  dir = await mkdtemp(path.join(tmpdir(), 'kb-wrandly-e2e-'));
+  await cp(FIXTURE, dir, { recursive: true });
+  const repo = new Repository(path.join(dir, 'project-management'));
+  await repo.refresh();
+  const bus = new EventBus();
+  const app = createApp({ repository: repo, port: 3737, eventBus: bus, projectRoot: dir });
+  server = serve({ fetch: app.fetch, hostname: '127.0.0.1', port: 0 });
+  await new Promise((resolve) => {
+    if (server.listening) return resolve();
+    server.once('listening', resolve);
+  });
+  port = server.address().port;
+});
+
+afterAll(async () => {
+  if (server) await new Promise((resolve) => server.close(resolve));
+  await rm(dir, { recursive: true, force: true });
+});
+
+const get = async (p) => {
+  const res = await fetch(`http://127.0.0.1:${port}${p}`);
+  return { status: res.status, json: res.status < 400 ? await res.json() : null };
+};
+
+describe('Kanban + Backlog screens (/api/stories)', () => {
+  it('returns the full story set (history + current), not just the active sprint', async () => {
+    const { json } = await get('/api/stories');
+    // current sprint (6) + 8 archived sprints worth of stories + 1 markdown story.
+    expect(json.stories.length).toBeGreaterThan(30);
+  });
+
+  it('never leaves every story stuck on priority "should"', async () => {
+    const { json } = await get('/api/stories');
+    const priorities = new Set(json.stories.map((s) => s.priority));
+    expect(priorities.size).toBeGreaterThan(1);
+    expect(priorities.has('must')).toBe(true);
+  });
+});
+
+describe('Sprints screen (/api/sprints list)', () => {
+  it('lists all 9 sprints with non-empty point roll-ups', async () => {
+    const { json } = await get('/api/sprints');
+    expect(json.sprints.length).toBe(9);
+    const s1 = json.sprints.find((s) => s.id === 'sprint-1-infrastructure');
+    expect(s1.story_count).toBe(8);
+    expect(s1.total_points).toBe(25);
+    expect(s1.done_points).toBe(25);
+  });
+
+  it('reports has_review / has_retro coherently with the files on disk', async () => {
+    const { json } = await get('/api/sprints');
+    const s1 = json.sprints.find((s) => s.id === 'sprint-1-infrastructure');
+    const s2 = json.sprints.find((s) => s.id === 'sprint-2-design-system');
+    const s9 = json.sprints.find((s) => s.id === 'sprint-9-auth-premium');
+    expect(s1.has_retro).toBe(false); // sprint-1 has no retro file
+    expect(s2.has_retro).toBe(true);
+    expect(s9.has_review).toBe(false); // current sprint not closed
+  });
+});
+
+describe('Sprint detail screen (/api/sprints/:id)', () => {
+  it('exposes a sprint object with name and dates (shape coherent with /current)', async () => {
+    const { json } = await get('/api/sprints/sprint-9-auth-premium');
+    // RED: current detail returns { id, has_goal, has_review, has_retro } — no name/dates.
+    expect(json.sprint.name).toBeTruthy();
+    expect(json.sprint.start_date).toBeTruthy();
+    expect(json.sprint.end_date).toBeTruthy();
+  });
+
+  it('returns stories with their assignee for the detail table', async () => {
+    const { json } = await get('/api/sprints/sprint-1-infrastructure');
+    expect(json.stories.length).toBe(8);
+    expect(json.stories[0]).toHaveProperty('assigned_to');
+  });
+});
+
+describe('Burndown screen (/api/sprints/current)', () => {
+  it('returns 200 with the current sprint name, capacity and a coherent burndown total', async () => {
+    const { status, json } = await get('/api/sprints/current');
+    expect(status).toBe(200);
+    expect(json.sprint.name).toBeTruthy();
+    expect(json.sprint.capacity_points).toBe(13);
+    const sumPoints = json.stories.reduce((n, s) => n + (s.story_points ?? 0), 0);
+    expect(json.burndown.total_points).toBe(sumPoints);
+  });
+});
+
+describe('Dependencies screen (/api/dependencies)', () => {
+  it('builds a non-empty graph from the freeform YAML dependency strings', async () => {
+    const { json } = await get('/api/dependencies');
+    expect(json.nodes.length).toBeGreaterThan(0);
+    expect(json.edges.length).toBeGreaterThan(0);
+    const edge = json.edges.find((e) => e.to === 'US-E4-03' || e.from === 'US-E4-03');
+    expect(edge).toBeDefined();
+  });
+});
+
+describe('Docs screen (/api/docs)', () => {
+  it('lists browsable markdown (prd, architecture, sprint goals/reviews/retros)', async () => {
+    const { json } = await get('/api/docs');
+    const rels = json.docs.map((d) => d.rel);
+    expect(rels).toContain('prd.md');
+    expect(rels.some((r) => r.startsWith('architecture/'))).toBe(true);
+    expect(rels.some((r) => r.endsWith('sprint-review.md'))).toBe(true);
+  });
+});

--- a/tests/kanban/wrandly-anon-ingestion.test.js
+++ b/tests/kanban/wrandly-anon-ingestion.test.js
@@ -1,0 +1,128 @@
+/**
+ * Functional tests — ingestion of a realistic anonymized BMAD v6 project ("Atlas")
+ * into the kanban Repository. These reproduce the bugs reported on the real board:
+ * whole-board-empty (schema rejects null/loose fields), archived sprints invisible,
+ * priority frozen to 'should', dependencies dropped.
+ *
+ * Fixture: tests/fixtures/wrandly-anon (BMAD v6 single-writer track — stories live in
+ * .bmad/sprint-status.yaml; no standalone US-*.md except two edge-case markdown stories).
+ *
+ * Written BEFORE the fixes (TDD red). They MUST fail until repository.js / schemas.js /
+ * sprint-cache.js are corrected.
+ */
+import { describe, it, expect, beforeEach } from 'vitest';
+import { mkdtemp, cp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Repository } from '../../cli/kanban/server/services/repository.js';
+import { loadSprintStatus } from '../../cli/kanban/server/services/sprint-cache.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const FIXTURE = path.resolve(__dirname, '../fixtures/wrandly-anon');
+
+const CURRENT_SPRINT = 'sprint-9-auth-premium';
+
+let projectRoot; // tmp copy root (parent of project-management/)
+let repo;
+
+beforeEach(async () => {
+  const dir = await mkdtemp(path.join(tmpdir(), 'kb-wrandly-'));
+  await cp(FIXTURE, dir, { recursive: true });
+  projectRoot = dir;
+  repo = new Repository(path.join(dir, 'project-management'));
+  await repo.refresh();
+});
+
+describe('sprint-status.yaml validation (real BMAD v6 shape)', () => {
+  it('accepts assigned_to:null and loose tdd_phase without flagging the file invalid', async () => {
+    const ss = await loadSprintStatus(projectRoot);
+    expect(ss).not.toBeNull();
+    // RED: current schema rejects assigned_to:null and tdd_phase "not-started"/"review"
+    // → safeParse fails → loadSprintStatus returns { _invalid: true } → board empty.
+    expect(ss._invalid).toBeFalsy();
+    expect(ss.metadata.sprint_id).toBe(CURRENT_SPRINT);
+  });
+
+  it('preserves capacity_points on the current sprint metadata', async () => {
+    const ss = await loadSprintStatus(projectRoot);
+    expect(ss._invalid).toBeFalsy();
+    expect(ss.metadata.capacity_points).toBe(13);
+  });
+});
+
+describe('current sprint stories surfaced', () => {
+  it('exposes all current-sprint stories from the YAML overlay', () => {
+    const ids = new Set(repo.listStories({ sprintId: CURRENT_SPRINT }).map((s) => s.id));
+    for (const id of ['TT-20', 'US-E4-03', 'US-E4-06', 'US-E4-07a', 'US-E4-07b', 'US-E4-08']) {
+      expect(ids.has(id), `missing ${id}`).toBe(true);
+    }
+    // US-200 is a markdown-backed story also pinned to this sprint.
+    expect(ids.has('US-200')).toBe(true);
+  });
+
+  it('maps BMAD P0..P3 priorities onto the MoSCoW enum', () => {
+    const byId = Object.fromEntries(repo.listStories({ sprintId: CURRENT_SPRINT }).map((s) => [s.id, s]));
+    // P0->must, P1->should, P2->could, P3->wont
+    expect(byId['US-E4-03'].priority).toBe('must'); // P0
+    expect(byId['US-E4-07b'].priority).toBe('should'); // P1
+    expect(byId['US-E4-06'].priority).toBe('could'); // P2
+    expect(byId['US-E4-08'].priority).toBe('wont'); // P3
+  });
+
+  it('parses freeform dependency strings down to known story ids', () => {
+    const story = repo.getStory('US-E4-03');
+    // dependencies in YAML: ["US-E4-02 (modèle compte, S8, done)", "Config console AuthProvider ..."]
+    expect(story.dependencies).toContain('US-E4-02');
+  });
+
+  it('keeps a YAML-only story read-only (no backing markdown file)', () => {
+    const story = repo.getStory('US-E4-03');
+    expect(story._writable).toBe(false);
+    expect(story._source).toBe('sprint-status');
+  });
+
+  it('handles assigned_to:null and role assignees without crashing', () => {
+    const byId = Object.fromEntries(repo.listStories({ sprintId: CURRENT_SPRINT }).map((s) => [s.id, s]));
+    expect(byId['US-E4-03'].assigned_to ?? '').toBe(''); // null normalized
+    expect(byId['TT-20'].assigned_to).toBe('conductor');
+  });
+});
+
+describe('archived sprint history surfaced', () => {
+  it('ingests archived_sprints stories with their sprint_id and points', () => {
+    const s1 = repo.listStories({ sprintId: 'sprint-1-infrastructure' });
+    expect(s1.length).toBe(8);
+    const total = s1.reduce((n, s) => n + (s.story_points ?? 0), 0);
+    expect(total).toBe(25); // points_delivered for sprint-1
+    expect(s1.every((s) => s.status === 'done')).toBe(true);
+  });
+
+  it('carries the epic from the archived sprint onto its stories', () => {
+    const s2 = repo.listStories({ sprintId: 'sprint-2-design-system' });
+    expect(s2.length).toBe(8); // US-E1-01..05 + TT-01..03
+    expect(s2.every((s) => s.epic_id === 'E1')).toBe(true);
+  });
+
+  it('marks archived stories read-only', () => {
+    const s1 = repo.listStories({ sprintId: 'sprint-1-infrastructure' });
+    expect(s1.length).toBe(8);
+    expect(s1.every((s) => s._writable === false)).toBe(true);
+  });
+
+  it('surfaces deferred stories without breaking the enum', () => {
+    // TT-03 is "deferred" in sprint-2 archived data.
+    const s2 = repo.listStories({ sprintId: 'sprint-2-design-system' });
+    const tt03 = s2.find((s) => s.id === 'TT-03');
+    expect(tt03).toBeDefined();
+  });
+});
+
+describe('markdown story edge cases', () => {
+  it('classifies a numeric-id markdown story and lets it win over any YAML entry', () => {
+    const legacy = repo.getStory('US-200');
+    expect(legacy).not.toBeNull();
+    expect(legacy._writable).toBe(true);
+    expect(legacy._source).toBe('markdown');
+  });
+});

--- a/tests/kanban/wrandly-anon-units.test.js
+++ b/tests/kanban/wrandly-anon-units.test.js
@@ -1,0 +1,117 @@
+/**
+ * Unit tests — pure logic extracted to support the kanban fixes. These target
+ * small, DOM-free helpers (new modules created in the fix phase) plus the
+ * existing config color map. Written BEFORE the fixes (TDD red): the imports of
+ * not-yet-created modules will fail until Phase 3 lands them.
+ */
+import { describe, it, expect } from 'vitest';
+
+import { TASK_TYPE } from '../../cli/kanban/client/src/lib/config.js';
+import { mapBmadPriority } from '../../cli/kanban/shared/priority.js';
+import { parseDependencyRefs } from '../../cli/kanban/shared/deps.js';
+import { computeSprintProgress } from '../../cli/kanban/client/src/lib/progress.js';
+import { alignBurndownByDate } from '../../cli/kanban/client/src/lib/burndown.js';
+import { classifyKanbanEvent } from '../../cli/kanban/client/src/lib/events.js';
+
+describe('config TASK_TYPE matches the schema task types', () => {
+  // schemas.js TASK_TYPES = ['DB','BE','FE-WEB','FE-MOB','TEST','DOC','OPS','REV']
+  it('defines a color for every schema task type', () => {
+    for (const t of ['DB', 'BE', 'FE-WEB', 'FE-MOB', 'TEST', 'DOC', 'OPS', 'REV']) {
+      expect(TASK_TYPE[t], `missing color for ${t}`).toBeTruthy();
+    }
+  });
+  it('drops the stale keys that match no task type', () => {
+    expect(TASK_TYPE.FE).toBeUndefined();
+    expect(TASK_TYPE.DOCS).toBeUndefined();
+  });
+});
+
+describe('mapBmadPriority (P0..P3 -> MoSCoW)', () => {
+  it('maps each BMAD priority', () => {
+    expect(mapBmadPriority('P0')).toBe('must');
+    expect(mapBmadPriority('P1')).toBe('should');
+    expect(mapBmadPriority('P2')).toBe('could');
+    expect(mapBmadPriority('P3')).toBe('wont');
+  });
+  it('passes through valid MoSCoW values and defaults the rest to should', () => {
+    expect(mapBmadPriority('must')).toBe('must');
+    expect(mapBmadPriority(undefined)).toBe('should');
+    expect(mapBmadPriority('weird')).toBe('should');
+  });
+});
+
+describe('parseDependencyRefs (freeform strings -> ids)', () => {
+  it('extracts the leading id token from each freeform dependency', () => {
+    const refs = parseDependencyRefs([
+      'US-E4-02 (modèle compte, S8, done)',
+      'Config console AuthProvider (Phase 0, NON PRÊTE)',
+      'US-E4-07a (checkout + entitlements)',
+    ]);
+    expect(refs).toContain('US-E4-02');
+    expect(refs).toContain('US-E4-07a');
+    // a non-id sentence yields no ref
+    expect(refs).not.toContain('Config');
+  });
+  it('is safe on empty / undefined input', () => {
+    expect(parseDependencyRefs([])).toEqual([]);
+    expect(parseDependencyRefs(undefined)).toEqual([]);
+  });
+});
+
+describe('computeSprintProgress (App progress bar — sprint-scoped, bug #6)', () => {
+  const stories = [
+    { sprint_id: 'A', status: 'done', story_points: 5 },
+    { sprint_id: 'A', status: 'in-progress', story_points: 3 },
+    { sprint_id: 'B', status: 'done', story_points: 8 }, // other sprint must not count
+  ];
+  it('counts only stories of the active sprint', () => {
+    const p = computeSprintProgress(stories, 'A');
+    expect(p.totalPoints).toBe(8);
+    expect(p.donePoints).toBe(5);
+    expect(p.pct).toBe(Math.round((5 / 8) * 100));
+  });
+  it('returns 0% safely when the sprint has no points', () => {
+    const p = computeSprintProgress([], 'A');
+    expect(p.totalPoints).toBe(0);
+    expect(p.pct).toBe(0);
+  });
+});
+
+describe('alignBurndownByDate (sr-only table join by date, bug #8)', () => {
+  it('joins ideal and actual rows on their date, not their array index', () => {
+    const ideal = [
+      { date: '2026-07-27', points: 13 },
+      { date: '2026-07-28', points: 11 },
+      { date: '2026-07-29', points: 9 },
+    ];
+    const actual = [
+      { date: '2026-07-27', points: 13 },
+      { date: '2026-07-29', points: 6 }, // no entry on the 28th
+    ];
+    const rows = alignBurndownByDate(ideal, actual);
+    expect(rows.map((r) => r.date)).toEqual(['2026-07-27', '2026-07-28', '2026-07-29']);
+    const d29 = rows.find((r) => r.date === '2026-07-29');
+    expect(d29.ideal).toBe(9);
+    expect(d29.actual).toBe(6); // joined by date, would be wrong if joined by index
+    const d28 = rows.find((r) => r.date === '2026-07-28');
+    expect(d28.actual).toBeNull();
+  });
+});
+
+describe('classifyKanbanEvent (SSE refresh routing, bug #7)', () => {
+  it('reloads the sprint/burndown on a story status change', () => {
+    const r = classifyKanbanEvent({ event: 'story:updated' });
+    expect(r.reloadStories).toBe(true);
+    expect(r.reloadSprint).toBe(true);
+  });
+  it('reloads both on a relevant file change', () => {
+    const r = classifyKanbanEvent({ event: 'file:changed', payload: { category: 'story' } });
+    expect(r.reloadStories).toBe(true);
+    expect(r.reloadSprint).toBe(true);
+  });
+  it('ignores irrelevant file changes', () => {
+    const r = classifyKanbanEvent({ event: 'file:changed', payload: { category: 'other' } });
+    expect(r.reloadStories).toBe(false);
+    expect(r.reloadSprint).toBe(false);
+  });
+});


### PR DESCRIPTION
## Contexte
Sur un vrai projet BMAD v6 (stories uniquement dans `.bmad/sprint-status.yaml`), le board Kanban affichait des écrans vides ou incohérents. Audit complet (16 bugs) → tests d'abord (RED) → corrections (GREEN).

## Cause racine dominante
`SprintStatusSchema` rejetait `assigned_to: null` et `tdd_phase` libre (`not-started`/`review`) → fichier `_invalid` → **board + burndown entièrement vides**.

## Corrections

**Serveur / ingestion**
- Schéma assoupli (`passthrough`, `assigned_to` nullable, `tdd_phase` libre, `metadata` passthrough → préserve `capacity_points`).
- `Repository#ingestArchivedSprints` : l'historique des sprints clôturés (`archived_sprints.*.stories`) est désormais surfacé (read-only).
- Priorités `P0..P3` → MoSCoW (`shared/priority.js`) (avant : tout figé à `should`).
- Dépendances en texte libre parsées en refs d'id (`shared/deps.js`) → graphe Deps non vide.
- Métadonnées sprint (nom, dates, epic, points livrés) exposées ; shapes `/api/sprints*` homogènes.

**Client**
- Board + progression topbar scopés au sprint actif.
- SSE rafraîchit aussi le sprint/burndown.
- Table sr-only burndown jointe par date (a11y).
- `BurndownView` : `chart` sorti de `$state` (lu+écrit dans le même `$effect` → boucle réactive) → corrige le **doublon de canvas** et la **navigation figée**.
- `TASK_TYPE` aligné au schéma ; compteur de tâches réconcilié pour les `done` ; label Deps corrigé.

## Tests
- Fixture BMAD v6 **anonymisé et exhaustif** : `tests/fixtures/wrandly-anon/` (9 sprints, P0-P3, null/role assignees, TT-* 0pt done, deferred, deps freeform, titres accentués).
- Unit + fonctionnel + E2E (API) : `tests/kanban/wrandly-anon-{ingestion,api,units}.test.js` — rouges avant, verts après.
- Smoke navigateur (Chrome) : 9 sprints visibles, priorités variées, deps 47 nodes/5 edges, burndown 1 chart, nav OK.

## Vérif
- 1079 tests verts ; couverture 95.4% stmts / 89% branch (> seuils) ; lint + prettier OK ; build client OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)