### PR TITLE
fix(kanban): Lighthouse 100 sur les 6 écrans du board

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,16 @@ test-bmad: ## Lance les tests bats BMAD (gate-validator + garde anti ((var++)))
 
 test-bats: test-MultiAccount test-StatusLine test-RTK test-AgentTeams test-bmad ## Lance tous les tests bats
 
+# tests/scripts/*.test.mjs shell out to `bash "<script>.sh"` (bashismes :
+# [[ ]], arrays, type -t, local, ${VAR:+}). Lancer la suite dans une image
+# SANS bash (busybox/alpine) fait echouer les 12 fichiers concernes avec
+# `/bin/sh: bash: not found`. node:24 (Debian) embarque bash → suite verte.
+# La garde tests/scripts/bash-available.test.mjs verifie ce prerequis.
+TEST_IMAGE ?= node:24
+test-scripts-docker: ## Lance tests/scripts dans une image docker AVEC bash
+	@docker run --rm -v "$(CURDIR):/app" -w /app $(TEST_IMAGE) \
+		npx vitest run tests/scripts/
+
 test-all: ## Lance tous les tests (vitest + bats)
 	@npm test && $(MAKE) test-bats
 

--- a/cli/kanban/client/index.html
+++ b/cli/kanban/client/index.html
@@ -5,8 +5,17 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>claude-craft kanban</title>
     <meta
+      name="description"
+      content="Tableau Kanban claude-craft pour le suivi de sprint BMAD v6 : board, backlog, sprints, burndown, dépendances et docs."
+    />
+    <!-- Inline SVG favicon (data: covered by img-src 'self' data:) — avoids a /favicon.ico 404 in the console. -->
+    <link
+      rel="icon"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='7' fill='%23222'/%3E%3Ctext x='16' y='22' font-family='monospace' font-size='16' font-weight='700' fill='%23c5f72b' text-anchor='middle'%3Ecc%3C/text%3E%3C/svg%3E"
+    />
+    <meta
       http-equiv="Content-Security-Policy"
-      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self';"
+      content="default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; font-src 'self'; connect-src 'self';"
     />
   </head>
   <body>

--- a/cli/kanban/client/src/app.css
+++ b/cli/kanban/client/src/app.css
@@ -16,7 +16,9 @@
   /* --- Foreground --- */
   --fg: oklch(0.965 0.004 264);
   --fg-dim: oklch(0.72 0.012 264);
-  --fg-faint: oklch(0.55 0.012 264);
+  /* WCAG AA: 0.64 yields ≥4.8:1 on the lightest surface (--bg-elev-2). The
+     prior 0.55 scored 3.7:1 and failed Lighthouse color-contrast. */
+  --fg-faint: oklch(0.64 0.012 264);
 
   /* --- Lines --- */
   --border: oklch(0.3 0.012 264);

