### PR TITLE
chore(release): v8.17.1

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.17.0 | **Languages:** en, fr, es, de, pt
+**Version:** 8.17.1 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.11.0
+- **Version:** 8.17.1
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.17.1] - 2026-06-26
+
+### Added
+
+- **Makefile `test-scripts-docker`** : lance la suite `tests/scripts/` dans une image docker embarquant bash (`TEST_IMAGE ?= node:24`), afin que le workflow « TOUJOURS docker » dispose de bash.
+
+### Fixed
+
+- **`tests/scripts/` sous image sans bash** : les 12 fichiers qui exécutent `bash "<script>.sh"` (bashismes : `[[ ]]`, arrays, `type -t`, `local`, `${VAR:+}`) échouaient avec `/bin/sh: bash: not found` sous une image busybox/alpine. Ajout de la garde `tests/scripts/bash-available.test.mjs` qui codifie le prérequis GNU bash (docs/PREREQUISITES.md §2) avec un message actionnable pointant vers `make test-scripts-docker`.
+
 ## [8.17.0] - 2026-06-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,7 +28,11 @@ Plus **11 stack-specific reviewers** (@symfony-reviewer, @react-reviewer, @pytho
 
 A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces (219 total), 55 skills**, all token-optimized via `context: fork` and sub-agent model routing.
 
-## What's New in v8.17.0
+## What's New in v8.17.1
+
+**Correctifs tests (2026-06-26, v8.17.1) :**
+
+- **`tests/scripts/` sous docker sans bash** : les 12 fichiers shell-out `bash "*.sh"` échouaient en `/bin/sh: bash: not found` sous busybox/alpine. Nouveau target `make test-scripts-docker` (image bash, `node:24`) + garde `tests/scripts/bash-available.test.mjs`.
 
 **Audit exhaustif multi-agents + mises à jour 2026-06-24 (v8.17.0) :**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Supported          |
 |---------|--------------------|
-| 8.9.x   | :white_check_mark: |
-| 8.8.x   | :white_check_mark: |
-| 8.7.x   | :white_check_mark: |
-| < 8.7   | :x:                |
+| 8.17.x  | :white_check_mark: |
+| 8.16.x  | :white_check_mark: |
+| 8.15.x  | :white_check_mark: |
+| < 8.15  | :x:                |
 
 
 ## Reporting a Vulnerability

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.17.0",
+  "version": "8.17.1",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
## Release v8.17.1 (PATCH)

Correctif tests + bump version.

### Fixed
- `tests/scripts/` échouait (12 fichiers) sous image docker sans bash (busybox/alpine) : `/bin/sh: bash: not found`. Ajout garde `tests/scripts/bash-available.test.mjs` + target `make test-scripts-docker` (image `node:24`).

### Release
- `package.json`, `.claude/CLAUDE.md`, `.claude/context-essentials.md` → 8.17.1
- `CHANGELOG.md` entrée [8.17.1]
- `SECURITY.md` table versions supportées rafraîchie (8.15–8.17.x)
- `README.md` What's New

### Vérifications locales
- vitest (docker node:24) : 1113/1113 ✓
- BATS : 29/27/13/138/4 ✓
- `lint:i18n`, `docs:check`, `lint:versions` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)