### PR TITLE
feat(workflow): /workflow:auto-sprint end-to-end orchestrator

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **Version:** 8.17.2 | **Languages:** en, fr, es, de, pt
 
-A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces, and BMAD v6 project management.
+A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 126 commands across 15 namespaces, and BMAD v6 project management.
 
 ---
 
@@ -45,7 +45,7 @@ See `@.claude/INDEX.md` for condensed checklists and patterns.
 
 ---
 
-## Available Commands (15 namespaces, 125 commands)
+## Available Commands (15 namespaces, 126 commands)
 
 Core: `/common:*`, `/workflow:*`, `/team:*`, `/qa:*`, `/uiux:*` | Tech: `/symfony:*`, `/react:*`, `/flutter:*`, `/python:*`, `/angular:*`, `/vuejs:*`, `/laravel:*`, `/reactnative:*`, `/csharp:*`, `/php:*`, `/paperclip:*` | Infra (via `@devops-engineer`): Docker 29.6.0, Coolify v4.1.2, K8s 1.36.1, OpenTofu 1.12.2, Ansible 2.21.1, FrankenPHP 1.12.4, PgBouncer 1.25.2 | Project: `/sprint:*`, `/gate:*`, `/project:*`
 

--- a/.claude/commands/workflow/auto-sprint.md
+++ b/.claude/commands/workflow/auto-sprint.md
@@ -1,0 +1,197 @@
+---
+description: Orchestrateur de sprint de bout en bout (démarrage -> décomposition -> validation -> implémentation -> PR -> CI -> revue -> rétro -> merge)
+argument-hint: "<N> [--auto-merge] [--max-fix-attempts=2] [--max-workers=3] [--base=main] [--dry-run] [--overnight]"
+---
+
+# Auto Sprint — Orchestrateur de Sprint de Bout en Bout
+
+Tu joues le rôle de **Product Owner / Scrum Master** et tu pilotes un sprint complet, du lancement au merge,
+en **une seule commande**. Chaque cérémonie s'exécute dans un **sous-agent isolé** : la fenêtre de contexte
+propre au sous-agent remplace le `/clear` manuel entre les étapes, ce qui permet à ton contexte d'orchestrateur
+de rester léger. La phase d'implémentation est conduite **par toi en tant que chef d'orchestre** (même logique
+que `/team:sprint`) afin d'éviter l'imbrication d'Agent Teams.
+
+Cette commande automatise ce qui nécessitait auparavant six commandes manuelles avec un `/clear` entre chaque :
+
+```
+/workflow:start N -> /project:decompose-tasks 00N -> /gate:validate-sprint 00N
+-> /team:sprint "sprint-00N" -> /workflow:review N -> /workflow:retro N
+```
+
+…et ajoute : branche, commit, Pull Request, surveillance CI et merge.
+
+## Arguments
+
+$ARGUMENTS
+
+- `<N>` : Numéro du sprint (ex. `5`). **Obligatoire.**
+- `--auto-merge` : Merge automatiquement dès que la CI est verte et que la DoD est validée. **Défaut : DÉSACTIVÉ** — la
+  commande se met en pause et attend un GO humain explicite avant de merger (respecte la règle de « revue obligatoire »,
+  règle 09, et le principe Karpathy « pas d'auto-merge sans revue humaine »).
+- `--max-fix-attempts=2` : Nombre maximal de tentatives de correction automatique par gate échoué avant abandon (défaut : 2).
+- `--max-workers=3` : Nombre maximal de workers dev parallèles pendant la phase d'implémentation (défaut : 2, max : 3).
+- `--base=main` : Branche de base pour la PR (défaut : `main`).
+- `--dry-run` : Affiche les 9 phases planifiées et le contexte de sprint résolu, puis s'arrête. **Aucune écriture.**
+- `--overnight` : Transmis à la phase d'implémentation (borné, s'arrête à 6h).
+
+## Prérequis
+
+- Claude Code v2.1.32+ avec le support Agent Teams
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` défini
+- CLI `gh` authentifié (création de PR / checks / merge)
+- Docker disponible (tous les tests s'exécutent via Docker — voir le CLAUDE.md du projet)
+- Projet BMAD v6 avec `.bmad/sprint-status.yaml` présent
+
+> Si un prérequis est manquant, abandonner immédiatement avec un message clair et actionnable. Ne jamais ignorer silencieusement une phase.
+
+## Normalisation du numéro de sprint
+
+Les commandes chaînées ne s'accordent pas sur le format. Normaliser **une seule fois** en Phase 0 et transmettre
+la bonne forme à chaque phase :
+
+| Phase | Forme attendue |
+|-------|----------------|
+| `start`, `review`, `retro` | `N` brut (ex. `5`) |
+| `decompose-tasks` | `00N` avec zéros (ex. `005`) |
+| `team:sprint` (implémentation) | nom libre du sprint résolu depuis le dossier / fichier de statut |
+
+Résoudre le dossier du sprint via glob `project-management/sprints/sprint-{N}-*/` et lire
+`.bmad/sprint-status.yaml` pour le nom canonique du sprint et la liste de stories.
+
+## Processus
+
+### Phase 0 — Normalisation & branche (inline)
+
+1. Parser `<N>` et les drapeaux. Dériver `N`, `00N`, le slug et le nom du sprint.
+2. Résoudre `project-management/sprints/sprint-{N}-*/` et `.bmad/sprint-status.yaml`.
+   **Abandonner** si aucun des deux n'existe (rien à orchestrer).
+3. Vérifier que l'arbre de travail est propre et que `--base` est à jour. **Abandonner** si sale.
+4. Créer / basculer sur la branche feature `feature/sprint-{N}-<slug>` depuis `--base`
+   (règle 09 : `main` toujours déployable — ne jamais travailler directement sur la branche de base).
+5. Si `--dry-run` : afficher le contexte résolu + les 9 phases planifiées et **s'arrêter ici**.
+
+### Phase 1 — Démarrage (sous-agent)
+
+Instancier un sous-agent isolé :
+
+> « Lis `.claude/commands/workflow/start.md` et exécute-le pour le sprint **N**.
+> Crée la structure de dossier du sprint, `sprint-goal.md`, et la checklist pré-sprint.
+> Retourne un résumé concis (< 50 tokens) et la liste des fichiers créés. »
+
+### Phase 2 — Décomposition (sous-agent)
+
+> « Lis `.claude/commands/project/decompose-tasks.md` et exécute-le pour le sprint **00N**.
+> Génère les fichiers de tâches par US, `task-board.md`, et le graphe de dépendances.
+> Retourne un résumé concis et les fichiers créés. »
+
+### Phase 3 — Validation du gate (sous-agent + boucle de correction automatique)
+
+> « Lis `.claude/commands/gate/validate-sprint.md` et exécute-le pour le sprint **00N**.
+> Retourne PASS/FAIL, le score et la liste des critères échoués. »
+
+**En cas d'ÉCHEC → boucle de correction automatique** (jusqu'à `--max-fix-attempts`) :
+- Instancier un sous-agent de remédiation qui corrige les écarts signalés (stories non `ready-for-dev`,
+  estimations manquantes, dépendances non résolues) directement dans les fichiers du sprint.
+- Relancer le sous-agent de validation.
+- Si toujours en échec après `--max-fix-attempts` → **abandonner** avec le rapport de remédiation.
+
+### Phase 4 — Implémentation (tu = chef d'orchestre)
+
+Prendre **directement le rôle de conducteur `/team:sprint`** (ne **pas** instancier un Agent Team imbriqué) :
+
+1. Lire `.bmad/sprint-status.yaml` ; filtrer les stories à `ready-for-dev`.
+2. Analyser l'indépendance des domaines de fichiers (signaler les chevauchements `**/Shared/**`, `**/Common/**`, `**/Utils/**`,
+   `**/Helpers/**` → séquencer dans le même worker).
+3. Estimer le coût via `Tools/AgentTeams/lib/cost-estimator.sh` (respecter le garde Fast Mode bloquant
+   et `--max-cost` si présent).
+4. `TaskCreate` un worker dev par story indépendante (max `--max-workers`), contexte réduit
+   (uniquement `@.claude/references/<project-tech>/CLAUDE.md`). Les workers suivent le cycle TDD Rouge/Vert/Refactor
+   avec des commandes de test **Docker**.
+5. Interroger `TaskList` toutes les 30s (reculer à 60s après 3 sondages sans activité). Rafraîchir `TaskList`
+   toutes les 5 complétion de worker (atténuation de la compaction de contexte). Limiter les messages de
+   complétion de worker à < 50 tokens.
+6. Valider la **DoD** par story ; faire passer l'état `in-progress -> review` dans `sprint-status.yaml`
+   via le pattern single-writer.
+
+**En cas de non-respect de la DoD pour une story → boucle de correction automatique** (même budget de tentatives) : reconfier la story au worker avec les vérifications en échec ; après `--max-fix-attempts`, marquer la story `blocked` et continuer.
+
+### Phase 5 — Commit & PR (inline)
+
+1. Commiter l'implémentation avec les **Conventional Commits** (atomique par story dans la mesure du possible).
+2. Pousser la branche feature.
+3. Ouvrir une PR en **brouillon** contre `--base` via `gh pr create` (titre + corps résumant l'objectif
+   du sprint, les stories livrées et l'état de la DoD).
+
+### Phase 6 — Surveillance CI (inline + boucle de correction automatique)
+
+1. Surveiller la CI : `gh pr checks --watch` (sondage ~30s).
+2. **En cas d'échec → boucle de correction automatique** (jusqu'à `--max-fix-attempts`) : lire les logs du job échoué
+   (`gh run view --log-failed`), instancier un sous-agent de correction, commiter + pousser, relancer la surveillance.
+3. Après `--max-fix-attempts` toujours en échec → **abandonner** avec le rapport de vérifications échouées.
+
+### Phase 7 — Revue (sous-agent)
+
+> « Lis `.claude/commands/workflow/review.md` et exécute-le pour le sprint **N** (il utilise
+> `git log` / `gh pr` pour collecter les données du sprint). Produis `sprint-review.md`. Retourne un résumé concis. »
+
+### Phase 8 — Rétrospective (sous-agent)
+
+> « Lis `.claude/commands/workflow/retro.md` et exécute-le pour le sprint **N**.
+> Produis `sprint-retro.md` avec des actions SMART. Retourne un résumé concis. »
+
+### Phase 9 — Merge (inline, gardé)
+
+- **Si `--auto-merge`** ET CI verte ET DoD validée :
+  `gh pr ready` puis `gh pr merge --squash --delete-branch`.
+- **Sinon (défaut)** : **se mettre en pause**. Présenter le résumé final, le lien PR, l'état CI et le
+  rapport DoD, puis **attendre un GO humain explicite** avant de merger.
+
+> **Les erreurs de merge sont remontées, jamais codées en dur.** Si le merge est bloqué par la protection de branche,
+> le signaler et suggérer `--admin`. S'il est bloqué parce que la PR touche `.github/workflows/`
+> et que le token n'a pas le scope `workflow`, le signaler et suggérer un squash-and-push manuel.
+> Ne pas intégrer les particularités d'un dépôt spécifique dans cette commande générique.
+
+## Rapport final
+
+```
+================================================================
+AUTO SPRINT — Résumé
+================================================================
+Sprint        : sprint-<N>-<slug>
+Branche       : feature/sprint-<N>-<slug>
+Base          : <base>
+PR            : <url>  (CI: <vert|rouge>)
+----------------------------------------------------------------
+Phase              | Statut | Notes
+-------------------|--------|---------------------------------------
+0 Normalisation    | OK     | <N>/00<N>, branche prête
+1 Démarrage        | OK     | sprint-goal.md
+2 Décomposition    | OK     | N fichiers de tâches
+3 Validation gate  | OK     | score X% (Y tentatives de correction)
+4 Implémentation   | OK     | A/B stories, C bloquées
+5 Commit + PR      | OK     | <url>
+6 Surveillance CI  | OK     | vert (Z tentatives de correction)
+7 Revue            | OK     | sprint-review.md
+8 Rétro            | OK     | sprint-retro.md
+9 Merge            | EN ATTENTE | attente GO humain   (ou MERGÉ)
+================================================================
+```
+
+## Gestion des erreurs
+
+| Situation | Comportement |
+|-----------|--------------|
+| Dossier sprint / fichier de statut absent | Abandon en Phase 0 |
+| Arbre de travail sale | Abandon en Phase 0 |
+| Gate de validation échoué après tentatives | Abandon avec rapport de remédiation |
+| DoD story non respectée après tentatives | Marquer `blocked`, continuer, signaler en fin |
+| CI en échec après tentatives | Abandon avec rapport de vérifications échouées |
+| Merge bloqué (protection / scope) | Remonter l'erreur + drapeau suggéré, ne pas forcer |
+| Agent Teams indisponible | Abandon Phase 4 avec indication de configuration (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) |
+
+## Notes
+
+- **Pas d'Agent Teams imbriqués** : tu exécutes toi-même le rôle de conducteur en Phase 4.
+- **L'auto-merge est opt-in** et intentionnellement conditionné à un drapeau.
+- **Docker est obligatoire** pour les tests (CLAUDE.md du projet).
+- L'isolation des sous-agents remplace `/clear` — garder chaque rapport de sous-agent concis.

--- a/Dev/i18n/de/Workflow/commands/auto-sprint.md
+++ b/Dev/i18n/de/Workflow/commands/auto-sprint.md
@@ -1,0 +1,198 @@
+---
+description: End-to-End-Sprint-Orchestrator (Start -> Zerlegung -> Validierung -> Implementierung -> PR -> CI -> Review -> Retro -> Merge)
+argument-hint: "<N> [--auto-merge] [--max-fix-attempts=2] [--max-workers=3] [--base=main] [--dry-run] [--overnight]"
+---
+
+# Auto Sprint — End-to-End-Sprint-Orchestrator
+
+Sie agieren als **Product Owner / Scrum Master** und steuern einen vollständigen Sprint von der Eröffnung bis zum Merge
+in einem **einzigen Befehl**. Jede Zeremonie läuft in einem **isolierten Unter-Agenten**: Das eigene
+Kontextfenster des Unter-Agenten ersetzt das manuelle `/clear` zwischen den Schritten, sodass der
+Orchestrator-Kontext schlank bleibt. Die Implementierungsphase wird **von Ihnen als Dirigent** übernommen
+(gleiche Logik wie `/team:sprint`), um verschachtelte Agent Teams zu vermeiden.
+
+Dies automatisiert, was zuvor sechs manuelle Befehle mit einem `/clear` dazwischen erforderte:
+
+```
+/workflow:start N -> /project:decompose-tasks 00N -> /gate:validate-sprint 00N
+-> /team:sprint "sprint-00N" -> /workflow:review N -> /workflow:retro N
+```
+
+…und ergänzt dies um: Branch, Commit, Pull Request, CI-Überwachung und Merge.
+
+## Argumente
+
+$ARGUMENTS
+
+- `<N>` : Sprint-Nummer (z.B. `5`). **Erforderlich.**
+- `--auto-merge` : Merge automatisch durchführen, sobald CI grün und DoD bestanden ist. **Standard: AUS** — der
+  Befehl pausiert und wartet auf ein explizites menschliches GO vor dem Merge (berücksichtigt „review obligatoire",
+  Regel 09, und das Karpathy-Prinzip „kein Auto-Merge ohne menschliche Review").
+- `--max-fix-attempts=2` : Maximale automatische Korrekturversuche pro fehlgeschlagenem Gate vor dem Abbruch (Standard: 2).
+- `--max-workers=3` : Maximale parallele Entwickler-Worker in der Implementierungsphase (Standard: 2, Maximum: 3).
+- `--base=main` : Basis-Branch für den PR (Standard: `main`).
+- `--dry-run` : Gibt die geplanten 9 Phasen und den aufgelösten Sprint-Kontext aus und hält dann an. **Keine Schreibvorgänge.**
+- `--overnight` : Wird an die Implementierungsphase weitergegeben (begrenzt, stoppt um 6 Uhr morgens).
+
+## Voraussetzungen
+
+- Claude Code v2.1.32+ mit Agent Teams Unterstützung
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` gesetzt
+- `gh` CLI authentifiziert (PR erstellen / Prüfungen / Merge)
+- Docker verfügbar (alle Tests laufen über Docker — siehe Projekt-CLAUDE.md)
+- BMAD v6-Projekt mit vorhandener `.bmad/sprint-status.yaml`
+
+> Falls eine Voraussetzung fehlt, sofort mit einer klaren, handlungsorientierten Meldung abbrechen. Eine Phase nicht stillschweigend überspringen.
+
+## Normalisierung der Sprint-Nummer
+
+Die verketteten Befehle sind sich über das Format uneinig. **Einmalig** in Phase 0 normalisieren und die richtige Form
+an jede Phase übergeben:
+
+| Phase | Erwartetes Format |
+|-------|-------------------|
+| `start`, `review`, `retro` | Reine Zahl `N` (z.B. `5`) |
+| `decompose-tasks` | Null-aufgefüllt `00N` (z.B. `005`) |
+| `team:sprint` (Implementierung) | Freier Sprint-Name, aus Ordner / Status-Datei aufgelöst |
+
+Den Sprint-Ordner durch Glob-Suche `project-management/sprints/sprint-{N}-*/` auflösen und
+`.bmad/sprint-status.yaml` für den kanonischen Sprint-Namen und die Story-Liste lesen.
+
+## Prozess
+
+### Phase 0 — Normalisieren & Branch anlegen (direkt)
+
+1. `<N>` und Flags parsen. `N`, `00N`, Sprint-Slug und Sprint-Name ableiten.
+2. `project-management/sprints/sprint-{N}-*/` und `.bmad/sprint-status.yaml` auflösen.
+   **Abbruch**, falls weder das eine noch das andere existiert (nichts zu orchestrieren).
+3. Sicherstellen, dass der Working Tree sauber ist und `--base` aktuell ist. **Abbruch** bei schmutzigem Tree.
+4. Den Feature-Branch `feature/sprint-{N}-<slug>` von `--base` erstellen / auschecken
+   (Regel 09: `main` immer deployfähig — nie direkt auf dem Basis-Branch arbeiten).
+5. Bei `--dry-run`: aufgelösten Kontext + die 9 geplanten Phasen ausgeben und **hier stoppen**.
+
+### Phase 1 — Start (Unter-Agent)
+
+Einen isolierten Unter-Agenten starten:
+
+> „Lesen Sie `.claude/commands/workflow/start.md` und führen Sie es für Sprint **N** aus.
+> Erstellen Sie die Sprint-Ordnerstruktur, `sprint-goal.md` und die Vor-Sprint-Checkliste.
+> Geben Sie eine knappe Zusammenfassung (< 50 Tokens) und die Liste der erstellten Dateien zurück."
+
+### Phase 2 — Zerlegung (Unter-Agent)
+
+> „Lesen Sie `.claude/commands/project/decompose-tasks.md` und führen Sie es für Sprint **00N** aus.
+> Generieren Sie die Task-Dateien je US, `task-board.md` und den Abhängigkeitsgraphen.
+> Geben Sie eine knappe Zusammenfassung und die erstellten Dateien zurück."
+
+### Phase 3 — Gate-Validierung (Unter-Agent + Auto-Korrektur-Schleife)
+
+> „Lesen Sie `.claude/commands/gate/validate-sprint.md` und führen Sie es für Sprint **00N** aus.
+> Geben Sie PASS/FAIL, die Punktzahl und die Liste der fehlgeschlagenen Kriterien zurück."
+
+**Bei FAIL → Auto-Korrektur-Schleife** (bis zu `--max-fix-attempts`):
+- Einen Korrektur-Unter-Agenten starten, der die gemeldeten Lücken direkt in den Sprint-Dateien behebt
+  (Stories nicht `ready-for-dev`, fehlende Schätzungen, ungelöste Abhängigkeiten).
+- Den Validierungs-Unter-Agenten erneut starten.
+- Falls nach `--max-fix-attempts` immer noch fehlgeschlagen → **Abbruch** mit dem Korrekturbericht.
+
+### Phase 4 — Implementierung (Sie = Dirigent)
+
+Direkt die **`/team:sprint`-Dirigenten-Rolle übernehmen** (kein verschachteltes Agent Team starten):
+
+1. `.bmad/sprint-status.yaml` lesen; Stories mit Status `ready-for-dev` filtern.
+2. Datei-Domain-Unabhängigkeit analysieren (`**/Shared/**`, `**/Common/**`, `**/Utils/**`,
+   `**/Helpers/**` Überschneidungen markieren → beim gleichen Worker sequenzieren).
+3. Kosten über `Tools/AgentTeams/lib/cost-estimator.sh` schätzen (Fast-Mode-Blockierungsschutz
+   und `--max-cost` falls vorhanden berücksichtigen).
+4. `TaskCreate` für einen Entwickler-Worker pro unabhängiger Story (max. `--max-workers`), schlanker Kontext
+   (nur `@.claude/references/<project-tech>/CLAUDE.md`). Worker folgen TDD Rot/Grün/Refactoring
+   mit **Docker**-Testbefehlen.
+5. `TaskList` alle 30 Sekunden abfragen (nach 3 inaktiven Abfragen auf 60 Sekunden zurückgehen). `TaskList`
+   alle 5 Worker-Abschlüsse aktualisieren (Kontext-Kompaktierungs-Absicherung). Worker-Abschlussmeldungen
+   auf < 50 Tokens begrenzen.
+6. **DoD** pro Story validieren; `in-progress -> review` in `sprint-status.yaml`
+   über das Single-Writer-Pattern umstellen.
+
+**Bei DoD-Verfehlung einer Story → Auto-Korrektur-Schleife** (gleiche Wiederholungsanzahl): Worker mit den
+fehlgeschlagenen Prüfungen erneut beauftragen; nach `--max-fix-attempts` die Story als `blocked` markieren und fortfahren.
+
+### Phase 5 — Commit & PR (direkt)
+
+1. Die Implementierung mit **Conventional Commits** committen (soweit möglich atomar pro Story).
+2. Den Feature-Branch pushen.
+3. Einen **Entwurfs**-PR gegen `--base` über `gh pr create` öffnen (Titel + Beschreibung mit Sprint-Ziel,
+   gelieferten Stories und DoD-Status).
+
+### Phase 6 — CI-Überwachung (direkt + Auto-Korrektur-Schleife)
+
+1. CI überwachen: `gh pr checks --watch` (ca. 30s-Abfrage).
+2. **Bei Rot → Auto-Korrektur-Schleife** (bis zu `--max-fix-attempts`): Protokolle des fehlgeschlagenen Jobs lesen
+   (`gh run view --log-failed`), einen Korrektur-Unter-Agenten starten, committen + pushen, erneut überwachen.
+3. Nach `--max-fix-attempts` immer noch rot → **Abbruch** mit dem Bericht über fehlgeschlagene Prüfungen.
+
+### Phase 7 — Review (Unter-Agent)
+
+> „Lesen Sie `.claude/commands/workflow/review.md` und führen Sie es für Sprint **N** aus (verwendet
+> `git log` / `gh pr` zum Sammeln von Sprint-Daten). Erstellen Sie `sprint-review.md`. Geben Sie eine knappe Zusammenfassung zurück."
+
+### Phase 8 — Retro (Unter-Agent)
+
+> „Lesen Sie `.claude/commands/workflow/retro.md` und führen Sie es für Sprint **N** aus.
+> Erstellen Sie `sprint-retro.md` mit SMART-Maßnahmen. Geben Sie eine knappe Zusammenfassung zurück."
+
+### Phase 9 — Merge (direkt, gesperrt)
+
+- **Falls `--auto-merge`** UND CI ist grün UND DoD bestanden:
+  `gh pr ready` dann `gh pr merge --squash --delete-branch`.
+- **Andernfalls (Standard)**: **pausieren**. Die abschließende Zusammenfassung, den PR-Link, den CI-Status und den
+  DoD-Bericht präsentieren, dann **auf ein explizites menschliches GO warten** bevor gemergt wird.
+
+> **Merge-Fehler werden gemeldet, nie hartcodiert.** Falls der Merge durch Branch-Schutz blockiert wird,
+> diesen melden und `--admin` vorschlagen. Falls er blockiert wird, weil der PR `.github/workflows/` berührt
+> und dem Token der `workflow`-Scope fehlt, diesen melden und einen manuellen Squash-und-Push vorschlagen.
+> Keine repository-spezifischen Eigenheiten in diesen generischen Befehl einbauen.
+
+## Abschlussbericht
+
+```
+================================================================
+AUTO SPRINT — Zusammenfassung
+================================================================
+Sprint        : sprint-<N>-<slug>
+Branch        : feature/sprint-<N>-<slug>
+Basis         : <base>
+PR            : <url>  (CI: <grün|rot>)
+----------------------------------------------------------------
+Phase                  | Status  | Anmerkungen
+-----------------------|---------|---------------------------------------
+0 Normalisieren        | OK      | <N>/00<N>, Branch bereit
+1 Start                | OK      | sprint-goal.md
+2 Zerlegung            | OK      | N Task-Dateien
+3 Gate-Validierung     | OK      | Punktzahl X% (Y Korrekturversuche)
+4 Implementierung      | OK      | A/B Stories, C blockiert
+5 Commit + PR          | OK      | <url>
+6 CI-Überwachung       | OK      | grün (Z Korrekturversuche)
+7 Review               | OK      | sprint-review.md
+8 Retro                | OK      | sprint-retro.md
+9 Merge                | PAUSIERT| wartet auf menschliches GO (oder GEMERGT)
+================================================================
+```
+
+## Fehlerbehandlung
+
+| Situation | Verhalten |
+|-----------|-----------|
+| Sprint-Ordner / Status-Datei fehlt | Abbruch in Phase 0 |
+| Working Tree schmutzig | Abbruch in Phase 0 |
+| Gate-Validierung schlägt nach Wiederholungen fehl | Abbruch mit Korrekturbericht |
+| Story-DoD-Verfehlung nach Wiederholungen | Als `blocked` markieren, fortfahren, am Ende berichten |
+| CI rot nach Wiederholungen | Abbruch mit Bericht über fehlgeschlagene Prüfungen |
+| Merge blockiert (Schutz / Scope) | Fehler melden + vorgeschlagenes Flag, nicht erzwingen |
+| Agent Teams nicht verfügbar | Abbruch von Phase 4 mit Setup-Hinweis (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) |
+
+## Hinweise
+
+- **Keine verschachtelten Agent Teams**: Die Dirigenten-Rolle in Phase 4 selbst übernehmen.
+- **Auto-Merge ist opt-in** und absichtlich hinter einem Flag gesperrt.
+- **Docker ist obligatorisch** für Tests (Projekt-CLAUDE.md).
+- Die Isolation der Unter-Agenten ersetzt `/clear` — jeden Unter-Agenten-Bericht knapp halten.

--- a/Dev/i18n/en/Workflow/commands/auto-sprint.md
+++ b/Dev/i18n/en/Workflow/commands/auto-sprint.md
@@ -1,0 +1,198 @@
+---
+description: End-to-end sprint orchestrator (start -> decompose -> validate -> implement -> PR -> CI -> review -> retro -> merge)
+argument-hint: "<N> [--auto-merge] [--max-fix-attempts=2] [--max-workers=3] [--base=main] [--dry-run] [--overnight]"
+---
+
+# Auto Sprint — End-to-End Sprint Orchestrator
+
+You act as **Product Owner / Scrum Master** and drive a full sprint from kick-off to merge
+in a **single command**. Each ceremony runs inside an **isolated sub-agent**: the sub-agent's
+own context window replaces the manual `/clear` between steps, so your orchestrator context
+stays lean. The implementation phase is run by **you as conductor** (same logic as
+`/team:sprint`) to avoid nesting Agent Teams.
+
+This automates what was previously six manual commands with a `/clear` in between:
+
+```
+/workflow:start N -> /project:decompose-tasks 00N -> /gate:validate-sprint 00N
+-> /team:sprint "sprint-00N" -> /workflow:review N -> /workflow:retro N
+```
+
+…and adds: branch, commit, Pull Request, CI watch, and merge.
+
+## Arguments
+
+$ARGUMENTS
+
+- `<N>` : Sprint number (e.g. `5`). **Required.**
+- `--auto-merge` : Merge automatically once CI is green and DoD passes. **Default: OFF** — the
+  command pauses and waits for an explicit human GO before merging (honors "review obligatoire",
+  rule 09, and the Karpathy "no auto-merge without human review" principle).
+- `--max-fix-attempts=2` : Max auto-fix retries per failing gate before aborting (default: 2).
+- `--max-workers=3` : Max parallel dev workers in the implementation phase (default: 2, max: 3).
+- `--base=main` : Base branch for the PR (default: `main`).
+- `--dry-run` : Print the planned 9 phases and the resolved sprint context, then stop. **No writes.**
+- `--overnight` : Pass-through to the implementation phase (bounded, stops at 6am).
+
+## Prerequisites
+
+- Claude Code v2.1.32+ with Agent Teams support
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` set
+- `gh` CLI authenticated (PR create / checks / merge)
+- Docker available (all tests run via Docker — see project CLAUDE.md)
+- BMAD v6 project with `.bmad/sprint-status.yaml` present
+
+> If a prerequisite is missing, abort early with a clear, actionable message. Do not silently skip a phase.
+
+## Sprint number normalization
+
+The chained commands disagree on format. Normalize **once** in Phase 0 and pass the right form
+to each phase:
+
+| Phase | Expected form |
+|-------|---------------|
+| `start`, `review`, `retro` | bare `N` (e.g. `5`) |
+| `decompose-tasks` | zero-padded `00N` (e.g. `005`) |
+| `team:sprint` (implementation) | free-form sprint name resolved from the folder / status file |
+
+Resolve the sprint folder by globbing `project-management/sprints/sprint-{N}-*/` and read
+`.bmad/sprint-status.yaml` for the canonical sprint name and story list.
+
+## Process
+
+### Phase 0 — Normalize & branch (inline)
+
+1. Parse `<N>` and flags. Derive `N`, `00N`, sprint slug, and sprint name.
+2. Resolve `project-management/sprints/sprint-{N}-*/` and `.bmad/sprint-status.yaml`.
+   **Abort** if neither exists (nothing to orchestrate).
+3. Verify the working tree is clean and `--base` is up to date. **Abort** if dirty.
+4. Create / checkout the feature branch `feature/sprint-{N}-<slug>` from `--base`
+   (rule 09: `main` always deployable — never work directly on the base branch).
+5. If `--dry-run`: print the resolved context + the 9 planned phases and **stop here**.
+
+### Phase 1 — Start (sub-agent)
+
+Spawn one isolated sub-agent:
+
+> "Read `.claude/commands/workflow/start.md` and execute it for sprint **N**.
+> Create the sprint folder structure, `sprint-goal.md`, and the pre-sprint checklist.
+> Return a terse summary (< 50 tokens) and the list of files created."
+
+### Phase 2 — Decompose (sub-agent)
+
+> "Read `.claude/commands/project/decompose-tasks.md` and execute it for sprint **00N**.
+> Generate the per-US task files, `task-board.md`, and the dependency graph.
+> Return a terse summary and the files created."
+
+### Phase 3 — Validate gate (sub-agent + auto-fix loop)
+
+> "Read `.claude/commands/gate/validate-sprint.md` and run it for sprint **00N**.
+> Return PASS/FAIL, the score, and the list of failing criteria."
+
+**On FAIL → auto-fix loop** (up to `--max-fix-attempts`):
+- Spawn a remediation sub-agent that fixes the reported gaps (stories not `ready-for-dev`,
+  missing estimates, unresolved dependencies) directly in the sprint files.
+- Re-run the validation sub-agent.
+- If still failing after `--max-fix-attempts` → **abort** with the remediation report.
+
+### Phase 4 — Implement (you = conductor)
+
+Assume the **`/team:sprint` conductor role directly** (do **not** spawn a nested Agent Team):
+
+1. Read `.bmad/sprint-status.yaml`; filter stories at `ready-for-dev`.
+2. Analyze file-domain independence (flag `**/Shared/**`, `**/Common/**`, `**/Utils/**`,
+   `**/Helpers/**` overlaps → sequence in the same worker).
+3. Estimate cost via `Tools/AgentTeams/lib/cost-estimator.sh` (honor the Fast Mode blocking
+   guard and `--max-cost` if present).
+4. `TaskCreate` one dev worker per independent story (max `--max-workers`), lean context
+   (only `@.claude/references/<project-tech>/CLAUDE.md`). Workers follow TDD Red/Green/Refactor
+   with **Docker** test commands.
+5. Poll `TaskList` every 30s (back off to 60s after 3 idle polls). Refresh `TaskList`
+   every 5 worker completions (context-compaction mitigation). Cap worker completion messages
+   at < 50 tokens.
+6. Validate the **DoD** per story; transition `in-progress -> review` in `sprint-status.yaml`
+   via the single-writer pattern.
+
+**On DoD miss for a story → auto-fix loop** (same retry budget): re-task the worker with the
+failing checks; after `--max-fix-attempts`, mark the story `blocked` and continue.
+
+### Phase 5 — Commit & PR (inline)
+
+1. Commit the implementation with **Conventional Commits** (atomic per story where possible).
+2. Push the feature branch.
+3. Open a **draft** PR against `--base` via `gh pr create` (title + body summarizing the sprint
+   goal, stories delivered, and DoD status).
+
+### Phase 6 — CI watch (inline + auto-fix loop)
+
+1. Watch CI: `gh pr checks --watch` (poll ~30s).
+2. **On red → auto-fix loop** (up to `--max-fix-attempts`): read the failing job logs
+   (`gh run view --log-failed`), spawn a fix sub-agent, commit + push, re-watch.
+3. After `--max-fix-attempts` still red → **abort** with the failing-check report.
+
+### Phase 7 — Review (sub-agent)
+
+> "Read `.claude/commands/workflow/review.md` and execute it for sprint **N** (it uses
+> `git log` / `gh pr` to gather sprint data). Produce `sprint-review.md`. Return a terse summary."
+
+### Phase 8 — Retro (sub-agent)
+
+> "Read `.claude/commands/workflow/retro.md` and execute it for sprint **N**.
+> Produce `sprint-retro.md` with SMART action items. Return a terse summary."
+
+### Phase 9 — Merge (inline, gated)
+
+- **If `--auto-merge`** AND CI is green AND DoD passed:
+  `gh pr ready` then `gh pr merge --squash --delete-branch`.
+- **Otherwise (default)**: **pause**. Present the final summary, the PR link, CI status, and the
+  DoD report, then **wait for an explicit human GO** before merging.
+
+> **Merge errors are surfaced, never hardcoded.** If the merge is blocked by branch protection,
+> report it and suggest `--admin`. If it is blocked because the PR touches `.github/workflows/`
+> and the token lacks the `workflow` scope, report that and suggest a manual squash-and-push.
+> Do not bake repository-specific quirks into this generic command.
+
+## Final report
+
+```
+================================================================
+AUTO SPRINT — Summary
+================================================================
+Sprint        : sprint-<N>-<slug>
+Branch        : feature/sprint-<N>-<slug>
+Base          : <base>
+PR            : <url>  (CI: <green|red>)
+----------------------------------------------------------------
+Phase            | Status | Notes
+-----------------|--------|---------------------------------------
+0 Normalize      | OK     | <N>/00<N>, branch ready
+1 Start          | OK     | sprint-goal.md
+2 Decompose      | OK     | N task files
+3 Validate gate  | OK     | score X% (Y fix attempts)
+4 Implement      | OK     | A/B stories, C blocked
+5 Commit + PR    | OK     | <url>
+6 CI watch       | OK     | green (Z fix attempts)
+7 Review         | OK     | sprint-review.md
+8 Retro          | OK     | sprint-retro.md
+9 Merge          | PAUSED | awaiting human GO   (or MERGED)
+================================================================
+```
+
+## Error handling
+
+| Situation | Behavior |
+|-----------|----------|
+| Sprint folder / status file missing | Abort in Phase 0 |
+| Working tree dirty | Abort in Phase 0 |
+| Validate gate fails after retries | Abort with remediation report |
+| Story DoD miss after retries | Mark `blocked`, continue, report at the end |
+| CI red after retries | Abort with failing-check report |
+| Merge blocked (protection / scope) | Surface the error + suggested flag, do not force |
+| Agent Teams unavailable | Abort Phase 4 with a setup hint (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) |
+
+## Notes
+
+- **No nested Agent Teams**: you run the conductor role yourself in Phase 4.
+- **Auto-merge is opt-in** and intentionally gated behind a flag.
+- **Docker is mandatory** for tests (project CLAUDE.md).
+- Sub-agent isolation is what replaces `/clear` — keep each sub-agent report terse.

--- a/Dev/i18n/es/Workflow/commands/auto-sprint.md
+++ b/Dev/i18n/es/Workflow/commands/auto-sprint.md
@@ -1,0 +1,197 @@
+---
+description: Orquestador de sprint de extremo a extremo (inicio -> descomposición -> validación -> implementación -> PR -> CI -> revisión -> retro -> merge)
+argument-hint: "<N> [--auto-merge] [--max-fix-attempts=2] [--max-workers=3] [--base=main] [--dry-run] [--overnight]"
+---
+
+# Auto Sprint — Orquestador de Sprint de Extremo a Extremo
+
+Actúas como **Product Owner / Scrum Master** y conduces un sprint completo desde el arranque hasta el merge
+en un **único comando**. Cada ceremonia se ejecuta dentro de un **sub-agente aislado**: la ventana de
+contexto propia del sub-agente reemplaza el `/clear` manual entre pasos, de modo que el contexto del
+orquestador se mantiene liviano. La fase de implementación la ejecutas **tú como conductor** (misma lógica
+que `/team:sprint`) para evitar el anidamiento de Agent Teams.
+
+Esto automatiza lo que antes eran seis comandos manuales con un `/clear` de por medio:
+
+```
+/workflow:start N -> /project:decompose-tasks 00N -> /gate:validate-sprint 00N
+-> /team:sprint "sprint-00N" -> /workflow:review N -> /workflow:retro N
+```
+
+…y añade: rama, commit, Pull Request, vigilancia de CI y merge.
+
+## Argumentos
+
+$ARGUMENTS
+
+- `<N>` : Número de sprint (p. ej. `5`). **Obligatorio.**
+- `--auto-merge` : Realiza el merge automáticamente una vez que la CI esté en verde y el DoD se haya aprobado. **Por defecto: DESACTIVADO** — el
+  comando hace una pausa y espera una confirmación humana explícita antes de hacer el merge (respeta la "revisión obligatoria",
+  regla 09, y el principio Karpathy de "no auto-merge sin revisión humana").
+- `--max-fix-attempts=2` : Máximo de reintentos de corrección automática por gate fallido antes de abortar (por defecto: 2).
+- `--max-workers=3` : Máximo de workers de desarrollo en paralelo durante la fase de implementación (por defecto: 2, máximo: 3).
+- `--base=main` : Rama base para la PR (por defecto: `main`).
+- `--dry-run` : Muestra las 9 fases planificadas y el contexto de sprint resuelto, luego se detiene. **Sin escrituras.**
+- `--overnight` : Se pasa directamente a la fase de implementación (acotada, se detiene a las 6 a.m.).
+
+## Requisitos previos
+
+- Claude Code v2.1.32+ con soporte de Agent Teams
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` configurado
+- CLI `gh` autenticada (creación de PR / checks / merge)
+- Docker disponible (todos los tests se ejecutan vía Docker — ver CLAUDE.md del proyecto)
+- Proyecto BMAD v6 con `.bmad/sprint-status.yaml` presente
+
+> Si falta algún requisito previo, abortar de inmediato con un mensaje claro y accionable. No omitir ninguna fase en silencio.
+
+## Normalización del número de sprint
+
+Los comandos encadenados difieren en el formato esperado. Normalizar **una sola vez** en la Fase 0 y pasar
+la forma correcta a cada fase:
+
+| Fase | Formato esperado |
+|------|-----------------|
+| `start`, `review`, `retro` | `N` simple (p. ej. `5`) |
+| `decompose-tasks` | `00N` con ceros iniciales (p. ej. `005`) |
+| `team:sprint` (implementación) | nombre libre de sprint resuelto desde la carpeta / archivo de estado |
+
+Resolver la carpeta del sprint mediante un glob `project-management/sprints/sprint-{N}-*/` y leer
+`.bmad/sprint-status.yaml` para obtener el nombre canónico del sprint y la lista de historias.
+
+## Proceso
+
+### Fase 0 — Normalización y rama (en línea)
+
+1. Parsear `<N>` y los flags. Derivar `N`, `00N`, el slug del sprint y el nombre del sprint.
+2. Resolver `project-management/sprints/sprint-{N}-*/` y `.bmad/sprint-status.yaml`.
+   **Abortar** si ninguno existe (no hay nada que orquestar).
+3. Verificar que el árbol de trabajo esté limpio y que `--base` esté actualizado. **Abortar** si está sucio.
+4. Crear / hacer checkout de la rama de feature `feature/sprint-{N}-<slug>` desde `--base`
+   (regla 09: `main` siempre desplegable — nunca trabajar directamente sobre la rama base).
+5. Si `--dry-run`: mostrar el contexto resuelto + las 9 fases planificadas y **detenerse aquí**.
+
+### Fase 1 — Inicio (sub-agente)
+
+Lanzar un sub-agente aislado:
+
+> "Lee `.claude/commands/workflow/start.md` y ejecútalo para el sprint **N**.
+> Crea la estructura de carpetas del sprint, `sprint-goal.md` y el checklist previo al sprint.
+> Devuelve un resumen breve (< 50 tokens) y la lista de archivos creados."
+
+### Fase 2 — Descomposición (sub-agente)
+
+> "Lee `.claude/commands/project/decompose-tasks.md` y ejecútalo para el sprint **00N**.
+> Genera los archivos de tareas por historia de usuario, `task-board.md` y el grafo de dependencias.
+> Devuelve un resumen breve y los archivos creados."
+
+### Fase 3 — Validación de gate (sub-agente + bucle de corrección automática)
+
+> "Lee `.claude/commands/gate/validate-sprint.md` y ejecútalo para el sprint **00N**.
+> Devuelve PASS/FAIL, la puntuación y la lista de criterios fallidos."
+
+**En caso de FAIL → bucle de corrección automática** (hasta `--max-fix-attempts`):
+- Lanzar un sub-agente de remediación que corrija los gaps reportados (historias no en `ready-for-dev`,
+  estimaciones faltantes, dependencias no resueltas) directamente en los archivos del sprint.
+- Volver a ejecutar el sub-agente de validación.
+- Si sigue fallando tras `--max-fix-attempts` → **abortar** con el informe de remediación.
+
+### Fase 4 — Implementación (tú = conductor)
+
+Asumir directamente el **rol de conductor de `/team:sprint`** (**no** lanzar un Agent Team anidado):
+
+1. Leer `.bmad/sprint-status.yaml`; filtrar historias en estado `ready-for-dev`.
+2. Analizar la independencia de dominio de archivos (marcar solapamientos de `**/Shared/**`, `**/Common/**`, `**/Utils/**`,
+   `**/Helpers/**` → secuenciar en el mismo worker).
+3. Estimar el coste mediante `Tools/AgentTeams/lib/cost-estimator.sh` (respetar el bloqueo de modo Fast
+   y `--max-cost` si está presente).
+4. `TaskCreate` con un worker de desarrollo por historia independiente (máximo `--max-workers`), contexto mínimo
+   (solo `@.claude/references/<project-tech>/CLAUDE.md`). Los workers siguen el ciclo TDD Rojo/Verde/Refactorizar
+   con comandos de test vía **Docker**.
+5. Sondear `TaskList` cada 30s (ralentizar a 60s tras 3 sondeos sin actividad). Actualizar `TaskList`
+   cada 5 completaciones de workers (mitigación de compactación de contexto). Limitar los mensajes de
+   completación de workers a < 50 tokens.
+6. Validar el **DoD** por historia; hacer la transición `in-progress -> review` en `sprint-status.yaml`
+   mediante el patrón de escritor único.
+
+**En caso de fallo de DoD en una historia → bucle de corrección automática** (mismo presupuesto de reintentos): re-asignar la historia al worker con los checks fallidos; tras `--max-fix-attempts`, marcar la historia como `blocked` y continuar.
+
+### Fase 5 — Commit y PR (en línea)
+
+1. Hacer commit de la implementación con **Conventional Commits** (atómico por historia cuando sea posible).
+2. Hacer push de la rama de feature.
+3. Abrir una PR en modo **borrador** contra `--base` mediante `gh pr create` (título + cuerpo que resuma el
+   objetivo del sprint, las historias entregadas y el estado del DoD).
+
+### Fase 6 — Vigilancia de CI (en línea + bucle de corrección automática)
+
+1. Vigilar la CI: `gh pr checks --watch` (sondeo cada ~30s).
+2. **En rojo → bucle de corrección automática** (hasta `--max-fix-attempts`): leer los logs del job fallido
+   (`gh run view --log-failed`), lanzar un sub-agente de corrección, hacer commit + push, y volver a vigilar.
+3. Tras `--max-fix-attempts` todavía en rojo → **abortar** con el informe del check fallido.
+
+### Fase 7 — Revisión (sub-agente)
+
+> "Lee `.claude/commands/workflow/review.md` y ejecútalo para el sprint **N** (usa
+> `git log` / `gh pr` para recopilar los datos del sprint). Produce `sprint-review.md`. Devuelve un resumen breve."
+
+### Fase 8 — Retrospectiva (sub-agente)
+
+> "Lee `.claude/commands/workflow/retro.md` y ejecútalo para el sprint **N**.
+> Produce `sprint-retro.md` con puntos de acción SMART. Devuelve un resumen breve."
+
+### Fase 9 — Merge (en línea, con gate)
+
+- **Si `--auto-merge`** Y la CI está en verde Y el DoD ha pasado:
+  `gh pr ready` seguido de `gh pr merge --squash --delete-branch`.
+- **En caso contrario (por defecto)**: **pausa**. Presentar el resumen final, el enlace a la PR, el estado de la CI y el
+  informe del DoD, luego **esperar una confirmación humana explícita** antes de hacer el merge.
+
+> **Los errores de merge se muestran, nunca se ignoran.** Si el merge está bloqueado por protección de rama,
+> informar de ello y sugerir `--admin`. Si está bloqueado porque la PR toca `.github/workflows/`
+> y el token no tiene el scope `workflow`, informar de ello y sugerir un squash-and-push manual.
+> No incorporar quirks específicos del repositorio en este comando genérico.
+
+## Informe final
+
+```
+================================================================
+AUTO SPRINT — Resumen
+================================================================
+Sprint        : sprint-<N>-<slug>
+Rama          : feature/sprint-<N>-<slug>
+Base          : <base>
+PR            : <url>  (CI: <verde|roja>)
+----------------------------------------------------------------
+Fase                  | Estado  | Notas
+----------------------|---------|---------------------------------------
+0 Normalización       | OK      | <N>/00<N>, rama lista
+1 Inicio              | OK      | sprint-goal.md
+2 Descomposición      | OK      | N archivos de tareas
+3 Validación de gate  | OK      | puntuación X% (Y intentos de corrección)
+4 Implementación      | OK      | A/B historias, C bloqueadas
+5 Commit + PR         | OK      | <url>
+6 Vigilancia CI       | OK      | verde (Z intentos de corrección)
+7 Revisión            | OK      | sprint-review.md
+8 Retrospectiva       | OK      | sprint-retro.md
+9 Merge               | EN PAUSA| esperando confirmación humana   (o MERGEADO)
+================================================================
+```
+
+## Manejo de errores
+
+| Situación | Comportamiento |
+|-----------|---------------|
+| Carpeta de sprint / archivo de estado ausente | Abortar en la Fase 0 |
+| Árbol de trabajo sucio | Abortar en la Fase 0 |
+| Gate de validación falla tras reintentos | Abortar con informe de remediación |
+| Fallo de DoD en historia tras reintentos | Marcar `blocked`, continuar, informar al final |
+| CI en rojo tras reintentos | Abortar con informe del check fallido |
+| Merge bloqueado (protección / scope) | Mostrar el error + flag sugerido, no forzar |
+| Agent Teams no disponible | Abortar la Fase 4 con una pista de configuración (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) |
+
+## Notas
+
+- **Sin Agent Teams anidados**: tú ejecutas el rol de conductor directamente en la Fase 4.
+- **El auto-merge es opt-in** e intencionalmente requiere pasar un flag explícito.
+- **Docker es obligatorio** para los tests (CLAUDE.md del proyecto).
+- El aislamiento de sub-agentes es lo que reemplaza el `/clear` — mantener cada informe de sub-agente breve.

--- a/Dev/i18n/fr/Workflow/commands/auto-sprint.md
+++ b/Dev/i18n/fr/Workflow/commands/auto-sprint.md
@@ -1,0 +1,197 @@
+---
+description: Orchestrateur de sprint de bout en bout (démarrage -> décomposition -> validation -> implémentation -> PR -> CI -> revue -> rétro -> merge)
+argument-hint: "<N> [--auto-merge] [--max-fix-attempts=2] [--max-workers=3] [--base=main] [--dry-run] [--overnight]"
+---
+
+# Auto Sprint — Orchestrateur de Sprint de Bout en Bout
+
+Tu joues le rôle de **Product Owner / Scrum Master** et tu pilotes un sprint complet, du lancement au merge,
+en **une seule commande**. Chaque cérémonie s'exécute dans un **sous-agent isolé** : la fenêtre de contexte
+propre au sous-agent remplace le `/clear` manuel entre les étapes, ce qui permet à ton contexte d'orchestrateur
+de rester léger. La phase d'implémentation est conduite **par toi en tant que chef d'orchestre** (même logique
+que `/team:sprint`) afin d'éviter l'imbrication d'Agent Teams.
+
+Cette commande automatise ce qui nécessitait auparavant six commandes manuelles avec un `/clear` entre chaque :
+
+```
+/workflow:start N -> /project:decompose-tasks 00N -> /gate:validate-sprint 00N
+-> /team:sprint "sprint-00N" -> /workflow:review N -> /workflow:retro N
+```
+
+…et ajoute : branche, commit, Pull Request, surveillance CI et merge.
+
+## Arguments
+
+$ARGUMENTS
+
+- `<N>` : Numéro du sprint (ex. `5`). **Obligatoire.**
+- `--auto-merge` : Merge automatiquement dès que la CI est verte et que la DoD est validée. **Défaut : DÉSACTIVÉ** — la
+  commande se met en pause et attend un GO humain explicite avant de merger (respecte la règle de « revue obligatoire »,
+  règle 09, et le principe Karpathy « pas d'auto-merge sans revue humaine »).
+- `--max-fix-attempts=2` : Nombre maximal de tentatives de correction automatique par gate échoué avant abandon (défaut : 2).
+- `--max-workers=3` : Nombre maximal de workers dev parallèles pendant la phase d'implémentation (défaut : 2, max : 3).
+- `--base=main` : Branche de base pour la PR (défaut : `main`).
+- `--dry-run` : Affiche les 9 phases planifiées et le contexte de sprint résolu, puis s'arrête. **Aucune écriture.**
+- `--overnight` : Transmis à la phase d'implémentation (borné, s'arrête à 6h).
+
+## Prérequis
+
+- Claude Code v2.1.32+ avec le support Agent Teams
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` défini
+- CLI `gh` authentifié (création de PR / checks / merge)
+- Docker disponible (tous les tests s'exécutent via Docker — voir le CLAUDE.md du projet)
+- Projet BMAD v6 avec `.bmad/sprint-status.yaml` présent
+
+> Si un prérequis est manquant, abandonner immédiatement avec un message clair et actionnable. Ne jamais ignorer silencieusement une phase.
+
+## Normalisation du numéro de sprint
+
+Les commandes chaînées ne s'accordent pas sur le format. Normaliser **une seule fois** en Phase 0 et transmettre
+la bonne forme à chaque phase :
+
+| Phase | Forme attendue |
+|-------|----------------|
+| `start`, `review`, `retro` | `N` brut (ex. `5`) |
+| `decompose-tasks` | `00N` avec zéros (ex. `005`) |
+| `team:sprint` (implémentation) | nom libre du sprint résolu depuis le dossier / fichier de statut |
+
+Résoudre le dossier du sprint via glob `project-management/sprints/sprint-{N}-*/` et lire
+`.bmad/sprint-status.yaml` pour le nom canonique du sprint et la liste de stories.
+
+## Processus
+
+### Phase 0 — Normalisation & branche (inline)
+
+1. Parser `<N>` et les drapeaux. Dériver `N`, `00N`, le slug et le nom du sprint.
+2. Résoudre `project-management/sprints/sprint-{N}-*/` et `.bmad/sprint-status.yaml`.
+   **Abandonner** si aucun des deux n'existe (rien à orchestrer).
+3. Vérifier que l'arbre de travail est propre et que `--base` est à jour. **Abandonner** si sale.
+4. Créer / basculer sur la branche feature `feature/sprint-{N}-<slug>` depuis `--base`
+   (règle 09 : `main` toujours déployable — ne jamais travailler directement sur la branche de base).
+5. Si `--dry-run` : afficher le contexte résolu + les 9 phases planifiées et **s'arrêter ici**.
+
+### Phase 1 — Démarrage (sous-agent)
+
+Instancier un sous-agent isolé :
+
+> « Lis `.claude/commands/workflow/start.md` et exécute-le pour le sprint **N**.
+> Crée la structure de dossier du sprint, `sprint-goal.md`, et la checklist pré-sprint.
+> Retourne un résumé concis (< 50 tokens) et la liste des fichiers créés. »
+
+### Phase 2 — Décomposition (sous-agent)
+
+> « Lis `.claude/commands/project/decompose-tasks.md` et exécute-le pour le sprint **00N**.
+> Génère les fichiers de tâches par US, `task-board.md`, et le graphe de dépendances.
+> Retourne un résumé concis et les fichiers créés. »
+
+### Phase 3 — Validation du gate (sous-agent + boucle de correction automatique)
+
+> « Lis `.claude/commands/gate/validate-sprint.md` et exécute-le pour le sprint **00N**.
+> Retourne PASS/FAIL, le score et la liste des critères échoués. »
+
+**En cas d'ÉCHEC → boucle de correction automatique** (jusqu'à `--max-fix-attempts`) :
+- Instancier un sous-agent de remédiation qui corrige les écarts signalés (stories non `ready-for-dev`,
+  estimations manquantes, dépendances non résolues) directement dans les fichiers du sprint.
+- Relancer le sous-agent de validation.
+- Si toujours en échec après `--max-fix-attempts` → **abandonner** avec le rapport de remédiation.
+
+### Phase 4 — Implémentation (tu = chef d'orchestre)
+
+Prendre **directement le rôle de conducteur `/team:sprint`** (ne **pas** instancier un Agent Team imbriqué) :
+
+1. Lire `.bmad/sprint-status.yaml` ; filtrer les stories à `ready-for-dev`.
+2. Analyser l'indépendance des domaines de fichiers (signaler les chevauchements `**/Shared/**`, `**/Common/**`, `**/Utils/**`,
+   `**/Helpers/**` → séquencer dans le même worker).
+3. Estimer le coût via `Tools/AgentTeams/lib/cost-estimator.sh` (respecter le garde Fast Mode bloquant
+   et `--max-cost` si présent).
+4. `TaskCreate` un worker dev par story indépendante (max `--max-workers`), contexte réduit
+   (uniquement `@.claude/references/<project-tech>/CLAUDE.md`). Les workers suivent le cycle TDD Rouge/Vert/Refactor
+   avec des commandes de test **Docker**.
+5. Interroger `TaskList` toutes les 30s (reculer à 60s après 3 sondages sans activité). Rafraîchir `TaskList`
+   toutes les 5 complétion de worker (atténuation de la compaction de contexte). Limiter les messages de
+   complétion de worker à < 50 tokens.
+6. Valider la **DoD** par story ; faire passer l'état `in-progress -> review` dans `sprint-status.yaml`
+   via le pattern single-writer.
+
+**En cas de non-respect de la DoD pour une story → boucle de correction automatique** (même budget de tentatives) : reconfier la story au worker avec les vérifications en échec ; après `--max-fix-attempts`, marquer la story `blocked` et continuer.
+
+### Phase 5 — Commit & PR (inline)
+
+1. Commiter l'implémentation avec les **Conventional Commits** (atomique par story dans la mesure du possible).
+2. Pousser la branche feature.
+3. Ouvrir une PR en **brouillon** contre `--base` via `gh pr create` (titre + corps résumant l'objectif
+   du sprint, les stories livrées et l'état de la DoD).
+
+### Phase 6 — Surveillance CI (inline + boucle de correction automatique)
+
+1. Surveiller la CI : `gh pr checks --watch` (sondage ~30s).
+2. **En cas d'échec → boucle de correction automatique** (jusqu'à `--max-fix-attempts`) : lire les logs du job échoué
+   (`gh run view --log-failed`), instancier un sous-agent de correction, commiter + pousser, relancer la surveillance.
+3. Après `--max-fix-attempts` toujours en échec → **abandonner** avec le rapport de vérifications échouées.
+
+### Phase 7 — Revue (sous-agent)
+
+> « Lis `.claude/commands/workflow/review.md` et exécute-le pour le sprint **N** (il utilise
+> `git log` / `gh pr` pour collecter les données du sprint). Produis `sprint-review.md`. Retourne un résumé concis. »
+
+### Phase 8 — Rétrospective (sous-agent)
+
+> « Lis `.claude/commands/workflow/retro.md` et exécute-le pour le sprint **N**.
+> Produis `sprint-retro.md` avec des actions SMART. Retourne un résumé concis. »
+
+### Phase 9 — Merge (inline, gardé)
+
+- **Si `--auto-merge`** ET CI verte ET DoD validée :
+  `gh pr ready` puis `gh pr merge --squash --delete-branch`.
+- **Sinon (défaut)** : **se mettre en pause**. Présenter le résumé final, le lien PR, l'état CI et le
+  rapport DoD, puis **attendre un GO humain explicite** avant de merger.
+
+> **Les erreurs de merge sont remontées, jamais codées en dur.** Si le merge est bloqué par la protection de branche,
+> le signaler et suggérer `--admin`. S'il est bloqué parce que la PR touche `.github/workflows/`
+> et que le token n'a pas le scope `workflow`, le signaler et suggérer un squash-and-push manuel.
+> Ne pas intégrer les particularités d'un dépôt spécifique dans cette commande générique.
+
+## Rapport final
+
+```
+================================================================
+AUTO SPRINT — Résumé
+================================================================
+Sprint        : sprint-<N>-<slug>
+Branche       : feature/sprint-<N>-<slug>
+Base          : <base>
+PR            : <url>  (CI: <vert|rouge>)
+----------------------------------------------------------------
+Phase              | Statut | Notes
+-------------------|--------|---------------------------------------
+0 Normalisation    | OK     | <N>/00<N>, branche prête
+1 Démarrage        | OK     | sprint-goal.md
+2 Décomposition    | OK     | N fichiers de tâches
+3 Validation gate  | OK     | score X% (Y tentatives de correction)
+4 Implémentation   | OK     | A/B stories, C bloquées
+5 Commit + PR      | OK     | <url>
+6 Surveillance CI  | OK     | vert (Z tentatives de correction)
+7 Revue            | OK     | sprint-review.md
+8 Rétro            | OK     | sprint-retro.md
+9 Merge            | EN ATTENTE | attente GO humain   (ou MERGÉ)
+================================================================
+```
+
+## Gestion des erreurs
+
+| Situation | Comportement |
+|-----------|--------------|
+| Dossier sprint / fichier de statut absent | Abandon en Phase 0 |
+| Arbre de travail sale | Abandon en Phase 0 |
+| Gate de validation échoué après tentatives | Abandon avec rapport de remédiation |
+| DoD story non respectée après tentatives | Marquer `blocked`, continuer, signaler en fin |
+| CI en échec après tentatives | Abandon avec rapport de vérifications échouées |
+| Merge bloqué (protection / scope) | Remonter l'erreur + drapeau suggéré, ne pas forcer |
+| Agent Teams indisponible | Abandon Phase 4 avec indication de configuration (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) |
+
+## Notes
+
+- **Pas d'Agent Teams imbriqués** : tu exécutes toi-même le rôle de conducteur en Phase 4.
+- **L'auto-merge est opt-in** et intentionnellement conditionné à un drapeau.
+- **Docker est obligatoire** pour les tests (CLAUDE.md du projet).
+- L'isolation des sous-agents remplace `/clear` — garder chaque rapport de sous-agent concis.

--- a/Dev/i18n/pt/Workflow/commands/auto-sprint.md
+++ b/Dev/i18n/pt/Workflow/commands/auto-sprint.md
@@ -1,0 +1,198 @@
+---
+description: Orquestrador de sprint completo de ponta a ponta (início -> decomposição -> validação -> implementação -> PR -> CI -> revisão -> retro -> merge)
+argument-hint: "<N> [--auto-merge] [--max-fix-attempts=2] [--max-workers=3] [--base=main] [--dry-run] [--overnight]"
+---
+
+# Auto Sprint — Orquestrador de Sprint de Ponta a Ponta
+
+Você age como **Product Owner / Scrum Master** e conduz um sprint completo desde o início até o merge
+em um **único comando**. Cada cerimônia é executada dentro de um **sub-agente isolado**: a própria
+janela de contexto do sub-agente substitui o `/clear` manual entre as etapas, mantendo o contexto
+do orquestrador enxuto. A fase de implementação é executada por **você como maestro** (mesma lógica
+de `/team:sprint`) para evitar o aninhamento de Agent Teams.
+
+Isso automatiza o que anteriormente eram seis comandos manuais com `/clear` entre eles:
+
+```
+/workflow:start N -> /project:decompose-tasks 00N -> /gate:validate-sprint 00N
+-> /team:sprint "sprint-00N" -> /workflow:review N -> /workflow:retro N
+```
+
+…e adiciona: branch, commit, Pull Request, monitoramento de CI e merge.
+
+## Argumentos
+
+$ARGUMENTS
+
+- `<N>` : Número do sprint (ex: `5`). **Obrigatório.**
+- `--auto-merge` : Faz o merge automaticamente quando a CI estiver verde e o DoD aprovado. **Padrão: DESATIVADO** — o
+  comando pausa e aguarda um GO humano explícito antes de fazer o merge (respeita "revisão obrigatória",
+  regra 09, e o princípio Karpathy "sem auto-merge sem revisão humana").
+- `--max-fix-attempts=2` : Máximo de tentativas de correção automática por gate com falha antes de abortar (padrão: 2).
+- `--max-workers=3` : Máximo de workers de desenvolvimento em paralelo na fase de implementação (padrão: 2, máximo: 3).
+- `--base=main` : Branch base para o PR (padrão: `main`).
+- `--dry-run` : Exibe as 9 fases planejadas e o contexto do sprint resolvido, depois para. **Nenhuma escrita.**
+- `--overnight` : Repassado para a fase de implementação (limitado, para às 6h).
+
+## Pré-requisitos
+
+- Claude Code v2.1.32+ com suporte a Agent Teams
+- `CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1` definido
+- CLI `gh` autenticado (criação de PR / verificações / merge)
+- Docker disponível (todos os testes são executados via Docker — veja o CLAUDE.md do projeto)
+- Projeto BMAD v6 com `.bmad/sprint-status.yaml` presente
+
+> Se um pré-requisito estiver ausente, aborte imediatamente com uma mensagem clara e acionável. Não pule uma fase silenciosamente.
+
+## Normalização do número do sprint
+
+Os comandos encadeados divergem no formato. Normalize **uma única vez** na Fase 0 e passe a forma
+correta para cada fase:
+
+| Fase | Formato esperado |
+|------|-----------------|
+| `start`, `review`, `retro` | `N` simples (ex: `5`) |
+| `decompose-tasks` | `00N` com zeros à esquerda (ex: `005`) |
+| `team:sprint` (implementação) | nome de sprint em formato livre resolvido a partir da pasta / arquivo de status |
+
+Resolva a pasta do sprint fazendo glob de `project-management/sprints/sprint-{N}-*/` e leia
+`.bmad/sprint-status.yaml` para obter o nome canônico do sprint e a lista de histórias.
+
+## Processo
+
+### Fase 0 — Normalizar e criar branch (inline)
+
+1. Analise `<N>` e as flags. Derive `N`, `00N`, o slug e o nome do sprint.
+2. Resolva `project-management/sprints/sprint-{N}-*/` e `.bmad/sprint-status.yaml`.
+   **Aborte** se nenhum existir (nada a orquestrar).
+3. Verifique se a árvore de trabalho está limpa e se `--base` está atualizado. **Aborte** se estiver suja.
+4. Crie / faça checkout do branch de feature `feature/sprint-{N}-<slug>` a partir de `--base`
+   (regra 09: `main` sempre implantável — nunca trabalhe diretamente no branch base).
+5. Se `--dry-run`: exiba o contexto resolvido + as 9 fases planejadas e **pare aqui**.
+
+### Fase 1 — Início (sub-agente)
+
+Inicie um sub-agente isolado:
+
+> "Leia `.claude/commands/workflow/start.md` e execute para o sprint **N**.
+> Crie a estrutura de pastas do sprint, `sprint-goal.md` e o checklist pré-sprint.
+> Retorne um resumo conciso (< 50 tokens) e a lista de arquivos criados."
+
+### Fase 2 — Decomposição (sub-agente)
+
+> "Leia `.claude/commands/project/decompose-tasks.md` e execute para o sprint **00N**.
+> Gere os arquivos de tarefas por US, `task-board.md` e o grafo de dependências.
+> Retorne um resumo conciso e os arquivos criados."
+
+### Fase 3 — Validação do gate (sub-agente + loop de correção automática)
+
+> "Leia `.claude/commands/gate/validate-sprint.md` e execute para o sprint **00N**.
+> Retorne PASS/FAIL, a pontuação e a lista de critérios com falha."
+
+**Em caso de FAIL → loop de correção automática** (até `--max-fix-attempts`):
+- Inicie um sub-agente de remediação que corrige as lacunas reportadas (histórias sem `ready-for-dev`,
+  estimativas ausentes, dependências não resolvidas) diretamente nos arquivos do sprint.
+- Execute novamente o sub-agente de validação.
+- Se ainda falhar após `--max-fix-attempts` → **aborte** com o relatório de remediação.
+
+### Fase 4 — Implementação (você = maestro)
+
+Assuma diretamente o **papel de maestro de `/team:sprint`** (**não** inicie um Agent Team aninhado):
+
+1. Leia `.bmad/sprint-status.yaml`; filtre histórias em `ready-for-dev`.
+2. Analise a independência por domínio de arquivo (sinalize sobreposições de `**/Shared/**`, `**/Common/**`, `**/Utils/**`,
+   `**/Helpers/**` → sequencie no mesmo worker).
+3. Estime o custo via `Tools/AgentTeams/lib/cost-estimator.sh` (respeite o bloqueio de Fast Mode
+   e `--max-cost` se presente).
+4. `TaskCreate` um worker de desenvolvimento por história independente (máximo `--max-workers`), contexto enxuto
+   (apenas `@.claude/references/<project-tech>/CLAUDE.md`). Os workers seguem TDD Red/Green/Refactor
+   com comandos de teste via **Docker**.
+5. Consulte `TaskList` a cada 30s (recue para 60s após 3 polls ociosos). Atualize `TaskList`
+   a cada 5 conclusões de worker (mitigação de compactação de contexto). Limite as mensagens de conclusão
+   de worker a < 50 tokens.
+6. Valide o **DoD** por história; faça a transição `in-progress -> review` em `sprint-status.yaml`
+   via o padrão de gravação única.
+
+**Em caso de falha no DoD de uma história → loop de correção automática** (mesmo orçamento de tentativas): re-atribua o worker com as
+verificações que falharam; após `--max-fix-attempts`, marque a história como `blocked` e continue.
+
+### Fase 5 — Commit e PR (inline)
+
+1. Faça o commit da implementação com **Conventional Commits** (atômico por história quando possível).
+2. Faça push do branch de feature.
+3. Abra um PR **rascunho** contra `--base` via `gh pr create` (título + corpo resumindo o objetivo do sprint,
+   as histórias entregues e o status do DoD).
+
+### Fase 6 — Monitoramento de CI (inline + loop de correção automática)
+
+1. Monitore a CI: `gh pr checks --watch` (poll a cada ~30s).
+2. **Em caso de falha → loop de correção automática** (até `--max-fix-attempts`): leia os logs do job com falha
+   (`gh run view --log-failed`), inicie um sub-agente de correção, faça commit + push, monitore novamente.
+3. Após `--max-fix-attempts` ainda com falha → **aborte** com o relatório de verificações com falha.
+
+### Fase 7 — Revisão (sub-agente)
+
+> "Leia `.claude/commands/workflow/review.md` e execute para o sprint **N** (ele usa
+> `git log` / `gh pr` para coletar os dados do sprint). Produza `sprint-review.md`. Retorne um resumo conciso."
+
+### Fase 8 — Retrospectiva (sub-agente)
+
+> "Leia `.claude/commands/workflow/retro.md` e execute para o sprint **N**.
+> Produza `sprint-retro.md` com itens de ação SMART. Retorne um resumo conciso."
+
+### Fase 9 — Merge (inline, com gate)
+
+- **Se `--auto-merge`** E a CI estiver verde E o DoD aprovado:
+  `gh pr ready` depois `gh pr merge --squash --delete-branch`.
+- **Caso contrário (padrão)**: **pause**. Apresente o resumo final, o link do PR, o status da CI e o
+  relatório do DoD, depois **aguarde um GO humano explícito** antes de fazer o merge.
+
+> **Erros de merge são expostos, nunca ignorados.** Se o merge for bloqueado por proteção de branch,
+> informe e sugira `--admin`. Se for bloqueado porque o PR toca `.github/workflows/`
+> e o token não tem o escopo `workflow`, informe e sugira um squash-and-push manual.
+> Não incorpore peculiaridades específicas do repositório neste comando genérico.
+
+## Relatório final
+
+```
+================================================================
+AUTO SPRINT — Resumo
+================================================================
+Sprint        : sprint-<N>-<slug>
+Branch        : feature/sprint-<N>-<slug>
+Base          : <base>
+PR            : <url>  (CI: <verde|vermelha>)
+----------------------------------------------------------------
+Fase             | Status | Notas
+-----------------|--------|---------------------------------------
+0 Normalizar     | OK     | <N>/00<N>, branch pronto
+1 Início         | OK     | sprint-goal.md
+2 Decomposição   | OK     | N arquivos de tarefas
+3 Validar gate   | OK     | pontuação X% (Y tentativas de correção)
+4 Implementação  | OK     | A/B histórias, C bloqueadas
+5 Commit + PR    | OK     | <url>
+6 Monitor CI     | OK     | verde (Z tentativas de correção)
+7 Revisão        | OK     | sprint-review.md
+8 Retrospectiva  | OK     | sprint-retro.md
+9 Merge          | PAUSADO| aguardando GO humano   (ou MERGED)
+================================================================
+```
+
+## Tratamento de erros
+
+| Situação | Comportamento |
+|----------|---------------|
+| Pasta do sprint / arquivo de status ausente | Abortar na Fase 0 |
+| Árvore de trabalho suja | Abortar na Fase 0 |
+| Gate de validação falha após tentativas | Abortar com relatório de remediação |
+| Falha no DoD da história após tentativas | Marcar como `blocked`, continuar, reportar ao final |
+| CI vermelha após tentativas | Abortar com relatório de verificações com falha |
+| Merge bloqueado (proteção / escopo) | Expor o erro + flag sugerida, não forçar |
+| Agent Teams indisponível | Abortar Fase 4 com dica de configuração (`CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS=1`) |
+
+## Notas
+
+- **Sem Agent Teams aninhados**: você executa o papel de maestro diretamente na Fase 4.
+- **Auto-merge é opt-in** e intencionalmente protegido por uma flag.
+- **Docker é obrigatório** para os testes (CLAUDE.md do projeto).
+- O isolamento do sub-agente é o que substitui o `/clear` — mantenha cada relatório de sub-agente conciso.

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Plus **11 stack-specific reviewers** (@symfony-reviewer, @react-reviewer, @pytho
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTheBeardedBearSAS%2Fclaude-craft%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/TheBeardedBearSAS/claude-craft/main)
 
-A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **31 specialized agents (+39 infra agents on-demand), 125 commands across 15 namespaces (219 total), 55 skills**, all token-optimized via `context: fork` and sub-agent model routing.
+A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **31 specialized agents (+39 infra agents on-demand), 126 commands across 15 namespaces (220 total), 55 skills**, all token-optimized via `context: fork` and sub-agent model routing.
 
 ## What's New in v8.17.2
 
@@ -96,7 +96,7 @@ A comprehensive framework for AI-assisted development with [Claude Code](https:/
 - **MIT-only strict (v8.8.0)** -- Claude Craft est 100 % open-source MIT, aucune licence commerciale ou enterprise. Stratégie open-core abandonnée.
 - **Parité i18n stricte (v8.8.2)** -- la CI bloque désormais si un fichier traduit est à < 80 % de la taille de l'anglais. Dette i18n résorbée (gap 101 → 0).
 - **Branding the-bearded-bear.com (v8.10.1)** -- migration complète des domaines vers `the-bearded-bear.com`, normalisation de l'organisation GitHub.
-- **125 commandes sur 15 namespaces** (219 total avec infra/projet) -- namespace `/paperclip:*` (8 commandes) ajouté, 55 skills disponibles.
+- **126 commandes sur 15 namespaces** (220 total avec infra/projet) -- namespace `/paperclip:*` (8 commandes) ajouté, 55 skills disponibles.
 - **Claude Code 2.1.168** -- version recommandée (Opus 4.8, Dynamic Workflows, `effort: ultracode`).
 
 > ← Versions antérieures (v8.0 → v8.7) : voir le [CHANGELOG](CHANGELOG.md) et [.claude/COMPATIBILITY.md](.claude/COMPATIBILITY.md).
@@ -214,7 +214,7 @@ These are the commands you'll use most:
 | `/common:ralph-run "task"` | Run Claude in continuous loop until task is done |
 | `/qa:recette` | Automated acceptance testing via Chrome |
 
-See [CLI Reference](docs/CLI-REFERENCE.md) for all 125 commands across 15 core namespaces (219 total including infra and project management).
+See [CLI Reference](docs/CLI-REFERENCE.md) for all 126 commands across 15 core namespaces (220 total including infra and project management).
 
 ## Installation
 
@@ -296,7 +296,7 @@ Context usage is optimized: ~3,500 tokens always loaded vs ~70,000 if everything
 | [Installation](docs/INSTALLATION.md) | All installation methods |
 | [Configuration](docs/CONFIGURATION.md) | Project configuration |
 | [CLI Reference](docs/CLI-REFERENCE.md) | Full CLI documentation |
-| [Commands](docs/COMMANDS.md) | All 125 commands |
+| [Commands](docs/COMMANDS.md) | All 126 commands |
 | [Agents](docs/AGENTS.md) | All 31 default agents (+ 39 infra on-demand) |
 | [Skills](docs/SKILLS.md) | Best practices reference |
 | [Technologies](docs/TECHNOLOGIES.md) | Stack-specific guides |

--- a/docs/COMMANDS-FULL-REFERENCE.md
+++ b/docs/COMMANDS-FULL-REFERENCE.md
@@ -33,8 +33,8 @@
 | `/team:*` | 4 |
 | `/uiux:*` | 8 |
 | `/vuejs:*` | 6 |
-| `/workflow:*` | 9 |
-| **Total** | **219** |
+| `/workflow:*` | 10 |
+| **Total** | **220** |
 
 ## `/angular:*`
 
@@ -381,6 +381,7 @@
 | Command | Description |
 |---------|-------------|
 | [`/workflow:analyze`](../.claude/commands/workflow/analyze.md) | Exécuter la phase d'Analyse - recherche, exploration et identification des contraintes |
+| [`/workflow:auto-sprint`](../.claude/commands/workflow/auto-sprint.md) | Orchestrateur de sprint de bout en bout (démarrage -> décomposition -> validation -> implémentation -> PR -> CI -> revue -> rétro -> merge) |
 | [`/workflow:design`](../.claude/commands/workflow/design.md) | Exécuter la phase de Conception (Solutioning) - spécification technique et architecture |
 | [`/workflow:implement`](../.claude/commands/workflow/implement.md) | Exécuter la phase d'Implémentation - développement sprint avec TDD/BDD |
 | [`/workflow:init`](../.claude/commands/workflow/init.md) | Analyser le contexte du projet et recommander le track de workflow optimal |

--- a/docs/COMMANDS.md
+++ b/docs/COMMANDS.md
@@ -35,7 +35,7 @@ Every command includes a **Plan Mode** section that indicates when Claude should
 
 ## Command Namespaces
 
-> Les **15 namespaces cœur + technologies** (`/common`, `/workflow`, `/team`, `/qa`, `/uiux` + les 11 stacks dont `/paperclip:*`) totalisent **125 commandes** — c'est le chiffre d'en-tête de Claude Craft. Le tableau ci-dessous inclut en plus les namespaces d'infrastructure et de gestion de projet (BMAD), pour un total installable de **219 commandes sur 27 namespaces**. Référence détaillée auto-générée : [COMMANDS-FULL-REFERENCE](COMMANDS-FULL-REFERENCE.md).
+> Les **15 namespaces cœur + technologies** (`/common`, `/workflow`, `/team`, `/qa`, `/uiux` + les 11 stacks dont `/paperclip:*`) totalisent **126 commandes** — c'est le chiffre d'en-tête de Claude Craft. Le tableau ci-dessous inclut en plus les namespaces d'infrastructure et de gestion de projet (BMAD), pour un total installable de **220 commandes sur 27 namespaces**. Référence détaillée auto-générée : [COMMANDS-FULL-REFERENCE](COMMANDS-FULL-REFERENCE.md).
 
 | Namespace | Technology | Count |
 |-----------|------------|-------|
@@ -92,6 +92,7 @@ Transversal commands for all projects.
 | Command | Description |
 |---------|-------------|
 | `/workflow:start` | Initialize a new sprint |
+| `/workflow:auto-sprint` | End-to-end sprint orchestrator (start → decompose → validate → implement → PR → CI → review → retro → merge) |
 | `/workflow:review` | Generate sprint review summary |
 | `/workflow:retro` | Conduct sprint retrospective |
 | `/common:daily-standup` | Generate standup summary |
@@ -213,6 +214,7 @@ BMAD-inspired workflow system adapted to project complexity.
 | `/workflow:retro` | Sprint retrospective |
 | `/workflow:review` | Sprint review summary |
 | `/workflow:start` | Start a new sprint |
+| `/workflow:auto-sprint` | End-to-end sprint orchestrator (PO/SM): chains start → decompose → validate → implement → PR → CI watch → review → retro → merge, each step in an isolated sub-agent (replaces `/clear`) |
 
 ---
 

--- a/tests/scripts/namespace-integrity.test.mjs
+++ b/tests/scripts/namespace-integrity.test.mjs
@@ -122,7 +122,7 @@ describe('v7.0.0 namespace integrity', () => {
   it('correct command counts per namespace', () => {
     const expected = {
       'Dev/i18n/en/Common/commands': 14,
-      'Dev/i18n/en/Workflow/commands': 9,
+      'Dev/i18n/en/Workflow/commands': 10,
       'Dev/i18n/en/Team/commands': 4,
       'Dev/i18n/en/QA/commands': 6,
       'Dev/i18n/en/UIUX/commands': 8,


### PR DESCRIPTION
## Contexte

Livrer un sprint demandait 6 commandes lancées **manuellement** avec un `/clear` entre chaque :

```
/workflow:start N → /project:decompose-tasks 00N → /gate:validate-sprint 00N
→ /team:sprint "sprint-00N" → /workflow:review N → /workflow:retro N
```

Manquaient : l'enchaînement auto, la gestion du `/clear`, la PR, la surveillance CI, le merge.

## Solution — `/workflow:auto-sprint <N>`

Commande unique jouant **Product Owner / Scrum Master**. Chaque cérémonie s'exécute dans un **sous-agent au contexte isolé** → l'isolation remplace le `/clear` (l'orchestrateur reste léger). La phase d'implémentation assume le rôle conductor **inline** (réutilise `/team:sprint`) pour éviter le nesting d'Agent Teams. Ajoute commit + PR + watch CI + merge via `gh`.

### Décisions
- **Merge** : `--auto-merge` opt-in ; **défaut = pause + GO humain** (règle 09 « review obligatoire » + Karpathy).
- **Échec gate** (validate KO / CI rouge / DoD miss) : **auto-fix loop** borné (`--max-fix-attempts`, défaut 2) avant abort.
- **Distribution** : 5 langues (`Dev/i18n/{en,fr,es,de,pt}`) + build local `.claude/` + docs ; compteurs 125→126 / 219→220.

## Vérif
- `bash scripts/verify-i18n-parity.sh` ✅ (count 100 % + size ≥ 0.80)
- `npm run lint:versions` ✅
- vitest `tests/content/` + `tests/scripts/` ✅ 332 passed (compte par namespace + doc-counts à jour)

🤖 Generated with [Claude Code](https://claude.com/claude-code)