--- a/cli/kanban/client/src/components/Avatar.svelte
+++ b/cli/kanban/client/src/components/Avatar.svelte
@@ -9,6 +9,7 @@
 {#if id}
   <span
     class="avatar"
+    role="img"
     title={id}
     aria-label={`Assigné à : ${id}`}
     style="width:{size}px; height:{size}px; background:{avatarColor(id)}; font-size:{size * 0.38}px;"
@@ -16,6 +17,7 @@
 {:else}
   <span
     class="avatar avatar-empty"
+    role="img"
     title="Non assigné"
     aria-label="Non assigné"
     style="width:{size}px; height:{size}px;"

--- a/cli/kanban/client/src/lib/deps-style.js
+++ b/cli/kanban/client/src/lib/deps-style.js
@@ -1,0 +1,62 @@
+// Pure helpers for the cytoscape dependency graph (no DOM, no cytoscape) —
+// unit-tested in tests/kanban/deps-style.test.js.
+//
+// Console-warning fix (deps view): the acid-lime design tokens are authored in
+// `oklch()`. getComputedStyle resolves CSS custom properties to their computed
+// value — a `lab()`/`oklch()` string in modern Chrome — which cytoscape's canvas
+// colour parser cannot read. It logged ~20 "style property `…: lab(…)` is
+// invalid" + "Custom function mappers may not return invalid values" warnings
+// and dropped the node status colour. We detect such values and let the caller
+// normalise them through a Canvas 2D context (its `fillStyle` setter parses any
+// CSS Color 4 value and serialises it back to an sRGB string cytoscape accepts).
+
+/** CSS Color 4 functions cytoscape's parser rejects. */
+const CSS_COLOR4 = /\b(?:lab|lch|oklab|oklch|color)\(/i;
+
+/**
+ * @param {unknown} color
+ * @returns {boolean} true when `color` is a CSS Color 4 value cytoscape can't parse.
+ */
+export function needsColorNormalization(color) {
+  return typeof color === 'string' && CSS_COLOR4.test(color);
+}
+
+/**
+ * Normalise a CSS colour to a value cytoscape's canvas renderer understands.
+ * sRGB values (hex/rgb/named) pass straight through. lab()/oklch()/color()
+ * values are *rasterised* — painted onto a 1px canvas and read back as raw RGBA
+ * bytes — yielding an `rgb()`/`rgba()` string. Reading `ctx.fillStyle` back is
+ * NOT enough: modern Chrome preserves the colour space, so `fillStyle = 'lab(…)'`
+ * round-trips to `lab(…)`, which cytoscape still rejects. getImageData forces sRGB.
+ * @param {string} color
+ * @param {CanvasRenderingContext2D|null} [ctx] - injected for testability.
+ * @returns {string} an sRGB colour, or `color` unchanged when no ctx is available.
+ */
+export function normalizeColor(color, ctx) {
+  if (!needsColorNormalization(color)) return color;
+  if (!ctx || typeof ctx.getImageData !== 'function') return color;
+  ctx.fillStyle = color;
+  ctx.fillRect(0, 0, 1, 1);
+  const [r, g, b, a] = ctx.getImageData(0, 0, 1, 1).data;
+  return a === 255 ? `rgb(${r}, ${g}, ${b})` : `rgba(${r}, ${g}, ${b}, ${+(a / 255).toFixed(3)})`;
+}
+
+// Node label box sizing — replaces cytoscape's deprecated `width/height: 'label'`
+// auto-sizing (3.34 logs "The style value of `label` is deprecated for width").
+// JetBrains Mono 11px ≈ 6.7px per glyph; PAD_X mirrors the 10px+10px padding.
+const CHAR_W = 6.7;
+const PAD_X = 20;
+const MIN_W = 24;
+
+/** Height = 11px line + 7px+7px vertical padding ≈ 28px. */
+export const NODE_HEIGHT = 28;
+
+/**
+ * Deterministic node width from its label (monospace), in px.
+ * @param {unknown} label
+ * @returns {number} integer width, never below MIN_W.
+ */
+export function estimateNodeWidth(label, { charW = CHAR_W, padX = PAD_X, min = MIN_W } = {}) {
+  const text = String(label ?? '');
+  return Math.max(min, Math.round(text.length * charW + padX));
+}

--- a/cli/kanban/client/src/views/DepsView.svelte
+++ b/cli/kanban/client/src/views/DepsView.svelte
@@ -1,13 +1,41 @@
+<script module>
+  // Cytoscape (~480 KB avec dagre) est importé dynamiquement à l'init du graphe,
+  // PAS au chargement de la vue : le shell deps (header + stats) peint alors
+  // aussi vite que les autres écrans (FCP/LCP), au lieu d'attendre le bundle viz.
+  // Le flag de module garantit un seul enregistrement de l'extension dagre.
+  let dagreRegistered = false;
+  let cytoscapePromise = null;
+  // Mémoïsé : un seul téléchargement du bundle, partagé par le préchargement au
+  // mount et l'init du graphe. Le préchargement chevauche le fetch /api/* pour
+  // sortir les 435 KB du chemin critique (LCP).
+  function loadCytoscape() {
+    if (!cytoscapePromise) {
+      cytoscapePromise = (async () => {
+        const [{ default: cytoscape }, { default: dagre }] = await Promise.all([
+          import('cytoscape'),
+          import('cytoscape-dagre'),
+        ]);
+        if (!dagreRegistered) {
+          cytoscape.use(dagre);
+          dagreRegistered = true;
+        }
+        return cytoscape;
+      })();
+    }
+    return cytoscapePromise;
+  }
+</script>
+
 <script>
-  import cytoscape from 'cytoscape';
-  import dagre from 'cytoscape-dagre';
   import { STATUS } from '../lib/config.js';
   import { buildDepsElements } from '../lib/deps-graph.js';
 
-  cytoscape.use(dagre);
-
   let graphContainer = $state(null);
-  let cyInstance = $state(null);
+  // Non-réactif volontairement : l'instance cytoscape est mutée en async depuis
+  // .then(). En faire un $state lu par le garde du $effect provoquerait une
+  // auto-invalidation (set → re-run → cleanup → destroy juste après création).
+  let cyInstance = null;
+  let graphBuilt = false;
   let nodes = $state([]);
   let edges = $state([]);
   let cycles = $state([]);
@@ -48,8 +76,23 @@
     loadDependencies();
   });
 
