### PR TITLE
fix(kanban): correct 6 UI/UX board bugs

### DIFF
--- a/cli/kanban/client/src/App.svelte
+++ b/cli/kanban/client/src/App.svelte
@@ -6,6 +6,7 @@
   import { computeSprintProgress } from './lib/progress.js';
   import Icon from './components/Icon.svelte';
   import TweaksPanel from './components/TweaksPanel.svelte';
+  import StoryDetail from './components/StoryDetail.svelte';
   import KanbanView from './views/KanbanView.svelte';
   import BacklogView from './views/BacklogView.svelte';
   // Lazy-loaded : tire des libs viz lourdes (uPlot, Cytoscape, marked+dompurify).
@@ -190,3 +191,6 @@
 </div>
 
 <TweaksPanel bind:this={tweaksPanel} />
+
+<!-- Modale de détail partagée (Board + Backlog) — pilotée par lib/detail.svelte.js -->
+<StoryDetail />

--- a/cli/kanban/client/src/components/StoryDetail.svelte
+++ b/cli/kanban/client/src/components/StoryDetail.svelte
@@ -1,0 +1,137 @@
+<script>
+  import { tick } from 'svelte';
+  import Icon from './Icon.svelte';
+  import Avatar from './Avatar.svelte';
+  import PriorityChip from './PriorityChip.svelte';
+  import TddPip from './TddPip.svelte';
+  import { STATUS, TDD, TASK_TYPE, epicHue } from '../lib/config.js';
+  import { buildCardDetails } from '../lib/kanban-nav.js';
+  import { detail, closeDetail, consumeTrigger } from '../lib/detail.svelte.js';
+  import { route } from '../lib/router.svelte.js';
+
+  let dialogEl = $state(null);
+
+  // Toutes les fermetures (bouton, backdrop, Échap) passent par dialogEl.close(),
+  // qui déclenche `onclose` — chemin UNIQUE de fermeture (évite la double
+  // fermeture + la perte du retour de focus).
+  function requestClose() {
+    dialogEl?.close();
+  }
+
+  // Déclenché par la fermeture native du <dialog>. Réinitialise l'état puis rend
+  // le focus à l'élément déclencheur APRÈS le démontage du dialog (tick).
+  function onDialogClose() {
+    const trigger = consumeTrigger();
+    closeDetail();
+    tick().then(() => trigger?.focus?.());
+  }
+
+  // Fermer la modale si l'utilisateur change de vue (sécurité : la modale est
+  // partagée/globale et ne doit pas « suivre » entre les routes).
+  let lastView = route.parts[0];
+  $effect(() => {
+    const view = route.parts[0];
+    if (view !== lastView) {
+      lastView = view;
+      if (detail.card) requestClose();
+    }
+  });
+
+  const fields = $derived(detail.card ? buildCardDetails(detail.card) : null);
+  const estTotal = $derived(detail.tasks.reduce((a, t) => a + (t.estimation_hours || 0), 0));
+  const actTotal = $derived(detail.tasks.reduce((a, t) => a + (t.actual_hours || 0), 0));
+
+  // Open the native <dialog> as soon as a card is selected (focus trap + aria-modal
+  // are handled natively). Closing is driven by closeDetail() which nulls the card,
+  // unmounting the dialog.
+  $effect(() => {
+    if (fields && dialogEl && !dialogEl.open) dialogEl.showModal();
+  });
+</script>
+
+{#if fields}
+  <dialog
+    bind:this={dialogEl}
+    class="modal"
+    aria-modal="true"
+    aria-labelledby="detail-title"
+    onclose={onDialogClose}
+    onclick={(e) => {
+      if (e.target === dialogEl) requestClose();
+    }}
+  >
+    <div class="modal-inner">
+      <header class="modal-head">
+        <div class="row1">
+          <span class="m-id mono">{fields.id}</span>
+          {#if fields.epicId}
+            <span style="color: var(--fg-faint)">·</span>
+            <span style="display:inline-flex; align-items:center; gap:7px; font-size:12.5px; color: var(--fg-dim)">
+              <i aria-hidden="true" style="width:8px; height:8px; border-radius:50%; background: {epicHue(fields.epicId)}; display:inline-block"></i>
+              {fields.epicId}
+            </span>
+          {/if}
+          {#if fields.readOnly}
+            <span class="ro-lock" style="margin-left:8px"><Icon name="lock" size={13} /> read-only</span>
+          {/if}
+          <button class="icon-btn m-close" onclick={() => requestClose()} aria-label="Fermer"><Icon name="close" size={18} /></button>
+        </div>
+        <h2 class="modal-title" id="detail-title">{fields.title}</h2>
+        <div class="modal-frontmatter">
+          <span class="chip chip-soft"><i class="swatch" style="background: var({STATUS[fields.status]?.cssVar || '--border'})"></i>{STATUS[fields.status]?.label || fields.status}</span>
+          <PriorityChip priority={fields.priority} />
+          <TddPip phase={fields.tddPhase} />
+        </div>
+      </header>
+
+      <div class="modal-body">
+        <div class="fm-grid">
+          <div class="fm-cell"><div class="k">Points</div><div class="v"><span class="points mono">{fields.storyPoints}</span></div></div>
+          <div class="fm-cell"><div class="k">Assigné</div><div class="v">{#if fields.assignedTo}<Avatar id={fields.assignedTo} size={22} />{fields.assignedTo}{:else}<span style="color: var(--fg-faint)">—</span>{/if}</div></div>
+          <div class="fm-cell"><div class="k">Persona</div><div class="v">{fields.persona || '—'}</div></div>
+          <div class="fm-cell"><div class="k">Phase TDD</div><div class="v"><TddPip phase={fields.tddPhase} />{#if !fields.tddPhase || !TDD[fields.tddPhase]}<span style="color: var(--fg-faint)">—</span>{/if}</div></div>
+          <div class="fm-cell"><div class="k">Tâches</div><div class="v mono">{fields.tasks.completed}/{fields.tasks.total}</div></div>
+          {#if estTotal > 0}
+            <div class="fm-cell"><div class="k">Heures est / réel</div><div class="v mono">{estTotal} / <span class={actTotal > estTotal ? 't-over' : ''}>{actTotal}</span></div></div>
+          {/if}
+        </div>
+
+        {#if fields.blockedReason}
+          <div class="modal-readonly-note" style="border-color: var(--danger); color: var(--danger)">⚠ Bloqué : {fields.blockedReason}</div>
+        {/if}
+
+        {#if detail.tasks.length > 0}
+          <div class="section-h"><h3>Tâches</h3><span class="n mono">{fields.tasks.completed}/{fields.tasks.total}</span><span class="line"></span></div>
+          <table class="tasks">
+            <thead><tr><th style="width:54px">Type</th><th>Tâche</th><th>Statut</th><th style="text-align:right">Est</th><th style="text-align:right">Réel</th></tr></thead>
+            <tbody>
+              {#each detail.tasks as t}
+                <tr>
+                  <td><span class="t-type" style="background: color-mix(in oklch, {TASK_TYPE[t.type] || 'var(--fg-faint)'} 16%, transparent); color: {TASK_TYPE[t.type] || 'var(--fg-dim)'}">{t.type}</span></td>
+                  <td class="t-name">{t.id}</td>
+                  <td>{t.status}</td>
+                  <td class="t-hrs">{t.estimation_hours ?? '—'}</td>
+                  <td class="t-hrs {(t.actual_hours || 0) > (t.estimation_hours || 0) ? 't-over' : ''}">{t.actual_hours ?? '—'}</td>
+                </tr>
+              {/each}
+            </tbody>
+          </table>
+        {:else if detail.loading}
+          <p aria-live="polite" style="color: var(--fg-faint); font-size:12px; margin-top:12px">Chargement des tâches…</p>
+        {/if}
+
+        {#if detail.body}
+          <div class="section-h"><h3>Description</h3><span class="line"></span></div>
+          <div class="md-body">{@html detail.body}</div>
+        {/if}
+
+        {#if fields.readOnly}
+          <p class="modal-readonly-note">
+            Carte en lecture seule — gérée par <code>.bmad/sprint-status.yaml</code> (BMAD v6 single-writer).
+            Changez son statut via les commandes <code>team:</code> / <code>qa:</code>.
+          </p>
+        {/if}
+      </div>
+    </div>
+  </dialog>
+{/if}

--- a/cli/kanban/client/src/lib/deps-graph.js
+++ b/cli/kanban/client/src/lib/deps-graph.js
@@ -1,0 +1,38 @@
+// Pure dependency-graph element builder (no DOM, no cytoscape) — unit-tested in
+// tests/kanban/deps-graph.test.js.
+//
+// Bug #6 : the dependency view fed all stories to dagre, including the many that
+// have NO dependency edge. Disconnected nodes share rank 0 and dagre stacks them
+// in a single vertical column → an illegible wall. We graph only the connected
+// sub-set and report how many isolated nodes were hidden.
+
+/**
+ * @param {Array<{id:string}>} nodes
+ * @param {Array<{from:string,to:string}>} edges
+ * @param {string[][]} [cycles]
+ * @returns {{elements:object[], keptNodes:object[], hiddenCount:number, cycleSet:Set<string>}}
+ */
+export function buildDepsElements(nodes = [], edges = [], cycles = []) {
+  const nodeIds = new Set(nodes.map((n) => n.id));
+  // Edges whose BOTH endpoints exist as nodes (a dangling edge crashes cytoscape).
+  const validEdges = edges.filter((e) => nodeIds.has(e.from) && nodeIds.has(e.to));
+
+  const connected = new Set();
+  for (const e of validEdges) {
+    connected.add(e.from);
+    connected.add(e.to);
+  }
+
+  const cycleSet = new Set(cycles.flat());
+  const keptNodes = nodes.filter((n) => connected.has(n.id));
+
+  const elements = [
+    ...keptNodes.map((n) => ({
+      data: { id: n.id, label: n.id },
+      classes: cycleSet.has(n.id) ? 'in-cycle' : '',
+    })),
+    ...validEdges.map((e) => ({ data: { source: e.from, target: e.to } })),
+  ];
+
+  return { elements, keptNodes, hiddenCount: nodes.length - keptNodes.length, cycleSet };
+}

--- a/cli/kanban/client/src/lib/detail.svelte.js
+++ b/cli/kanban/client/src/lib/detail.svelte.js
@@ -1,0 +1,63 @@
+// Shared story-detail modal state (Svelte 5 runes). Both the Kanban board and the
+// Backlog open the SAME detail dialog through openDetail() — bug #3: backlog rows
+// were not clickable and had no way to reach a story's details. The <StoryDetail>
+// component (mounted once in App) renders whatever `detail.card` points to.
+
+export const detail = $state({
+  card: null,
+  tasks: [],
+  body: '',
+  loading: false,
+});
+
+// Element to refocus when the modal closes (WCAG 2.4.3 focus return).
+let triggerEl = null;
+
+export async function openDetail(card) {
+  if (!card) return;
+  triggerEl = typeof document !== 'undefined' ? document.activeElement : null;
+  detail.card = card;
+  detail.tasks = [];
+  detail.body = '';
+  await loadDetailExtras(card.id);
+}
+
+// Reset state only. Focus return is handled by <StoryDetail> AFTER the <dialog>
+// is unmounted (tick), via consumeTrigger() — focusing while the modal dialog is
+// still in the DOM is unreliable (focus falls back to <body> on some AT/Safari).
+export function closeDetail() {
+  detail.card = null;
+  detail.tasks = [];
+  detail.body = '';
+}
+
+/** Hand the trigger element to the caller and forget it (single-use). */
+export function consumeTrigger() {
+  const el = triggerEl;
+  triggerEl = null;
+  return el;
+}
+
+/**
+ * Load tasks + markdown body for the open story and render the markdown.
+ * marked/DOMPurify are imported lazily so the board bundle stays light.
+ */
+async function loadDetailExtras(id) {
+  detail.loading = true;
+  try {
+    const res = await fetch(`/api/stories/${encodeURIComponent(id)}`);
+    if (!res.ok) return;
+    const data = await res.json();
+    if (detail.card?.id !== id) return; // a newer card was opened meanwhile
+    detail.tasks = data.tasks ?? [];
+    if (data.body) {
+      const [{ marked }, dompurify] = await Promise.all([import('marked'), import('dompurify')]);
+      const DOMPurify = dompurify.default ?? dompurify;
+      if (detail.card?.id === id) detail.body = DOMPurify.sanitize(marked.parse(data.body));
+    }
+  } catch {
+    /* keep the base details derived from the frontmatter */
+  } finally {
+    detail.loading = false;
+  }
+}

--- a/cli/kanban/client/src/lib/sprints.js
+++ b/cli/kanban/client/src/lib/sprints.js
@@ -24,9 +24,11 @@ export function summarizeSprint(sprintEntry, stories) {
 
 /**
  * Sort sprint summaries by id descending (most recent sprint first).
+ * Numeric-aware so unpadded ids order correctly (sprint-10 before sprint-9);
+ * a plain localeCompare sorts lexically and buries sprint-10 under sprint-2.
  * @param {Array<{ id:string }>} summaries
  * @returns {Array<{ id:string }>}
  */
 export function sortSprints(summaries) {
-  return [...summaries].sort((a, b) => b.id.localeCompare(a.id));
+  return [...summaries].sort((a, b) => b.id.localeCompare(a.id, undefined, { numeric: true, sensitivity: 'base' }));
 }

--- a/cli/kanban/client/src/views.css
+++ b/cli/kanban/client/src/views.css
@@ -280,6 +280,10 @@
 /* ---- Card ---- */
 .card {
   position: relative;
+  /* flex-none : sans ça, dans .col-body (flex column) les cartes se compriment
+     (flex-shrink:1 par défaut) avant que la colonne ne scrolle, et `overflow:hidden`
+     tronque alors le titre/contenu (bug #1). */
+  flex: none;
   background: var(--bg-elev);
   border: 1px solid var(--border-faint);
   border-radius: var(--radius);
@@ -439,6 +443,10 @@
 
 /* ================= STORY MODAL ================= */
 dialog.modal {
+  /* margin:auto : le reset global `* { margin: 0 }` écrase le centrage que
+     l'UA applique aux <dialog> ouverts via showModal() → la modale se collait
+     en haut-gauche (bug #2). On rétablit le centrage. */
+  margin: auto;
   width: min(760px, 94vw);
   max-height: 88vh;
   padding: 0;
@@ -764,13 +772,23 @@ table.tasks .t-hrs {
   align-items: center;
   gap: 13px;
   padding: 11px 18px 11px 36px;
+  border: none;
   border-top: 1px solid var(--border-faint);
   width: 100%;
   text-align: left;
   transition: background 0.12s;
+  /* Rendue cliquable (ouvre le détail de la story — bug #3) : reset du <button>. */
+  background: none;
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
 }
 .story-row:hover {
   background: var(--bg-elev);
+}
+.story-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
 }
 .story-row .s-id {
   font-family: var(--mono);
@@ -1074,6 +1092,10 @@ table.tasks .t-hrs {
 }
 .deps-header .stat.danger {
   color: var(--danger);
+}
+.deps-header .stat.muted {
+  margin-left: auto;
+  color: var(--fg-faint);
 }
 .deps-content {
   display: flex;

--- a/cli/kanban/client/src/views/BacklogView.svelte
+++ b/cli/kanban/client/src/views/BacklogView.svelte
@@ -1,5 +1,6 @@
 <script>
   import { store } from '../lib/store.svelte.js';
+  import { openDetail } from '../lib/detail.svelte.js';
   import { groupStoriesByEpic } from '../lib/backlog.js';
   import { STATUS, epicHue } from '../lib/config.js';
   import Icon from '../components/Icon.svelte';
@@ -58,7 +59,7 @@
           <div class="epic-stories">
             <div>
               {#each stories as story (story.id)}
-                <div class="story-row">
+                <button type="button" class="story-row" onclick={() => openDetail(story)}>
                   <span class="s-id mono">{story.id}</span>
                   <span class="s-title">{story.title}</span>
                   {#if story._writable === false}<span class="ro-lock"><Icon name="lock" size={12} /></span>{/if}
@@ -68,7 +69,7 @@
                     <i style="background: var({STATUS[story.status]?.cssVar || '--fg-faint'})"></i>{STATUS[story.status]?.label || story.status}
                   </span>
                   <Avatar id={story.assigned_to} size={24} />
-                </div>
+                </button>
               {/each}
             </div>
           </div>
@@ -94,7 +95,7 @@
           <div class="epic-stories">
             <div>
               {#each epicGroups.orphans as story (story.id)}
-                <div class="story-row">
+                <button type="button" class="story-row" onclick={() => openDetail(story)}>
                   <span class="s-id mono">{story.id}</span>
                   <span class="s-title">{story.title}</span>
                   {#if story._writable === false}<span class="ro-lock"><Icon name="lock" size={12} /></span>{/if}
@@ -104,7 +105,7 @@
                     <i style="background: var({STATUS[story.status]?.cssVar || '--fg-faint'})"></i>{STATUS[story.status]?.label || story.status}
                   </span>
                   <Avatar id={story.assigned_to} size={24} />
-                </div>
+                </button>
               {/each}
             </div>
           </div>

--- a/cli/kanban/client/src/views/BurndownView.svelte
+++ b/cli/kanban/client/src/views/BurndownView.svelte
@@ -69,7 +69,10 @@
       series: [
         { label: 'Date' },
         { label: 'Ideal', stroke: cFaint, width: 1.5, dash: [5, 5], points: { show: false } },
-        { label: 'Actual', stroke: cAccent, width: 3, points: { show: true, size: 6, fill: cAccent, stroke: cAccent } },
+        // spanGaps : l'axe X couvre chaque jour idéal, donc la série réelle
+        // (événementielle) a des trous (null) entre deux mesures. Sans spanGaps,
+        // uPlot rompt le trait et on ne voit que des points isolés (bug #5).
+        { label: 'Actual', stroke: cAccent, width: 3, spanGaps: true, points: { show: true, size: 6, fill: cAccent, stroke: cAccent } },
       ],
       legend: { show: true },
     };

--- a/cli/kanban/client/src/views/DepsView.svelte
+++ b/cli/kanban/client/src/views/DepsView.svelte
@@ -2,6 +2,7 @@
   import cytoscape from 'cytoscape';
   import dagre from 'cytoscape-dagre';
   import { STATUS } from '../lib/config.js';
+  import { buildDepsElements } from '../lib/deps-graph.js';
 
   cytoscape.use(dagre);
 
@@ -15,6 +16,9 @@
   let error = $state(null);
 
   const stats = $derived({ nodes: nodes.length, edges: edges.length, cycles: cycles.length });
+  // Nœuds sans aucune dépendance : exclus du graphe (sinon dagre les empile en
+  // colonne illisible) mais comptés pour informer l'utilisateur.
+  const isolatedCount = $derived(buildDepsElements(nodes, edges, cycles).hiddenCount);
 
   /** Couleur de statut côté DOM (badge) — var() résolu par le navigateur. */
   const domStatusColor = (status) => `var(${STATUS[status]?.cssVar || '--fg-faint'})`;
@@ -57,12 +61,9 @@
     const cDanger = tok('--danger', '#e5484d');
     const cMono = tok('--mono', 'monospace');
 
-    const cycleSet = new Set(cycles.flat());
-
-    const elements = [
-      ...nodes.map((n) => ({ data: { id: n.id, label: n.id }, classes: cycleSet.has(n.id) ? 'in-cycle' : '' })),
-      ...edges.map((e) => ({ data: { source: e.from, target: e.to } })),
-    ];
+    // Graphe limité aux nœuds connectés (les isolés cassent le layout dagre).
+    const { elements } = buildDepsElements(nodes, edges, cycles);
+    if (elements.length === 0) return; // aucun lien → rien à dessiner (note affichée dans le DOM)
 
     const cy = cytoscape({
       container: graphContainer,
@@ -105,8 +106,11 @@
           },
         },
       ],
-      layout: { name: 'dagre', rankDir: 'LR', spacingFactor: 1.3, nodeDimensionsIncludeLabels: true },
+      layout: { name: 'dagre', rankDir: 'LR', spacingFactor: 1.3, nodeDimensionsIncludeLabels: true, fit: true, padding: 30 },
     });
+
+    // Recentrer/zoomer pour que le graphe occupe le canvas (évite le rendu décalé).
+    cy.ready(() => cy.fit(undefined, 40));
 
     cy.on('tap', 'node', (evt) => {
       const nodeData = nodes.find((n) => n.id === evt.target.id());
@@ -137,7 +141,16 @@
         <span class="stat">Nodes: {stats.nodes}</span>
         <span class="stat">Edges: {stats.edges}</span>
         <span class="stat" class:danger={stats.cycles > 0}>Cycles: {stats.cycles}</span>
+        {#if isolatedCount > 0}
+          <span class="stat muted" title="Stories sans dépendance — masquées pour garder le graphe lisible">
+            {isolatedCount} isolée{isolatedCount > 1 ? 's' : ''} masquée{isolatedCount > 1 ? 's' : ''}
+          </span>
+        {/if}
       </header>
+
+      {#if stats.edges === 0}
+        <div class="empty">Aucune dépendance entre stories — rien à afficher dans le graphe.</div>
+      {:else}
 
       <div class="deps-content">
         <div
@@ -170,6 +183,7 @@
           </aside>
         {/if}
       </div>
+      {/if}
 
       <div class="sr-only">
         <h2>Dependency edges (text fallback)</h2>

--- a/cli/kanban/client/src/views/KanbanView.svelte
+++ b/cli/kanban/client/src/views/KanbanView.svelte
@@ -8,26 +8,18 @@
   import TddPip from '../components/TddPip.svelte';
   import Points from '../components/Points.svelte';
   import TaskProgress from '../components/TaskProgress.svelte';
-  import { locateCard, reduceKey, buildCardDetails } from '../lib/kanban-nav.js';
-  import { STATUS, PRIORITY, TDD, TASK_TYPE, codeColor, epicHue } from '../lib/config.js';
+  import { locateCard, reduceKey } from '../lib/kanban-nav.js';
+  import { STATUS, PRIORITY, codeColor, epicHue } from '../lib/config.js';
   import { tweaks } from '../lib/tweaks.svelte.js';
+  import { openDetail as openDetailStore } from '../lib/detail.svelte.js';
 
   let promptDialog = $state(null);
   /** Référence au <dialog> natif du menu de déplacement */
   let moveMenuDialog = $state(null);
   /** Élément de carte ayant déclenché l'ouverture du menu (pour retour de focus) */
   let moveMenuTriggerEl = $state(null);
-  /** Référence au <dialog> natif de la modale de détail */
-  let detailDialog = $state(null);
-  /** Carte actuellement affichée dans la modale de détail */
-  let detailCard = $state(null);
-  /** Élément ayant déclenché l'ouverture de la modale (pour retour de focus) */
-  let detailTriggerEl = $state(null);
-  /** Tâches associées à la story affichée (chargées à l'ouverture via /api/stories/:id) */
-  let detailTasks = $state([]);
-  /** Corps markdown de la story rendu en HTML (AC, Gherkin…) */
-  let detailBody = $state('');
-  let detailLoading = $state(false);
+  // La modale de détail est désormais un composant partagé (<StoryDetail>, monté
+  // dans App) piloté par le store lib/detail.svelte.js — réutilisée par le Backlog.
 
   const COLUMNS = [
     { key: 'backlog', label: 'Backlog', emptyHint: 'No stories — run /workflow:plan' },
@@ -256,57 +248,10 @@
     }
   }
 
-  /** Détails normalisés de la carte affichée (null si modale fermée). */
-  const detailFields = $derived(detailCard ? buildCardDetails(detailCard) : null);
-  const detailEstTotal = $derived(detailTasks.reduce((a, t) => a + (t.estimation_hours || 0), 0));
-  const detailActTotal = $derived(detailTasks.reduce((a, t) => a + (t.actual_hours || 0), 0));
-
-  /** Ouvre la modale de détail (clic ou Entrée). */
-  async function openDetail(card) {
-    detailTriggerEl = document.activeElement;
-    detailCard = card;
-    detailTasks = [];
-    detailBody = '';
+  /** Ouvre la modale de détail partagée (clic ou Entrée) + annonce sr-only. */
+  function openDetail(card) {
     announceCardDetails(card);
-    await tick();
-    detailDialog?.showModal();
-    loadDetailExtras(card.id);
-  }
-
-  /**
-   * Charge tâches + corps markdown de la story et rend le markdown.
-   * marked/DOMPurify importés dynamiquement pour ne pas alourdir le bundle du board.
-   */
-  async function loadDetailExtras(id) {
-    detailLoading = true;
-    try {
-      const res = await fetch(`/api/stories/${encodeURIComponent(id)}`);
-      if (!res.ok) return;
-      const data = await res.json();
-      if (detailCard?.id !== id) return;
-      detailTasks = data.tasks ?? [];
-      if (data.body) {
-        const [{ marked }, dompurify] = await Promise.all([import('marked'), import('dompurify')]);
-        const DOMPurify = dompurify.default ?? dompurify;
-        if (detailCard?.id === id) detailBody = DOMPurify.sanitize(marked.parse(data.body));
-      }
-    } catch {
-      /* on garde les détails de base issus du frontmatter */
-    } finally {
-      detailLoading = false;
-    }
-  }
-
-  /** Ferme la modale de détail et retourne le focus à la carte source. */
-  function closeDetail() {
-    detailCard = null;
-    detailTasks = [];
-    detailBody = '';
-    detailDialog?.close();
-    if (detailTriggerEl) {
-      detailTriggerEl.focus();
-      detailTriggerEl = null;
-    }
+    openDetailStore(card);
   }
 </script>
 
@@ -443,94 +388,13 @@
   </dialog>
 {/if}
 
-<!-- Modale de détail : <dialog> natif, style design (dialog.modal) -->
-{#if detailFields}
-  <dialog
-    bind:this={detailDialog}
-    class="modal"
-    aria-labelledby="detail-title"
-    onclose={() => { if (detailCard) closeDetail(); }}
-    onclick={(e) => { if (e.target === detailDialog) closeDetail(); }}
-  >
-    <div class="modal-inner">
-      <header class="modal-head">
-        <div class="row1">
-          <span class="m-id mono">{detailFields.id}</span>
-          {#if detailFields.epicId}
-            <span style="color: var(--fg-faint)">·</span>
-            <span style="display:inline-flex; align-items:center; gap:7px; font-size:12.5px; color: var(--fg-dim)">
-              <i style="width:8px; height:8px; border-radius:50%; background: {epicHue(detailFields.epicId)}; display:inline-block"></i>
-              {detailFields.epicId}
-            </span>
-          {/if}
-          {#if detailFields.readOnly}
-            <span class="ro-lock" style="margin-left:8px"><Icon name="lock" size={13} /> read-only</span>
-          {/if}
-          <button class="icon-btn m-close" onclick={() => closeDetail()} aria-label="Fermer"><Icon name="close" size={18} /></button>
-        </div>
-        <h2 class="modal-title" id="detail-title">{detailFields.title}</h2>
-        <div class="modal-frontmatter">
-          <span class="chip chip-soft"><i class="swatch" style="background: var({STATUS[detailFields.status]?.cssVar || '--border'})"></i>{STATUS[detailFields.status]?.label || detailFields.status}</span>
-          <PriorityChip priority={detailFields.priority} />
-          <TddPip phase={detailFields.tddPhase} />
-        </div>
-      </header>
-
-      <div class="modal-body">
-        <div class="fm-grid">
-          <div class="fm-cell"><div class="k">Points</div><div class="v"><span class="points mono">{detailFields.storyPoints}</span></div></div>
-          <div class="fm-cell"><div class="k">Assigné</div><div class="v">{#if detailFields.assignedTo}<Avatar id={detailFields.assignedTo} size={22} />{detailFields.assignedTo}{:else}<span style="color: var(--fg-faint)">—</span>{/if}</div></div>
-          <div class="fm-cell"><div class="k">Persona</div><div class="v">{detailFields.persona || '—'}</div></div>
-          <div class="fm-cell"><div class="k">Phase TDD</div><div class="v"><TddPip phase={detailFields.tddPhase} />{#if !detailFields.tddPhase || !TDD[detailFields.tddPhase]}<span style="color: var(--fg-faint)">—</span>{/if}</div></div>
-          <div class="fm-cell"><div class="k">Tâches</div><div class="v mono">{detailFields.tasks.completed}/{detailFields.tasks.total}</div></div>
-          {#if detailEstTotal > 0}
-            <div class="fm-cell"><div class="k">Heures est / réel</div><div class="v mono">{detailEstTotal} / <span class={detailActTotal > detailEstTotal ? 't-over' : ''}>{detailActTotal}</span></div></div>
-          {/if}
-        </div>
-
-        {#if detailFields.blockedReason}
-          <div class="modal-readonly-note" style="border-color: var(--danger); color: var(--danger)">⚠ Bloqué : {detailFields.blockedReason}</div>
-        {/if}
-
-        {#if detailTasks.length > 0}
-          <div class="section-h"><h3>Tâches</h3><span class="n mono">{detailFields.tasks.completed}/{detailFields.tasks.total}</span><span class="line"></span></div>
-          <table class="tasks">
-            <thead><tr><th style="width:54px">Type</th><th>Tâche</th><th>Statut</th><th style="text-align:right">Est</th><th style="text-align:right">Réel</th></tr></thead>
-            <tbody>
-              {#each detailTasks as t}
-                <tr>
-                  <td><span class="t-type" style="background: color-mix(in oklch, {TASK_TYPE[t.type] || 'var(--fg-faint)'} 16%, transparent); color: {TASK_TYPE[t.type] || 'var(--fg-dim)'}">{t.type}</span></td>
-                  <td class="t-name">{t.id}</td>
-                  <td>{t.status}</td>
-                  <td class="t-hrs">{t.estimation_hours ?? '—'}</td>
-                  <td class="t-hrs {(t.actual_hours || 0) > (t.estimation_hours || 0) ? 't-over' : ''}">{t.actual_hours ?? '—'}</td>
-                </tr>
-              {/each}
-            </tbody>
-          </table>
-        {:else if detailLoading}
-          <p style="color: var(--fg-faint); font-size:12px; margin-top:12px">Chargement des tâches…</p>
-        {/if}
-
-        {#if detailBody}
-          <div class="section-h"><h3>Description</h3><span class="line"></span></div>
-          <div class="md-body">{@html detailBody}</div>
-        {/if}
-
-        {#if detailFields.readOnly}
-          <p class="modal-readonly-note">
-            Carte en lecture seule — gérée par <code>.bmad/sprint-status.yaml</code> (BMAD v6 single-writer).
-            Changez son statut via les commandes <code>team:</code> / <code>qa:</code>.
-          </p>
-        {/if}
-      </div>
-    </div>
-  </dialog>
-{/if}
 
 <style>
   /* Menu de déplacement — spécifique au board (hors design system global) */
   .move-menu-dialog {
+    /* margin:auto : recentre le <dialog> que le reset global `* { margin:0 }`
+       décalerait en haut-gauche (cf. bug #2). */
+    margin: auto;
     background: var(--bg-elev); border: 1px solid var(--border-strong);
     border-radius: var(--radius-lg); padding: 0; min-width: 300px;
     box-shadow: var(--shadow-lg); color: var(--fg);

--- a/cli/kanban/server/services/sprint-cache.js
+++ b/cli/kanban/server/services/sprint-cache.js
@@ -81,7 +81,7 @@ export async function rebuildSprintStatus(projectRoot, repository) {
  * @param {Array} storiesBySprint - Current stories in the sprint
  * @returns {object} Burndown chart with ideal/actual lines and on_track indicator
  */
-export function computeBurndown(sprintStatus, storiesBySprint) {
+export function computeBurndown(sprintStatus, storiesBySprint, now = new Date()) {
   const totalPoints = storiesBySprint.reduce((sum, s) => sum + (s.story_points ?? 0), 0);
 
   if (!sprintStatus.metadata.start_date || !sprintStatus.metadata.end_date) {
@@ -108,7 +108,7 @@ export function computeBurndown(sprintStatus, storiesBySprint) {
     });
   }
 
-  const actual = buildActualBurndown(sprintStatus, storiesBySprint, startDate, endDate);
+  const actual = buildActualBurndown(sprintStatus, storiesBySprint, startDate, endDate, now);
 
   let onTrack = null;
   if (actual.length > 0 && totalPoints > 0) {
@@ -166,7 +166,7 @@ async function readSprintGoal(repository, sprintId) {
   }
 }
 
-function buildActualBurndown(sprintStatus, storiesBySprint, startDate, endDate) {
+function buildActualBurndown(sprintStatus, storiesBySprint, startDate, endDate, now = new Date()) {
   const doneEvents = [];
 
   for (const story of storiesBySprint) {
@@ -188,8 +188,9 @@ function buildActualBurndown(sprintStatus, storiesBySprint, startDate, endDate) 
 
   doneEvents.sort((a, b) => a.date.localeCompare(b.date));
 
+  const total = storiesBySprint.reduce((sum, s) => sum + (s.story_points ?? 0), 0);
   const actual = [];
-  let remaining = storiesBySprint.reduce((sum, s) => sum + (s.story_points ?? 0), 0);
+  let remaining = total;
 
   actual.push({
     date: startDate.toISOString().split('T')[0],
@@ -202,6 +203,23 @@ function buildActualBurndown(sprintStatus, storiesBySprint, startDate, endDate) 
       date: event.date,
       points: Math.max(0, remaining),
     });
+  }
+
+  // Sprint EN COURS (now ∈ [start,end]) : ancrer un point "aujourd'hui" au
+  // remaining RÉEL (total − points des stories actuellement done). Sans ça, un
+  // sprint sans historique horodaté (history:[]) n'a qu'un point de départ et la
+  // courbe réelle est un point invisible (bug UI #5). Un sprint clôturé
+  // (now > end) ou pas encore démarré (now < start) garde l'historique brut.
+  const today = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  if (today >= startDate && today <= endDate) {
+    const liveDone = storiesBySprint
+      .filter((s) => s.status === 'done')
+      .reduce((sum, s) => sum + (s.story_points ?? 0), 0);
+    const todayStr = today.toISOString().split('T')[0];
+    const liveRemaining = Math.max(0, total - liveDone);
+    const last = actual[actual.length - 1];
+    if (last.date === todayStr) last.points = liveRemaining;
+    else actual.push({ date: todayStr, points: liveRemaining });
   }
 
   return actual;

--- a/tests/kanban/deps-graph.test.js
+++ b/tests/kanban/deps-graph.test.js
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { buildDepsElements } from '../../cli/kanban/client/src/lib/deps-graph.js';
+
+const N = (id, extra = {}) => ({ id, status: 'backlog', ...extra });
+
+describe('buildDepsElements', () => {
+  it('keeps only nodes that participate in at least one edge', () => {
+    // Bug #6 : 65 nodes / 5 edges → dagre empilait les ~60 nœuds isolés en une
+    // colonne verticale illisible. On ne graphe que les nœuds connectés.
+    const nodes = [N('A'), N('B'), N('C'), N('D'), N('E')];
+    const edges = [
+      { from: 'A', to: 'B' },
+      { from: 'B', to: 'C' },
+    ];
+    const { elements, keptNodes, hiddenCount } = buildDepsElements(nodes, edges);
+
+    expect(keptNodes.map((n) => n.id).sort()).toEqual(['A', 'B', 'C']);
+    expect(hiddenCount).toBe(2); // D et E isolés
+    // 3 nœuds + 2 arêtes
+    expect(elements.filter((e) => e.data.id)).toHaveLength(3);
+    expect(elements.filter((e) => e.data.source)).toHaveLength(2);
+  });
+
+  it('tags nodes in a cycle with the in-cycle class', () => {
+    const nodes = [N('A'), N('B'), N('C')];
+    const edges = [
+      { from: 'A', to: 'B' },
+      { from: 'B', to: 'A' },
+      { from: 'B', to: 'C' },
+    ];
+    const { elements } = buildDepsElements(nodes, edges, [['A', 'B']]);
+    const byId = Object.fromEntries(elements.filter((e) => e.data.id).map((e) => [e.data.id, e.classes]));
+    expect(byId.A).toBe('in-cycle');
+    expect(byId.B).toBe('in-cycle');
+    expect(byId.C).toBe('');
+  });
+
+  it('drops edges that reference an unknown node (avoids cytoscape crash)', () => {
+    const nodes = [N('A'), N('B')];
+    const edges = [
+      { from: 'A', to: 'B' },
+      { from: 'A', to: 'GHOST' },
+    ];
+    const { elements, keptNodes } = buildDepsElements(nodes, edges);
+    expect(keptNodes.map((n) => n.id).sort()).toEqual(['A', 'B']);
+    expect(elements.filter((e) => e.data.source)).toHaveLength(1);
+  });
+
+  it('returns empty graph when there are no edges', () => {
+    const { elements, keptNodes, hiddenCount } = buildDepsElements([N('A'), N('B')], []);
+    expect(elements).toEqual([]);
+    expect(keptNodes).toEqual([]);
+    expect(hiddenCount).toBe(2);
+  });
+
+  it('handles empty inputs', () => {
+    const { elements, keptNodes, hiddenCount } = buildDepsElements([], []);
+    expect(elements).toEqual([]);
+    expect(keptNodes).toEqual([]);
+    expect(hiddenCount).toBe(0);
+  });
+});

--- a/tests/kanban/sprint-cache.test.js
+++ b/tests/kanban/sprint-cache.test.js
@@ -722,6 +722,85 @@ sprint_id: sprint-zzz
       expect(result.total_points).toBe(5);
       expect(['on-track', 'at-risk', 'behind', null]).toContain(result.on_track);
     });
+
+    // --- Sprint EN COURS : la ligne "réel" doit refléter la réalité ---
+    // Bug #5 (UI) : un sprint actif dont les stories ont history:[] produisait un
+    // `actual` à UN SEUL point (juste le départ) → la courbe réelle était un point
+    // invisible. Pour un sprint en cours (now ∈ [start,end]) on ancre un point
+    // "aujourd'hui" au remaining RÉEL (total − points des stories actuellement done),
+    // même sans historique horodaté.
+    const activeSprintStatus = (stories) => ({
+      version: '1.0',
+      metadata: {
+        sprint_id: 'sprint-10',
+        name: 'Active',
+        start_date: '2026-04-01',
+        end_date: '2026-04-10',
+        goal: 'Goal',
+      },
+      stories,
+    });
+
+    it('anchors a "today" point at the live remaining for a running sprint (empty history)', () => {
+      const sprintStatus = activeSprintStatus({
+        'US-001': { title: 'A', status: 'done', story_points: 5, history: [] },
+        'US-002': { title: 'B', status: 'in-progress', story_points: 3, history: [] },
+      });
+      const stories = [
+        { id: 'US-001', status: 'done', story_points: 5 },
+        { id: 'US-002', status: 'in-progress', story_points: 3 },
+      ];
+      // now injecté DANS la fenêtre du sprint → déterministe.
+      const result = computeBurndown(sprintStatus, stories, new Date('2026-04-04T12:00:00Z'));
+
+      expect(result.actual).toHaveLength(2);
+      expect(result.actual[0]).toEqual({ date: '2026-04-01', points: 8 });
+      // 8 total − 5 done (live) = 3 restants, ancré à aujourd'hui.
+      expect(result.actual[1]).toEqual({ date: '2026-04-04', points: 3 });
+    });
+
+    it('does NOT anchor today for a finished sprint (now after end → history only)', () => {
+      const sprintStatus = activeSprintStatus({
+        'US-001': { title: 'A', status: 'done', story_points: 5, history: [] },
+      });
+      const stories = [{ id: 'US-001', status: 'done', story_points: 5 }];
+      const result = computeBurndown(sprintStatus, stories, new Date('2026-05-01T00:00:00Z'));
+      // Sprint clôturé : on garde l'historique brut (ici juste le point de départ).
+      expect(result.actual).toHaveLength(1);
+      expect(result.actual[0]).toEqual({ date: '2026-04-01', points: 5 });
+    });
+
+    it('does NOT anchor today before the sprint has started', () => {
+      const sprintStatus = activeSprintStatus({
+        'US-001': { title: 'A', status: 'backlog', story_points: 5, history: [] },
+      });
+      const stories = [{ id: 'US-001', status: 'backlog', story_points: 5 }];
+      const result = computeBurndown(sprintStatus, stories, new Date('2026-03-15T00:00:00Z'));
+      expect(result.actual).toHaveLength(1);
+      expect(result.actual[0]).toEqual({ date: '2026-04-01', points: 5 });
+    });
+
+    it('extends a sparse history line to today for a running sprint', () => {
+      const sprintStatus = activeSprintStatus({
+        'US-001': {
+          title: 'A',
+          status: 'done',
+          story_points: 5,
+          history: [{ timestamp: '2026-04-02T10:00:00Z', from: 'review', to: 'done', by: 'a', reason: '' }],
+        },
+        'US-002': { title: 'B', status: 'in-progress', story_points: 3, history: [] },
+      });
+      const stories = [
+        { id: 'US-001', status: 'done', story_points: 5 },
+        { id: 'US-002', status: 'in-progress', story_points: 3 },
+      ];
+      const result = computeBurndown(sprintStatus, stories, new Date('2026-04-06T12:00:00Z'));
+      // départ(8) → événement 04-02 (3) → ancre 04-06 au remaining live (8−5=3)
+      expect(result.actual).toHaveLength(3);
+      expect(result.actual[0]).toEqual({ date: '2026-04-01', points: 8 });
+      expect(result.actual[1]).toEqual({ date: '2026-04-02', points: 3 });
+      expect(result.actual[2]).toEqual({ date: '2026-04-06', points: 3 });
+    });
   });
 
   describe('GET /api/sprints/current', () => {

--- a/tests/kanban/sprints.test.js
+++ b/tests/kanban/sprints.test.js
@@ -31,9 +31,9 @@ describe('summarizeSprint', () => {
   });
 
   it('has_retro is true for a sprint-retro file and false for board', () => {
-    expect(summarizeSprint({ id: 'sprint-001', files: [mkFile('sprint-retro', 'sprint-retro.md')] }, []).has_retro).toBe(
-      true
-    );
+    expect(
+      summarizeSprint({ id: 'sprint-001', files: [mkFile('sprint-retro', 'sprint-retro.md')] }, []).has_retro
+    ).toBe(true);
     expect(summarizeSprint({ id: 'sprint-001', files: [mkFile('board', 'board.md')] }, []).has_retro).toBe(false);
   });
 
@@ -51,6 +51,19 @@ describe('sortSprints', () => {
   it('sorts by id descending', () => {
     const input = [{ id: 'sprint-001' }, { id: 'sprint-003' }, { id: 'sprint-002' }];
     expect(sortSprints(input).map((s) => s.id)).toEqual(['sprint-003', 'sprint-002', 'sprint-001']);
+  });
+
+  it('sorts numerically, not lexically (sprint-10 before sprint-9)', () => {
+    // Real sprint ids are NOT zero-padded (sprint-1 … sprint-10). A plain
+    // localeCompare puts "sprint-10" before "sprint-2" (lexical), so the most
+    // recent sprint was buried. Numeric-aware compare fixes the ordering.
+    const input = [{ id: 'sprint-2-foo' }, { id: 'sprint-10-bar' }, { id: 'sprint-1-baz' }, { id: 'sprint-9-qux' }];
+    expect(sortSprints(input).map((s) => s.id)).toEqual([
+      'sprint-10-bar',
+      'sprint-9-qux',
+      'sprint-2-foo',
+      'sprint-1-baz',
+    ]);
   });
 
   it('handles an empty array', () => {


### PR DESCRIPTION
## Contexte
Corrige 6 bugs UI/UX du Kanban board signalés sur le projet Wrandly. Analyse + tests (TDD) avant correction, vérification visuelle in-browser sur données reproduisant le board.

## Bugs corrigés
| # | Bug | Correctif |
|---|-----|-----------|
| 1 | Contenu des cards tronqué | `.card { flex:none }` (flex-shrink compressait + `overflow:hidden`) |
| 2 | Modale détail collée top-left | `margin:auto` (le reset global `* { margin:0 }` tuait le centrage UA du `<dialog>`) |
| 3 | Clic sur une US dans le Backlog → aucun détail | Modale détail extraite en composant partagé (`StoryDetail` + store `detail`), lignes Backlog rendues cliquables |
| 4 | Liste des sprints mal triée | tri numeric-aware (sprint-10 avant sprint-9, avant : lexical) |
| 5 | Burndown ne reflète pas la réalité | ancrage « aujourd'hui » au remaining live pour un sprint en cours + `spanGaps` uPlot |
| 6 | Écran Dependencies illisible | graphe limité aux nœuds connectés + compteur d'isolées + `cy.fit()` |

## Accessibilité (revue dédiée)
Chemin de fermeture natif unique (`dialogEl.close()` → `onclose`) avec retour de focus après `tick()`, `aria-modal`, dot décoratif `aria-hidden`, chargement `aria-live`, suppression d'un `aria-label` qui masquait le contenu des lignes.

## Tests
- `sprints.test.js` : tri numérique
- `sprint-cache.test.js` : ancrage burndown (`now` injecté, déterministe)
- `deps-graph.test.js` (nouveau) : filtrage nœuds isolés / cycles / arêtes orphelines
- **294/294 tests kanban verts**, eslint + prettier clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)