### PR TITLE
chore(release): v8.18.0

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.17.2 | **Languages:** en, fr, es, de, pt
+**Version:** 8.18.0 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 126 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.17.2
+- **Version:** 8.18.0
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.18.0] - 2026-06-27
+
+### Added
+
+- **Commande `/workflow:auto-sprint`** : orchestrateur de sprint de bout en bout jouant le rôle Product Owner / Scrum Master. Enchaîne en une seule commande `start → decompose → validate → implement → PR → CI watch → review → retro → merge`. Chaque cérémonie s'exécute dans un **sous-agent au contexte isolé** — l'isolation remplace le `/clear` manuel entre les étapes ; la phase d'implémentation assume le rôle conductor **inline** (réutilise `/team:sprint`) pour éviter le nesting d'Agent Teams. Ajoute création de PR, surveillance CI et merge via `gh`. Merge `--auto-merge` opt-in (défaut : pause + GO humain, conforme règle 09 + Karpathy) ; échec de gate (validate KO / CI rouge / DoD miss) déclenche un **auto-fix loop** borné (`--max-fix-attempts`). Livrée en 5 langues (`Dev/i18n/{en,fr,es,de,pt}`).
+
+### Changed
+
+- **Compteurs de commandes** : `126 core / 220 total` (au lieu de `125 / 219`) — `COMMANDS.md`, `COMMANDS-FULL-REFERENCE.md` (régénéré), `README.md`, `.claude/CLAUDE.md`. Test `namespace-integrity` mis à jour (namespace Workflow 9 → 10).
+
 ## [8.17.2] - 2026-06-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -28,6 +28,14 @@ Plus **11 stack-specific reviewers** (@symfony-reviewer, @react-reviewer, @pytho
 
 A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **31 specialized agents (+39 infra agents on-demand), 126 commands across 15 namespaces (220 total), 55 skills**, all token-optimized via `context: fork` and sub-agent model routing.
 
+## What's New in v8.18.0
+
+**Nouvelle commande `/workflow:auto-sprint` (2026-06-27, v8.18.0) :**
+
+- **Orchestrateur de sprint de bout en bout** : une seule commande joue le rôle Product Owner / Scrum Master et enchaîne `start → decompose → validate → implement → PR → CI watch → review → retro → merge`. Chaque cérémonie tourne dans un **sous-agent au contexte isolé** — l'isolation remplace le `/clear` manuel entre étapes ; la phase d'implémentation assume le rôle conductor **inline** (réutilise `/team:sprint`).
+- **PR + CI + merge intégrés** (`gh`) : `--auto-merge` opt-in (défaut : pause + GO humain) ; échec de gate (validate KO / CI rouge / DoD miss) → **auto-fix loop** borné (`--max-fix-attempts`).
+- **5 langues** (`Dev/i18n/{en,fr,es,de,pt}`) ; compteurs réalignés **126 core / 220 total** commandes.
+
 ## What's New in v8.17.2
 
 **Revue documentation (2026-06-26, v8.17.2) :**

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,10 +4,10 @@
 
 | Version | Supported          |
 |---------|--------------------|
+| 8.18.x  | :white_check_mark: |
 | 8.17.x  | :white_check_mark: |
 | 8.16.x  | :white_check_mark: |
-| 8.15.x  | :white_check_mark: |
-| < 8.15  | :x:                |
+| < 8.16  | :x:                |
 
 
 ## Reporting a Vulnerability

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -9,7 +9,7 @@
 > | v6.x → v7 | [MIGRATION-v7.md](MIGRATION-v7.md) |
 > | v7.x → v8 | [MIGRATION-v7-to-v8.md](MIGRATION-v7-to-v8.md) |
 >
