### PR TITLE
chore(release): 8.16.0

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "name": "claude-craft",
       "source": "./",
       "description": "Multi-stack framework: 31 specialized agents (+39 infra on-demand), 125 commands across 15 namespaces, BMAD v6 sprint workflow, browser QA automation, and token optimization (RTK). 5 languages.",
-      "version": "8.15.1",
+      "version": "8.16.0",
       "category": "development-framework",
       "keywords": ["framework", "multi-stack", "bmad", "qa-automation", "tech-leads", "clean-architecture", "tdd"],
       "license": "MIT"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.15.1",
+  "version": "8.16.0",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.15.1 | **Languages:** en, fr, es, de, pt
+**Version:** 8.16.0 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.16.0] - 2026-06-15
+
+### Added
+- **Kanban — historique des sprints clôturés** (`claude-craft kanban`) : les stories de `archived_sprints.*` du `.bmad/sprint-status.yaml` sont désormais ingérées en lecture seule. Le board (scopé au sprint actif), le Backlog, les Sprints et le Burndown couvrent l'ensemble des sprints, plus seulement le sprint courant.
+- Jeu de données de test BMAD v6 anonymisé et exhaustif (`tests/fixtures/wrandly-anon`) + suites unit / fonctionnel / E2E (`tests/kanban/wrandly-anon-*`).
+
+### Fixed
+- **Kanban — board entièrement vide sur un vrai projet BMAD v6** : `SprintStatusSchema` rejetait `assigned_to: null` et un `tdd_phase` hors énum (`not-started`/`review`), marquant tout le fichier invalide → board + burndown vides. Schéma assoupli (passthrough, `assigned_to` nullable, `tdd_phase` libre, `metadata` passthrough préservant `capacity_points`).
+- **Priorités figées** : les priorités BMAD `P0..P3` sont mappées sur MoSCoW (avant : tout affiché « Should »).
+- **Dépendances perdues** : les dépendances en texte libre du YAML sont parsées en références d'id → le graphe Dependencies n'est plus vide.
+- **Métadonnées sprint** (nom, dates, epic, points livrés) exposées ; shapes `sprint` cohérentes entre `/api/sprints`, `/api/sprints/:id` et `/api/sprints/current`.
+- **Incohérences d'écrans** : progression topbar/sidebar scopée au sprint actif ; rafraîchissement SSE du burndown ; table sr-only du burndown jointe par date (a11y) ; couleurs `TASK_TYPE` alignées au schéma ; compteur de tâches réconcilié pour les stories `done` ; libellé d'arête du graphe Dependencies corrigé.
+- **BurndownView — canvas dupliqué et navigation figée** : l'instance `chart` était un `$state` lu et écrit dans le même `$effect`, créant une boucle réactive qui dupliquait le canvas uPlot et saturait la boucle d'événements (le `hashchange` ne pouvait plus se propager). `chart` repassé en `let` simple.
+
 ## [8.15.1] - 2026-06-15
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.15.1",
+  "version": "8.16.0",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
Release **8.16.0** (MINOR).

Headline : le board Kanban affiche désormais l'historique complet des sprints BMAD v6 et tous les écrans sont cohérents (voir #91).

## Bumps
- `package.json`, `.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, `.claude/CLAUDE.md` → 8.16.0
- `CHANGELOG.md` : section `[8.16.0]`

## Contenu (depuis 8.15.1)
- **Added** : ingestion `archived_sprints` (historique read-only) ; fixture BMAD v6 anonymisé + suites unit/fonctionnel/E2E.
- **Fixed** : board vide (schéma rejetait `assigned_to:null`/`tdd_phase` libre), priorités P0-P3, deps freeform, métadonnées sprint, progression/SSE/burndown/Deps, doublon canvas + nav figée (BurndownView `$state`).

Gates locaux : lint:versions ✅, docs:check ✅ (70 agents / 219 commandes), 1079 tests ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)