+  // Diffère le chargement du bundle cytoscape (435 KB) jusqu'APRÈS l'événement
+  // `load`. Pendant la fenêtre de mesure du LCP (rendu du shell), le réseau reste
+  // ainsi libre : pas de contention de bande passante qui retarderait la peinture
+  // du texte du shell (élément LCP réel). Le graphe est progressif — il apparaît
+  // juste après le premier rendu, ce qui améliore aussi l'UX réelle.
+  function afterLoad(fn) {
+    const run = () =>
+      typeof requestIdleCallback === 'function' ? requestIdleCallback(fn, { timeout: 1000 }) : setTimeout(fn, 1);
+    if (document.readyState === 'complete') run();
+    else window.addEventListener('load', run, { once: true });
+  }
+
   $effect(() => {
-    if (!graphContainer || nodes.length === 0 || !edges || cyInstance) return;
+    if (!graphContainer || nodes.length === 0 || !edges || graphBuilt) return;
+    graphBuilt = true;
+    let cancelled = false;
+    const container = graphContainer;
 
     // Cytoscape rend sur canvas : on résout les tokens en couleurs réelles.
     const root = getComputedStyle(document.documentElement);
@@ -63,10 +106,18 @@
 
     // Graphe limité aux nœuds connectés (les isolés cassent le layout dagre).
     const { elements } = buildDepsElements(nodes, edges, cycles);
-    if (elements.length === 0) return; // aucun lien → rien à dessiner (note affichée dans le DOM)
+    if (elements.length === 0) {
+      graphBuilt = false;
+      return; // aucun lien → rien à dessiner (note affichée dans le DOM)
+    }
 
-    const cy = cytoscape({
-      container: graphContainer,
+    let cy = null;
+    afterLoad(() => {
+      if (cancelled) return;
+      loadCytoscape().then((cytoscape) => {
+        if (cancelled) return;
+        cy = cytoscape({
+      container,
       elements,
       style: [
         {
@@ -107,23 +158,26 @@
         },
       ],
       layout: { name: 'dagre', rankDir: 'LR', spacingFactor: 1.3, nodeDimensionsIncludeLabels: true, fit: true, padding: 30 },
+      });
+
+      // Recentrer/zoomer pour que le graphe occupe le canvas (évite le rendu décalé).
+      cy.ready(() => cy.fit(undefined, 40));
+
+      cy.on('tap', 'node', (evt) => {
+        const nodeData = nodes.find((n) => n.id === evt.target.id());
+        if (nodeData) selectedNode = nodeData;
+      });
+
+      cyInstance = cy;
+      });
     });
-
-    // Recentrer/zoomer pour que le graphe occupe le canvas (évite le rendu décalé).
-    cy.ready(() => cy.fit(undefined, 40));
-
-    cy.on('tap', 'node', (evt) => {
-      const nodeData = nodes.find((n) => n.id === evt.target.id());
-      if (nodeData) selectedNode = nodeData;
-    });
-
-    cyInstance = cy;
 
     return () => {
-      if (cyInstance) {
-        cyInstance.destroy();
-        cyInstance = null;
-      }
+      cancelled = true;
+      graphBuilt = false;
+      const instance = cyInstance || cy;
+      if (instance) instance.destroy();
+      cyInstance = null;
     };
   });
 </script>

--- a/cli/kanban/client/src/views/DepsView.svelte
+++ b/cli/kanban/client/src/views/DepsView.svelte
@@ -29,6 +29,7 @@
 <script>
   import { STATUS } from '../lib/config.js';
   import { buildDepsElements } from '../lib/deps-graph.js';
+  import { normalizeColor, estimateNodeWidth, NODE_HEIGHT } from '../lib/deps-style.js';
 
   let graphContainer = $state(null);
   // Non-réactif volontairement : l'instance cytoscape est mutée en async depuis
@@ -95,8 +96,14 @@
     const container = graphContainer;
 
     // Cytoscape rend sur canvas : on résout les tokens en couleurs réelles.
+    // Les tokens sont en oklch() ; getComputedStyle les renvoie en lab()/oklch(),
+    // que le parser de cytoscape rejette (warnings « style property invalid » +
+    // perte de la couleur des nœuds). Un contexte canvas 2D normalise chaque
+    // valeur en sRGB (cf. normalizeColor / deps-style.js).
+    const nctx = document.createElement('canvas').getContext('2d');
+    const norm = (col) => normalizeColor(col, nctx);
     const root = getComputedStyle(document.documentElement);
-    const tok = (n, fb) => root.getPropertyValue(n).trim() || fb;
+    const tok = (n, fb) => norm(root.getPropertyValue(n).trim() || fb);
     const statusColor = (status) => tok(STATUS[status]?.cssVar || '--fg-faint', '#888');
     const cBg = tok('--bg-inset', '#111');
     const cBorder = tok('--border-faint', '#333');
@@ -135,12 +142,11 @@
             'font-size': '11px',
             'font-weight': '600',
             'font-family': cMono,
-            width: 'label',
-            height: 'label',
-            'padding-left': '10px',
-            'padding-right': '10px',
-            'padding-top': '7px',
-            'padding-bottom': '7px',
+            // Dimensions déterministes (cf. estimateNodeWidth) : remplacent
+            // l'auto-sizing « label » des dimensions, déprécié par cytoscape 3.34.
+            width: (ele) => estimateNodeWidth(ele.data('label')),
+            height: NODE_HEIGHT,
+            'text-max-width': '200px',
             'border-width': 1,
             'border-color': cBorder,
           },

--- a/cli/kanban/client/src/views/SprintsView.svelte
+++ b/cli/kanban/client/src/views/SprintsView.svelte
@@ -126,7 +126,10 @@
       {/if}
     </aside>
 
-    <main class="sprint-detail" aria-label="Détail du sprint">
+    <!-- Région section (et non un landmark principal) : le shell App fournit déjà
+         l'unique landmark principal. L'imbriquer ici violait
+         landmark-no-duplicate-main / landmark-main-is-top-level. -->
+    <section class="sprint-detail" aria-label="Détail du sprint">
       {#if !selectedId}
         <div class="empty">Sélectionnez un sprint</div>
       {:else if loadingDetail}
@@ -221,7 +224,7 @@
           </div>
         {/if}
       {/if}
-    </main>
+    </section>
   </div>
 </div>
 

--- a/cli/kanban/client/vite.config.js
+++ b/cli/kanban/client/vite.config.js
@@ -10,6 +10,11 @@ export default defineConfig({
     emptyOutDir: true,
     sourcemap: false,
     target: 'es2022',
+    // Keep every font as a same-origin file. Vite's default 4 KB inline limit
+    // emitted small subsets as data:font/woff base64 URLs, which the strict CSP
+    // (default-src 'self') blocks → console errors + Lighthouse best-practices
+    // and font-render churn that delayed FCP/LCP. 0 = never inline.
+    assetsInlineLimit: 0,
   },
   server: {
     port: 5173,

--- a/tests/kanban/deps-style.test.js
+++ b/tests/kanban/deps-style.test.js
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import {
+  needsColorNormalization,
+  normalizeColor,
+  estimateNodeWidth,
+  NODE_HEIGHT,
+} from '../../cli/kanban/client/src/lib/deps-style.js';
+
+// Regression guards for the cytoscape console warnings observed on the deps
+// graph (Wrandly project): the acid-lime design tokens are authored in oklch();
+// getComputedStyle resolves them to lab()/oklch() strings, which cytoscape's
+// canvas colour parser rejects → 20+ "style property `… : lab(…)` is invalid"
+// + "Custom function mappers may not return invalid values" warnings, and the
+// nodes lose their status colour. A canvas 2D context normalises any CSS Color 4
+// value back to an sRGB string cytoscape understands. Written BEFORE the fix.
+
+describe('needsColorNormalization', () => {
+  it('flags CSS Color 4 values cytoscape cannot parse', () => {
+    for (const c of [
+      'lab(32.6566% -.301272 -5.22689)',
+      'lch(58% 67 28)',
+      'oklab(0.7 -0.1 -0.04)',
+      'oklch(0.165 0.012 264)',
+      'color(display-p3 0.5 0.2 0.9)',
+      'LAB(50% 0 0)', // case-insensitive
+    ]) {
+      expect(needsColorNormalization(c), c).toBe(true);
+    }
+  });
+
+  it('leaves sRGB values cytoscape already understands untouched', () => {
+    for (const c of ['#111', '#c5f72b', 'rgb(20, 20, 20)', 'rgba(0,0,0,.5)', 'red', 'monospace']) {
+      expect(needsColorNormalization(c), c).toBe(false);
+    }
+  });
+
+  it('is null/undefined safe', () => {
+    expect(needsColorNormalization('')).toBe(false);
+    expect(needsColorNormalization(undefined)).toBe(false);
+    expect(needsColorNormalization(null)).toBe(false);
+  });
+});
+
+describe('normalizeColor', () => {
+  // A stub mimicking a 1px CanvasRenderingContext2D: getImageData returns fixed
+  // RGBA bytes, the way a real canvas rasterises a painted colour to sRGB.
+  const fakeCtx = (rgba = [51, 102, 153, 255]) => ({
+    fillStyle: '#000',
+    fillRect() {},
+    getImageData: () => ({ data: rgba }),
+  });
+
+  it('passes already-sRGB colours straight through (no canvas needed)', () => {
+    expect(normalizeColor('#c5f72b', null)).toBe('#c5f72b');
+    expect(normalizeColor('rgb(1,2,3)', fakeCtx())).toBe('rgb(1,2,3)');
+  });
+
+  it('rasterises lab()/oklch() to an sRGB rgb() string cytoscape accepts', () => {
+    expect(normalizeColor('oklch(0.165 0.012 264)', fakeCtx())).toBe('rgb(51, 102, 153)');
+    expect(normalizeColor('lab(32% -.3 -5)', fakeCtx())).toBe('rgb(51, 102, 153)');
+  });
+
+  it('preserves alpha via rgba() when not fully opaque', () => {
+    expect(normalizeColor('oklch(0.5 0.1 200 / 0.5)', fakeCtx([10, 20, 30, 128]))).toBe('rgba(10, 20, 30, 0.502)');
+  });
+
+  it('returns the input unchanged when no usable context is available (fallback)', () => {
+    expect(normalizeColor('oklch(0.165 0.012 264)', null)).toBe('oklch(0.165 0.012 264)');
+    expect(normalizeColor('lab(32% -.3 -5)', {})).toBe('lab(32% -.3 -5)');
+  });
+});
+
+describe('estimateNodeWidth / NODE_HEIGHT', () => {
+  it('replaces the deprecated cytoscape width/height:"label" auto-sizing', () => {
+    // cytoscape 3.34 warns "The style value of `label` is deprecated for width".
+    // A deterministic char-count estimate sizes the node without the literal.
+    expect(estimateNodeWidth('A')).toBeLessThan(estimateNodeWidth('US-E4-08b-FIN'));
+    expect(typeof NODE_HEIGHT).toBe('number');
+    expect(NODE_HEIGHT).toBeGreaterThan(0);
+  });
+
+  it('never goes below a sane minimum and is integer-valued', () => {
+    const w = estimateNodeWidth('');
+    expect(w).toBeGreaterThanOrEqual(24);
+    expect(Number.isInteger(w)).toBe(true);
+  });
+
+  it('is null/undefined safe', () => {
+    expect(estimateNodeWidth(undefined)).toBeGreaterThanOrEqual(24);
+    expect(estimateNodeWidth(null)).toBeGreaterThanOrEqual(24);
+  });
+});

--- a/tests/kanban/lighthouse-regressions.test.js
+++ b/tests/kanban/lighthouse-regressions.test.js
@@ -35,6 +35,34 @@ describe('Best Practices — no console / CSP errors', () => {
     // eliminating the data:font/woff base64 URLs that violate `default-src 'self'`.
     expect(/assetsInlineLimit\s*:\s*0\b/.test(cfg), 'vite build.assetsInlineLimit must be 0').toBe(true);
   });
+
+  it('index.html CSP declares font-src (else self-hosted fonts fall back to default-src)', () => {
+    // A build without an explicit `font-src` made the browser fall back to
+    // `default-src 'self'` and log "font-src was not explicitly set" for every
+    // glyph. The directive must be present in the meta CSP.
+    const html = read('index.html');
+    const csp = html.match(/Content-Security-Policy["']\s+content="([^"]+)"/i);
+    expect(csp, 'missing meta Content-Security-Policy').not.toBeNull();
+    expect(/font-src\s+[^;]+/.test(csp[1]), 'CSP must declare font-src').toBe(true);
+  });
+
+  it('DepsView normalises oklch design tokens for the cytoscape canvas renderer', () => {
+    // getComputedStyle resolves the oklch() tokens to lab()/oklch() strings that
+    // cytoscape's parser rejects → ~20 "style property `…: lab(…)` is invalid" +
+    // "Custom function mappers may not return invalid values" warnings, and the
+    // node status colour is lost. normalizeColor() rasterises them back to sRGB.
+    const deps = read('src/views/DepsView.svelte');
+    expect(/normalizeColor/.test(deps), 'DepsView must route resolved tokens through normalizeColor').toBe(true);
+  });
+
+  it('DepsView avoids the deprecated cytoscape width/height:"label" auto-sizing', () => {
+    // cytoscape 3.34 logs "The style value of `label` is deprecated for width/height".
+    // Node dimensions come from estimateNodeWidth/NODE_HEIGHT instead.
+    const deps = read('src/views/DepsView.svelte');
+    expect(/width:\s*['"]label['"]/.test(deps), 'must not use width: "label"').toBe(false);
+    expect(/height:\s*['"]label['"]/.test(deps), 'must not use height: "label"').toBe(false);
+    expect(/estimateNodeWidth/.test(deps), 'node width must come from estimateNodeWidth').toBe(true);
+  });
 });
 
 describe('Accessibility — single main landmark', () => {

--- a/tests/kanban/lighthouse-regressions.test.js
+++ b/tests/kanban/lighthouse-regressions.test.js
@@ -1,0 +1,135 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// Regression guards for the "Lighthouse 100 on every board screen" goal.
+// Each assertion locks in a fix for a specific audit that scored < 100 in the
+// baseline (see scratchpad harness): SEO meta-description, Best-Practices
+// console/CSP errors (data: font inlining + favicon 404), and Accessibility
+// (aria-prohibited-attr on avatars + color-contrast on the faint text tier).
+// Written BEFORE the fixes — they fail on the pre-fix tree (true TDD).
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const CLIENT = path.resolve(here, '../../cli/kanban/client');
+const read = (rel) => readFileSync(path.join(CLIENT, rel), 'utf8');
+
+describe('SEO — meta description', () => {
+  it('index.html declares a non-empty meta description', () => {
+    const html = read('index.html');
+    const m = html.match(/<meta\s+name=["']description["']\s+content=["']([^"']+)["']/i);
+    expect(m, 'missing <meta name="description">').not.toBeNull();
+    expect(m[1].trim().length).toBeGreaterThan(20);
+  });
+});
+
+describe('Best Practices — no console / CSP errors', () => {
+  it('declares a favicon so the browser does not 404 on /favicon.ico', () => {
+    const html = read('index.html');
+    expect(/<link\s+rel=["']icon["']/i.test(html), 'missing <link rel="icon">').toBe(true);
+  });
+
+  it('vite disables asset inlining so fonts stay self-hosted files (no data: URIs blocked by CSP)', () => {
+    const cfg = read('vite.config.js');
+    // assetsInlineLimit: 0 forces every font to a same-origin file URL,
+    // eliminating the data:font/woff base64 URLs that violate `default-src 'self'`.
+    expect(/assetsInlineLimit\s*:\s*0\b/.test(cfg), 'vite build.assetsInlineLimit must be 0').toBe(true);
+  });
+});
+
+describe('Accessibility — single main landmark', () => {
+  it('no view component renders its own <main> (the App shell owns the sole <main>)', () => {
+    // axe landmark-no-duplicate-main / landmark-main-is-top-level fired on a
+    // nested <main> in SprintsView while App already wraps views in <main id="main">.
+    const views = ['KanbanView', 'BacklogView', 'SprintsView', 'BurndownView', 'DepsView', 'DocsView'];
+    for (const v of views) {
+      const src = read(`src/views/${v}.svelte`);
+      expect(/<main[\s>]/.test(src), `${v}.svelte must not declare a <main>`).toBe(false);
+    }
+  });
+});
+
+describe('Performance — heavy viz off the LCP critical path', () => {
+  const deps = read('src/views/DepsView.svelte');
+
+  it('cytoscape is dynamically imported, not a static top-level import', () => {
+    // A static `import cytoscape from 'cytoscape'` would bundle 435 KB into the
+    // view chunk and load it on the LCP critical path.
+    expect(/import\s+cytoscape\s+from/.test(deps), 'cytoscape must not be a static import').toBe(false);
+    expect(/import\(\s*['"]cytoscape['"]\s*\)/.test(deps), 'cytoscape must be dynamically imported').toBe(true);
+  });
+
+  it('the graph build is deferred until after the load event (no bandwidth contention during LCP)', () => {
+    expect(/addEventListener\(\s*['"]load['"]/.test(deps), 'must defer viz init to the load event').toBe(true);
+  });
+});
+
+describe('Accessibility — aria-prohibited-attr', () => {
+  it('the avatar carries role="img" so its aria-label is permitted', () => {
+    const svelte = read('src/components/Avatar.svelte');
+    // A <span> with aria-label but no role is flagged by axe (aria-prohibited-attr).
+    // Both branches (assigned + unassigned) use aria-label, so both need a role.
+    const spanBlocks = svelte.split('<span').slice(1);
+    const ariaSpans = spanBlocks.filter((s) => /aria-label/.test(s.slice(0, s.indexOf('>'))));
+    expect(ariaSpans.length).toBeGreaterThan(0);
+    for (const s of ariaSpans) {
+      const openTag = s.slice(0, s.indexOf('>'));
+      expect(/role=["']img["']/.test(openTag), `avatar span missing role="img": ${openTag.trim()}`).toBe(true);
+    }
+  });
+});
+
+// --- OKLCH → sRGB → WCAG relative luminance (Björn Ottosson matrices) ---
+function oklchToLinearRgb(L, C, hDeg) {
+  const h = (hDeg * Math.PI) / 180;
+  const a = C * Math.cos(h);
+  const b = C * Math.sin(h);
+  let l = L + 0.3963377774 * a + 0.2158037573 * b;
+  let m = L - 0.1055613458 * a - 0.0638541728 * b;
+  let s = L - 0.0894841775 * a - 1.291485548 * b;
+  l = l ** 3;
+  m = m ** 3;
+  s = s ** 3;
+  return [
+    4.0767416621 * l - 3.3077115913 * m + 0.2309699292 * s,
+    -1.2684380046 * l + 2.6097574011 * m - 0.3413193965 * s,
+    -0.0041960863 * l - 0.7034186147 * m + 1.707614701 * s,
+  ];
+}
+function relLuminance(L, C, h) {
+  const [r, g, b] = oklchToLinearRgb(L, C, h).map((v) => Math.max(0, Math.min(1, v)));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+function contrast(fg, bg) {
+  const Lf = relLuminance(...fg);
+  const Lb = relLuminance(...bg);
+  const [hi, lo] = Lf > Lb ? [Lf, Lb] : [Lb, Lf];
+  return (hi + 0.05) / (lo + 0.05);
+}
+function token(css, name) {
+  const m = css.match(new RegExp(`--${name}:\\s*oklch\\(([^)]+)\\)`));
+  if (!m) throw new Error(`token --${name} not found`);
+  const [L, C, h] = m[1].trim().split(/\s+/).map(Number);
+  return [L, C, h];
+}
+
+describe('Accessibility — color contrast (WCAG AA, small text ≥ 4.5:1)', () => {
+  const css = read('src/app.css');
+  // The lightest surface that ever hosts faint/dim text (proj-card, search kbd,
+  // sprint-pill, chips). Passing here implies passing on every darker surface.
+  const lightestSurface = '--bg-elev-2'; // oklch(0.245 …) — worst case
+
+  for (const fgName of ['--fg-faint', '--fg-dim']) {
+    it(`${fgName} reaches 4.5:1 against ${lightestSurface}`, () => {
+      const ratio = contrast(token(css, fgName.slice(2)), token(css, lightestSurface.slice(2)));
+      expect(ratio).toBeGreaterThanOrEqual(4.5);
+    });
+  }
+
+  it('sanity: the converter reproduces the baseline failing ratio (~3.7) for the old faint value', () => {
+    // oklch(0.55 0.012 264) on oklch(0.205) was reported by Lighthouse at ~3.71.
+    const ratio = contrast([0.55, 0.012, 264], [0.205, 0.013, 264]);
+    expect(ratio).toBeGreaterThan(3.4);
+    expect(ratio).toBeLessThan(4.0);
+  });
+});

--- a/tests/scripts/bash-available.test.mjs
+++ b/tests/scripts/bash-available.test.mjs
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { execSync } from 'child_process';
+
+/**
+ * Guard test (REL): every other tests/scripts/*.test.mjs shells out to
+ * `bash "<script>.sh"` because the scripts under test rely on bashisms
+ * ([[ ]], arrays, `type -t`, `local`, `${VAR:+}`). Run inside a shell
+ * environment without bash (e.g. a bare `node:*-alpine` / busybox image)
+ * those 12 files fail uniformly with `/bin/sh: bash: not found`.
+ *
+ * This test codifies the prerequisite (docs/PREREQUISITES.md §2 "Bash Shell")
+ * as an executable contract: if it fails, the docker/test image is missing
+ * bash — use the bash-capable runner (`make test-scripts-docker`) instead of
+ * a bare busybox image. It must never reach the AssertionError stage.
+ */
+describe('tests/scripts prerequisites', () => {
+  it('bash is available on PATH', () => {
+    let version = '';
+    try {
+      version = execSync('bash --version', { encoding: 'utf8', timeout: 5000 });
+    } catch (err) {
+      throw new Error(
+        'bash is not available in this test environment. The tests/scripts ' +
+          'suite requires GNU bash (the scripts use bashisms). Run the suite ' +
+          'in a bash-capable image — `make test-scripts-docker` — not a bare ' +
+          `busybox/alpine image. Underlying error: ${err.message}`
+      );
+    }
+    expect(version).toContain('GNU bash');
+  });
+});


### PR DESCRIPTION
## Objectif
Amener le board Kanban à **Lighthouse 100/100/100/100** (performance, accessibilité, best-practices, SEO) sur les **6 écrans** : kanban, backlog, sprints, burndown, deps, docs.

## Résultat
- **100 sur les 6 écrans × 4 catégories**, déterministe sous throttling mesuré (mode Lighthouse-in-DevTools).
- **axe-core** (WCAG 2.0/2.1 A/AA + best-practice) : **0 violation** sur les 6 écrans.
- Suite kanban : **304/304 tests verts**.

## Méthode — TDD (tests avant correction)
`tests/kanban/lighthouse-regressions.test.js` écrit AVANT les fixes (rouge → vert). Inclut un convertisseur OKLCH→sRGB validé contre la baseline pour verrouiller l'invariant de contraste, plus des gardes structurelles (landmark unique, viz hors chemin critique LCP, fonts non-inlinées).

## Corrections (cause → fix)
| Domaine | Cause | Correctif |
|---|---|---|
| SEO | `meta description` absente | ajout dans `index.html` |
| Best-practices | fonts inlinées en `data:font/...base64` → bloquées par CSP `'self'` (erreurs console + inspector CSP) | `build.assetsInlineLimit: 0` + favicon SVG inline (anti-404) + `font-src 'self'` |
| a11y contraste | `--fg-faint` oklch 0.55 (3.7:1) | → **0.64** (≥4.8:1) |
| a11y aria | avatars `aria-label` sans rôle | `role="img"` |
| a11y landmark | `<main>` imbriqué (SprintsView) | → `<section>` (App = unique `<main>`) |
| perf deps | cytoscape 435 KB sur le chemin critique | chunk dynamique + init différée après `load` |

## Caveat honnête (perf deps)
Sous throttling **`simulate`** (lantern, défaut CLI/PSI), `deps` oscille **98↔100** : artefact de modélisation lantern (contention bande passante du chunk cytoscape pendant la fenêtre LCP). Le LCP réel mesuré est ~80 ms ; sous throttling **mesuré (devtools)** la perf est **100 stable**. Le défer après `load` est le compromis honnête retenu — pas de délai calé sur le trace ; modulepreload/prefetch testés et écartés (ils empirent par contention).

## Vérification
- Build via docker (`node:22-alpine`) — `dist/` gitignored, reconstruit en CI.
- Le graphe de dépendances reste fonctionnel (DOM peuplé vérifié post-refactor async).

🤖 Generated with [Claude Code](https://claude.com/claude-code)