-> Always upgrade one major version at a time. The current release is **v8.17.2**.
+> Always upgrade one major version at a time. The current release is **v8.18.0**.
 
 This guide explains how to migrate from the legacy rules format to the official Claude Code skills format.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -60,7 +60,7 @@ Replace `react` with your technology: `symfony`, `flutter`, `python`, `angular`,
 **What you should see:**
 
 ```
-  Claude Craft v8.17.2 - AI Development Framework
+  Claude Craft v8.18.0 - AI Development Framework
 
   Installing react rules to /home/user/my-project...
   [OK] Common rules installed

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -270,7 +270,7 @@ ls ~/my-project/.claude/skills/
 | **Total unique** | **55** |
 | **With i18n (×5)** | **275** |
 
-> **Note :** Skills are counted across the full distribution (55 unique skills as of v8.17.2). The table above groups them by primary audience; many common skills (e.g. `security`, `testing`, `solid-principles`) are applicable to all stacks.
+> **Note :** Skills are counted across the full distribution (55 unique skills as of v8.18.0). The table above groups them by primary audience; many common skills (e.g. `security`, `testing`, `solid-principles`) are applicable to all stacks.
 
 The 55 skills include: `adapter-development`, `aggregates`, `api-gateway`, `architect`, `architecture`, `architecture-clean-ddd`, `architecture-paperclip`, `async`, `atomic-tasks`, `coding-standards`, `coding-standards-ts`, `cqrs`, `ddd-patterns`, `debug-methodical`, `design-md-convention`, `docker-hadolint`, `doctrine-extensions`, `documentation`, `domain-events`, `ecosystem-tools`, `edge-computing`, `event-driven`, `git-workflow`, `graphql`, `i18n`, `kiss-dry-yagni`, `monorepo`, `multitenant`, `navigation`, `observability`, `paperclip-onboarding`, `parallel-worktrees`, `performance`, `quality-tools`, `remotion`, `security`, `security-flutter`, `security-paperclip`, `security-react`, `security-reactnative`, `security-symfony`, `socratic-brainstorm`, `solid-principles`, `state-management`, `testing`, `testing-flutter`, `testing-paperclip`, `testing-python`, `testing-react`, `testing-reactnative`, `testing-symfony`, `tooling`, `value-objects`, `wasm`, `workflow-analysis`.
 

--- a/docs/comparison-claude-craft-vs-superclaude.md
+++ b/docs/comparison-claude-craft-vs-superclaude.md
@@ -2,7 +2,7 @@
 
 > **TL;DR :** SuperClaude is a viral, single-prompt persona library optimised for individual developers. Claude Craft is a multi-stack, team-oriented framework with sprint workflow and browser-based QA. They solve different problems for different audiences. This page compares them honestly so you can pick the right tool.
 
-**Last updated :** 2026-06-26 | **Claude Craft v8.17.2** | **SuperClaude v4.x (snapshot 2026-06)**
+**Last updated :** 2026-06-27 | **Claude Craft v8.18.0** | **SuperClaude v4.x (snapshot 2026-06)**
 
 > **Looking for the broader market picture?** This page is the user-facing, single-competitor comparison. For the full strategic landscape (all competitors, SWOT, roadmap), see the maintainer doc [`COMPETITIVE-ANALYSIS.md`](COMPETITIVE-ANALYSIS.md).
 

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Was wir bauen:** *TaskFlow* — ein kleines SaaS zur Aufgabenverfolgung im Team mit einer REST-API (Python / FastAPI) und einem React-Web-Client. Einfach genug, um es in einer Sitzung nachzuvollziehen, real genug, um den gesamten Workflow zu durchlaufen.
 >
-> **Claude Craft v8.17.2** · Geschätzte Lese- und Übungszeit: 60–90 Minuten.
+> **Claude Craft v8.18.0** · Geschätzte Lese- und Übungszeit: 60–90 Minuten.
 
 ---
 

--- a/docs/guides/en/10-complete-workflow.md
+++ b/docs/guides/en/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **What we build:** *TaskFlow* — a small team task-tracking SaaS with a REST API (Python / FastAPI) and a React web client. It is simple enough to follow in one sitting, real enough to exercise the whole workflow.
 >
-> **Claude Craft v8.17.2** · Estimated reading + doing time: 60–90 minutes.
+> **Claude Craft v8.18.0** · Estimated reading + doing time: 60–90 minutes.
 
 ---
 

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Qué construimos:** *TaskFlow* — un SaaS de seguimiento de tareas para equipos pequeños con una API REST (Python / FastAPI) y un cliente web en React. Es lo suficientemente sencillo para seguirlo en una sola sesión, y lo suficientemente real para ejercitar todo el flujo de trabajo.
 >
-> **Claude Craft v8.17.2** · Tiempo estimado de lectura + práctica: 60–90 minutos.
+> **Claude Craft v8.18.0** · Tiempo estimado de lectura + práctica: 60–90 minutos.
 
 ---
 

--- a/docs/guides/fr/10-complete-workflow.md
+++ b/docs/guides/fr/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Ce qu'on construit :** *TaskFlow* — un petit SaaS de suivi des tâches d'équipe avec une API REST (Python / FastAPI) et un client web React. Suffisamment simple pour être suivi en une séance, suffisamment réel pour exercer l'ensemble du workflow.
 >
-> **Claude Craft v8.17.2** · Durée estimée de lecture + pratique : 60–90 minutes.
+> **Claude Craft v8.18.0** · Durée estimée de lecture + pratique : 60–90 minutes.
 
 ---
 

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **O que vamos construir:** *TaskFlow* — um pequeno SaaS de acompanhamento de tarefas para equipes, com uma API REST (Python / FastAPI) e um cliente web em React. É simples o suficiente para seguir em uma única sessão e real o suficiente para exercitar todo o fluxo de trabalho.
 >
-> **Claude Craft v8.17.2** · Tempo estimado de leitura + execução: 60–90 minutos.
+> **Claude Craft v8.18.0** · Tempo estimado de leitura + execução: 60–90 minutos.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.17.2",
+  "version": "8.18.0",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",


### PR DESCRIPTION
## Release v8.18.0 (minor)

Première release embarquant **`/workflow:auto-sprint`** (orchestrateur de sprint de bout en bout, mergé en #104).

### Core (commit 1)
- `package.json` 8.17.2 → **8.18.0**
- `CHANGELOG.md` : section [8.18.0]
- `SECURITY.md` : versions supportées 8.18.x/8.17.x/8.16.x
- `.claude/CLAUDE.md`, `.claude/context-essentials.md` : version

### Docs (commit 2)
- `README.md` : section *What's New in v8.18.0*
- Stamps version → v8.18.0 : QUICKSTART, MIGRATION, comparison, SKILLS, guides `10-complete-workflow` (5 langues)
- Site (gitignored, modifié sur disque) : `LandingPage.vue` (badges 5 langues + FeatureCards + compteurs 125→126), `AgentShowcase.vue`

### Vérif
- `lint:versions` ✅ · `docs:check` ✅ (220 cmd / 70 agents) · i18n parity ✅
- vitest **1113 passed** (Docker node:24)

> Après merge + CI verte → tag `v8.18.0` → la CI publie sur NPM.

🤖 Generated with [Claude Code](https://claude.com/claude-code)