### PR TITLE
docs(website): bump LandingPage + AgentShowcase to v8.18.0

### DIFF
--- a/website/.vitepress/theme/LandingPage.vue
+++ b/website/.vitepress/theme/LandingPage.vue
@@ -17,7 +17,7 @@ const translations = {
     nav_tools: "Tools",
     nav_install: "Install",
     nav_tech: "Tech Stack",
-    hero_badge: "v8.17.2 - Claude Code 2.1.168",
+    hero_badge: "v8.18.0 - Claude Code 2.1.168",
     hero_title_1: "Supercharge",
     hero_title_2: "with Expert Knowledge",
     hero_desc: "A comprehensive framework for AI-assisted development. Install standardized rules, agents, and commands for your projects across multiple technology stacks.",
@@ -36,7 +36,7 @@ const translations = {
     feat_skills_title: "55 Skills",
     feat_skills_desc: "Best practices in official Claude Code format. Architecture, testing, security patterns for all technologies.",
     feat_3_title: "Automated Workflows",
-    feat_3_desc: "Use 125 slash commands to automate tedious tasks. Generate components, check architecture, and run pre-commit audits.",
+    feat_3_desc: "Use 126 slash commands to automate tedious tasks. Generate components, check architecture, and run pre-commit audits.",
     tools_title: "Developer Experience Tools",
     tools_desc: "Enhance your terminal workflow with power tools designed for daily use.",
     tool_status_title: "Custom Status Line",
@@ -73,7 +73,7 @@ const translations = {
     nav_tools: "Outils",
     nav_install: "Installation",
     nav_tech: "Technologies",
-    hero_badge: "v8.17.2 - Claude Code 2.1.168",
+    hero_badge: "v8.18.0 - Claude Code 2.1.168",
     hero_title_1: "Superchargez",
     hero_title_2: "d'une Expertise Technique",
     hero_desc: "Un framework complet pour le d\u00e9veloppement assist\u00e9 par IA. Installez des r\u00e8gles, agents et commandes standardis\u00e9s pour vos projets.",
@@ -92,7 +92,7 @@ const translations = {
     feat_skills_title: "55 Skills",
     feat_skills_desc: "Bonnes pratiques au format officiel Claude Code.",
     feat_3_title: "Flux Automatis\u00e9s",
-    feat_3_desc: "Utilisez 125 commandes pour automatiser les t\u00e2ches fastidieuses.",
+    feat_3_desc: "Utilisez 126 commandes pour automatiser les t\u00e2ches fastidieuses.",
     tools_title: "Outils d'Exp\u00e9rience D\u00e9veloppeur",
     tools_desc: "Am\u00e9liorez votre flux de travail terminal avec des outils puissants.",
     tool_status_title: "Barre d'\u00c9tat Personnalis\u00e9e",
@@ -126,7 +126,7 @@ const translations = {
   },
   es: {
     nav_features: "Caracter\u00edsticas", nav_tools: "Herramientas", nav_install: "Instalaci\u00f3n", nav_tech: "Tecnolog\u00edas",
-    hero_badge: "v8.17.2 - Claude Code 2.1.168", hero_title_1: "Potencia", hero_title_2: "con Conocimiento Experto",
+    hero_badge: "v8.18.0 - Claude Code 2.1.168", hero_title_1: "Potencia", hero_title_2: "con Conocimiento Experto",
     hero_desc: "Un marco integral para el desarrollo asistido por IA.", cta_get_started: "Empezar", cta_docs: "Documentaci\u00f3n",
     feat_main_title: "Todo lo que necesitas para escalar", feat_main_desc: "Equipa a Claude con herramientas conscientes del contexto.",
     feat_bmad_title: "Framework BMAD v6", feat_bmad_desc: "9 agentes Agent-as-Code, 5 Quality Gates.",
@@ -134,7 +134,7 @@ const translations = {
     feat_1_title: "Soporte Multi-Idioma", feat_1_desc: "Soporte nativo para 5 idiomas.",
     feat_2_title: "Agentes Especializados", feat_2_desc: "Despliega revisores, arquitectos y entrenadores virtuales.",
     feat_skills_title: "55 Skills", feat_skills_desc: "Mejores pr\u00e1cticas en formato oficial de Claude Code.",
-    feat_3_title: "Flujos Automatizados", feat_3_desc: "Usa 125 comandos para automatizar tareas.",
+    feat_3_title: "Flujos Automatizados", feat_3_desc: "Usa 126 comandos para automatizar tareas.",
     tools_title: "Herramientas de Desarrollador", tools_desc: "Mejora tu flujo de trabajo en la terminal.",
     tool_status_title: "L\u00ednea de Estado", tool_status_desc: "Barra de estado rica con perfil, modelo y git.",
     tool_account_title: "Gestor Multi-Cuenta", tool_account_desc: "Cambia f\u00e1cilmente entre perfiles.",
@@ -154,7 +154,7 @@ const translations = {
   },
   de: {
     nav_features: "Funktionen", nav_tools: "Werkzeuge", nav_install: "Installation", nav_tech: "Technologien",
-    hero_badge: "v8.17.2 - Claude Code 2.1.168", hero_title_1: "Laden Sie", hero_title_2: "mit Expertenwissen auf",
+    hero_badge: "v8.18.0 - Claude Code 2.1.168", hero_title_1: "Laden Sie", hero_title_2: "mit Expertenwissen auf",
     hero_desc: "Ein umfassendes Framework f\u00fcr KI-gest\u00fctzte Entwicklung.", cta_get_started: "Loslegen", cta_docs: "Dokumentation",
     feat_main_title: "Alles f\u00fcr skalierbare KI-Entwicklung", feat_main_desc: "Statten Sie Claude mit kontextbezogenen Tools aus.",
     feat_bmad_title: "BMAD v6 Framework", feat_bmad_desc: "9 Agent-as-Code Personas, 5 Quality Gates.",
@@ -162,7 +162,7 @@ const translations = {
     feat_1_title: "Mehrsprachige Unterst\u00fctzung", feat_1_desc: "Native Unterst\u00fctzung f\u00fcr 5 Sprachen.",
     feat_2_title: "Spezialisierte Agenten", feat_2_desc: "Virtuelle Reviewer, Architekten und Coaches.",
     feat_skills_title: "55 Skills", feat_skills_desc: "Best Practices im offiziellen Claude Code Format.",
-    feat_3_title: "Automatisierte Abl\u00e4ufe", feat_3_desc: "125 Befehle f\u00fcr Automatisierung.",
+    feat_3_title: "Automatisierte Abl\u00e4ufe", feat_3_desc: "126 Befehle f\u00fcr Automatisierung.",
     tools_title: "Entwickler-Tools", tools_desc: "Leistungsstarke Terminal-Tools.",
     tool_status_title: "Statuszeile", tool_status_desc: "Reichhaltige Statusleiste.",
     tool_account_title: "Multi-Account Manager", tool_account_desc: "Einfacher Profilwechsel.",
@@ -182,7 +182,7 @@ const translations = {
   },
   pt: {
     nav_features: "Funcionalidades", nav_tools: "Ferramentas", nav_install: "Instala\u00e7\u00e3o", nav_tech: "Tecnologias",
-    hero_badge: "v8.17.2 - Claude Code 2.1.168", hero_title_1: "Turbine o", hero_title_2: "com Conhecimento Especializado",
+    hero_badge: "v8.18.0 - Claude Code 2.1.168", hero_title_1: "Turbine o", hero_title_2: "com Conhecimento Especializado",
     hero_desc: "Um framework abrangente para desenvolvimento assistido por IA.", cta_get_started: "Come\u00e7ar", cta_docs: "Documenta\u00e7\u00e3o",
     feat_main_title: "Tudo para escalar", feat_main_desc: "Equipe o Claude com ferramentas conscientes do contexto.",
     feat_bmad_title: "Framework BMAD v6", feat_bmad_desc: "9 agentes Agent-as-Code, 5 Quality Gates.",
@@ -190,7 +190,7 @@ const translations = {
     feat_1_title: "Suporte Multi-Idioma", feat_1_desc: "Suporte nativo para 5 idiomas.",
     feat_2_title: "Agentes Especializados", feat_2_desc: "Implante revisores, arquitetos e treinadores virtuais.",
     feat_skills_title: "55 Skills", feat_skills_desc: "Melhores pr\u00e1ticas no formato oficial do Claude Code.",
-    feat_3_title: "Fluxos Automatizados", feat_3_desc: "Use 125 comandos para automatizar tarefas.",
+    feat_3_title: "Fluxos Automatizados", feat_3_desc: "Use 126 comandos para automatizar tarefas.",
     tools_title: "Ferramentas do Desenvolvedor", tools_desc: "Melhore seu fluxo de trabalho no terminal.",
     tool_status_title: "Linha de Status", tool_status_desc: "Barra de status rica.",
     tool_account_title: "Gerenciador Multi-Conta", tool_account_desc: "Alterne entre perfis.",
@@ -344,8 +344,8 @@ onMounted(() => {
           <p style="margin-top: 1rem; font-size: 1.25rem; color: #94a3b8;">{{ t('feat_main_desc') }}</p>
         </div>
         <div class="grid-3col" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 2rem;">
-          <FeatureCard icon="git-branch" color="cyan" :badge="'v8.17.2'" :title="t('feat_bmad_title')" :desc="t('feat_bmad_desc')" />
-          <FeatureCard icon="repeat" color="orange" :badge="'v8.17.2'" :title="t('feat_ralph_title')" :desc="t('feat_ralph_desc')" />
+          <FeatureCard icon="git-branch" color="cyan" :badge="'v8.18.0'" :title="t('feat_bmad_title')" :desc="t('feat_bmad_desc')" />
+          <FeatureCard icon="repeat" color="orange" :badge="'v8.18.0'" :title="t('feat_ralph_title')" :desc="t('feat_ralph_desc')" />
           <FeatureCard icon="globe" color="brand" :title="t('feat_1_title')" :desc="t('feat_1_desc')" />
           <FeatureCard icon="bot" color="blue" :title="t('feat_2_title')" :desc="t('feat_2_desc')" />
           <FeatureCard icon="sparkles" color="emerald" :title="t('feat_skills_title')" :desc="t('feat_skills_desc')" />

--- a/website/.vitepress/theme/components/AgentShowcase.vue
+++ b/website/.vitepress/theme/components/AgentShowcase.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 const agents = [
   { name: 'bmad-master', desc: 'BMAD orchestrator: routing, gates enforcement, sprint lifecycle, batch processing.', color: '#22d3ee', badge: 'BMAD v6', badgeBg: 'rgba(6,182,212,0.2)', borderColor: 'rgba(6,182,212,0.3)' },
-  { name: 'ralph-conductor', desc: 'v2.0: Adaptive profiles, hooks integration, health monitoring, and DoD templates.', color: '#fb923c', badge: 'v8.17.2', badgeBg: 'rgba(249,115,22,0.2)', borderColor: 'rgba(249,115,22,0.3)' },
+  { name: 'ralph-conductor', desc: 'v2.0: Adaptive profiles, hooks integration, health monitoring, and DoD templates.', color: '#fb923c', badge: 'v8.18.0', badgeBg: 'rgba(249,115,22,0.2)', borderColor: 'rgba(249,115,22,0.3)' },
   { name: 'uiux-orchestrator', desc: 'Coordinates UI, UX, and Accessibility experts for holistic design solutions.', color: '#f472b6', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },
   { name: 'product-owner', desc: 'Helps with user stories, backlog prioritization, and sprint planning.', color: '#fbbf24', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },
   { name: 'accessibility-expert', desc: 'Ensures WCAG 2.2 AAA compliance and ARIA best practices.', color: '#2dd4bf', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },


### PR DESCRIPTION
Les 2 composants Vue trackés du site (`LandingPage.vue`, `AgentShowcase.vue`) étaient restés sur v8.17.2 / 125 commandes (mes edits non commités effacés par un `git reset --hard` lors de la release #105). Réalignés : badges hero (5 langues) + FeatureCards + compteurs 125→126 + badge ralph-conductor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)