### PR TITLE
docs(website): StatsGrid Slash Commands 125 → 126

### DIFF
--- a/website/.vitepress/theme/components/StatsGrid.vue
+++ b/website/.vitepress/theme/components/StatsGrid.vue
@@ -11,7 +11,7 @@
 const stats = [
   { value: '11', label: 'Tech Stacks' },
   { value: '31', label: 'AI Agents' },
-  { value: '125', label: 'Slash Commands' },
+  { value: '126', label: 'Slash Commands' },
   { value: '55', label: 'Skills' },
   { value: '21', label: 'Templates' },
   { value: '10', label: 'Checklists' },


### PR DESCRIPTION
Compteur StatsGrid.vue raté lors du bump v8.18.0 (composant tracké non gaté par lint:versions). Aligné sur 126 commandes core.

🤖 Generated with [Claude Code](https://claude.com/claude-code)