### PR TITLE
chore(release): v8.18.2

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.18.1 | **Languages:** en, fr, es, de, pt
+**Version:** 8.18.2 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 126 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.18.1
+- **Version:** 8.18.2
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.18.2] - 2026-06-30
+
+### Fixed
+
+- **Descriptions de commandes garanties** : 91 fichiers commande (sur 1110) n'exposaient pas de description exploitable. 79 avaient un frontmatter YAML malformé (deux-points non quoté dans `description:`, ou `argument-hint: [a] [b]` interprété comme une séquence flow invalide) que le parser js-yaml strict de `generate-references.mjs` faisait silencieusement tomber à `_no description_` ; 12 étaient réellement sans description. Valeurs `description`/`argument-hint` quotées, descriptions manquantes ajoutées (localisées par langue + couche `base/` + `.claude/`), `COMMANDS-FULL-REFERENCE.md` régénéré (occurrences `_no description_` : 79+ → 0).
+
+### Added
+
+- **Garde-fou descriptions** : `tests/scripts/command-descriptions.test.mjs` (4 tests) impose, sur les 1110 fichiers commande des 4 layouts, que chacun ait un bloc frontmatter, parse en YAML strict et expose une description non vide. Reproduit le parsing de production → toute future commande sans description (ou au YAML cassé) fait échouer la CI.
+
 ## [8.18.1] - 2026-06-28
 
 ### Changed

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -9,7 +9,7 @@
 > | v6.x → v7 | [MIGRATION-v7.md](MIGRATION-v7.md) |
 > | v7.x → v8 | [MIGRATION-v7-to-v8.md](MIGRATION-v7-to-v8.md) |
 >
-> Always upgrade one major version at a time. The current release is **v8.18.1**.
+> Always upgrade one major version at a time. The current release is **v8.18.2**.
 
 This guide explains how to migrate from the legacy rules format to the official Claude Code skills format.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -60,7 +60,7 @@ Replace `react` with your technology: `symfony`, `flutter`, `python`, `angular`,
 **What you should see:**
 
 ```
-  Claude Craft v8.18.1 - AI Development Framework
+  Claude Craft v8.18.2 - AI Development Framework
 
   Installing react rules to /home/user/my-project...
   [OK] Common rules installed

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -270,7 +270,7 @@ ls ~/my-project/.claude/skills/
 | **Total unique** | **55** |
 | **With i18n (×5)** | **275** |
 
-> **Note :** Skills are counted across the full distribution (55 unique skills as of v8.18.1). The table above groups them by primary audience; many common skills (e.g. `security`, `testing`, `solid-principles`) are applicable to all stacks.
+> **Note :** Skills are counted across the full distribution (55 unique skills as of v8.18.2). The table above groups them by primary audience; many common skills (e.g. `security`, `testing`, `solid-principles`) are applicable to all stacks.
 
 The 55 skills include: `adapter-development`, `aggregates`, `api-gateway`, `architect`, `architecture`, `architecture-clean-ddd`, `architecture-paperclip`, `async`, `atomic-tasks`, `coding-standards`, `coding-standards-ts`, `cqrs`, `ddd-patterns`, `debug-methodical`, `design-md-convention`, `docker-hadolint`, `doctrine-extensions`, `documentation`, `domain-events`, `ecosystem-tools`, `edge-computing`, `event-driven`, `git-workflow`, `graphql`, `i18n`, `kiss-dry-yagni`, `monorepo`, `multitenant`, `navigation`, `observability`, `paperclip-onboarding`, `parallel-worktrees`, `performance`, `quality-tools`, `remotion`, `security`, `security-flutter`, `security-paperclip`, `security-react`, `security-reactnative`, `security-symfony`, `socratic-brainstorm`, `solid-principles`, `state-management`, `testing`, `testing-flutter`, `testing-paperclip`, `testing-python`, `testing-react`, `testing-reactnative`, `testing-symfony`, `tooling`, `value-objects`, `wasm`, `workflow-analysis`.
 

--- a/docs/comparison-claude-craft-vs-superclaude.md
+++ b/docs/comparison-claude-craft-vs-superclaude.md
@@ -2,7 +2,7 @@
 
 > **TL;DR :** SuperClaude is a viral, single-prompt persona library optimised for individual developers. Claude Craft is a multi-stack, team-oriented framework with sprint workflow and browser-based QA. They solve different problems for different audiences. This page compares them honestly so you can pick the right tool.
 
-**Last updated :** 2026-06-27 | **Claude Craft v8.18.1** | **SuperClaude v4.x (snapshot 2026-06)**
+**Last updated :** 2026-06-27 | **Claude Craft v8.18.2** | **SuperClaude v4.x (snapshot 2026-06)**
 
 > **Looking for the broader market picture?** This page is the user-facing, single-competitor comparison. For the full strategic landscape (all competitors, SWOT, roadmap), see the maintainer doc [`COMPETITIVE-ANALYSIS.md`](COMPETITIVE-ANALYSIS.md).
 

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Was wir bauen:** *TaskFlow* — ein kleines SaaS zur Aufgabenverfolgung im Team mit einer REST-API (Python / FastAPI) und einem React-Web-Client. Einfach genug, um es in einer Sitzung nachzuvollziehen, real genug, um den gesamten Workflow zu durchlaufen.
 >
-> **Claude Craft v8.18.1** · Geschätzte Lese- und Übungszeit: 60–90 Minuten.
+> **Claude Craft v8.18.2** · Geschätzte Lese- und Übungszeit: 60–90 Minuten.
 
 ---
 

--- a/docs/guides/en/10-complete-workflow.md
+++ b/docs/guides/en/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **What we build:** *TaskFlow* — a small team task-tracking SaaS with a REST API (Python / FastAPI) and a React web client. It is simple enough to follow in one sitting, real enough to exercise the whole workflow.
 >
-> **Claude Craft v8.18.1** · Estimated reading + doing time: 60–90 minutes.
+> **Claude Craft v8.18.2** · Estimated reading + doing time: 60–90 minutes.
 
 ---
 

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Qué construimos:** *TaskFlow* — un SaaS de seguimiento de tareas para equipos pequeños con una API REST (Python / FastAPI) y un cliente web en React. Es lo suficientemente sencillo para seguirlo en una sola sesión, y lo suficientemente real para ejercitar todo el flujo de trabajo.
 >
-> **Claude Craft v8.18.1** · Tiempo estimado de lectura + práctica: 60–90 minutos.
+> **Claude Craft v8.18.2** · Tiempo estimado de lectura + práctica: 60–90 minutos.
 
 ---
 

--- a/docs/guides/fr/10-complete-workflow.md
+++ b/docs/guides/fr/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Ce qu'on construit :** *TaskFlow* — un petit SaaS de suivi des tâches d'équipe avec une API REST (Python / FastAPI) et un client web React. Suffisamment simple pour être suivi en une séance, suffisamment réel pour exercer l'ensemble du workflow.
 >
-> **Claude Craft v8.18.1** · Durée estimée de lecture + pratique : 60–90 minutes.
+> **Claude Craft v8.18.2** · Durée estimée de lecture + pratique : 60–90 minutes.
 
 ---
 

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **O que vamos construir:** *TaskFlow* — um pequeno SaaS de acompanhamento de tarefas para equipes, com uma API REST (Python / FastAPI) e um cliente web em React. É simples o suficiente para seguir em uma única sessão e real o suficiente para exercitar todo o fluxo de trabalho.
 >
-> **Claude Craft v8.18.1** · Tempo estimado de leitura + execução: 60–90 minutos.
+> **Claude Craft v8.18.2** · Tempo estimado de leitura + execução: 60–90 minutos.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.18.1",
+  "version": "8.18.2",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",

--- a/website/.vitepress/theme/LandingPage.vue
+++ b/website/.vitepress/theme/LandingPage.vue
@@ -17,7 +17,7 @@ const translations = {
     nav_tools: "Tools",
     nav_install: "Install",
     nav_tech: "Tech Stack",
-    hero_badge: "v8.18.1 - Claude Code 2.1.168",
+    hero_badge: "v8.18.2 - Claude Code 2.1.168",
     hero_title_1: "Supercharge",
     hero_title_2: "with Expert Knowledge",
     hero_desc: "A comprehensive framework for AI-assisted development. Install standardized rules, agents, and commands for your projects across multiple technology stacks.",
@@ -73,7 +73,7 @@ const translations = {
     nav_tools: "Outils",
     nav_install: "Installation",
     nav_tech: "Technologies",
-    hero_badge: "v8.18.1 - Claude Code 2.1.168",
+    hero_badge: "v8.18.2 - Claude Code 2.1.168",
     hero_title_1: "Superchargez",
     hero_title_2: "d'une Expertise Technique",
     hero_desc: "Un framework complet pour le d\u00e9veloppement assist\u00e9 par IA. Installez des r\u00e8gles, agents et commandes standardis\u00e9s pour vos projets.",
@@ -126,7 +126,7 @@ const translations = {
   },
   es: {
     nav_features: "Caracter\u00edsticas", nav_tools: "Herramientas", nav_install: "Instalaci\u00f3n", nav_tech: "Tecnolog\u00edas",
-    hero_badge: "v8.18.1 - Claude Code 2.1.168", hero_title_1: "Potencia", hero_title_2: "con Conocimiento Experto",
+    hero_badge: "v8.18.2 - Claude Code 2.1.168", hero_title_1: "Potencia", hero_title_2: "con Conocimiento Experto",
     hero_desc: "Un marco integral para el desarrollo asistido por IA.", cta_get_started: "Empezar", cta_docs: "Documentaci\u00f3n",
     feat_main_title: "Todo lo que necesitas para escalar", feat_main_desc: "Equipa a Claude con herramientas conscientes del contexto.",
     feat_bmad_title: "Framework BMAD v6", feat_bmad_desc: "9 agentes Agent-as-Code, 5 Quality Gates.",
@@ -154,7 +154,7 @@ const translations = {
   },
   de: {
     nav_features: "Funktionen", nav_tools: "Werkzeuge", nav_install: "Installation", nav_tech: "Technologien",
-    hero_badge: "v8.18.1 - Claude Code 2.1.168", hero_title_1: "Laden Sie", hero_title_2: "mit Expertenwissen auf",
+    hero_badge: "v8.18.2 - Claude Code 2.1.168", hero_title_1: "Laden Sie", hero_title_2: "mit Expertenwissen auf",
     hero_desc: "Ein umfassendes Framework f\u00fcr KI-gest\u00fctzte Entwicklung.", cta_get_started: "Loslegen", cta_docs: "Dokumentation",
     feat_main_title: "Alles f\u00fcr skalierbare KI-Entwicklung", feat_main_desc: "Statten Sie Claude mit kontextbezogenen Tools aus.",
     feat_bmad_title: "BMAD v6 Framework", feat_bmad_desc: "9 Agent-as-Code Personas, 5 Quality Gates.",
@@ -182,7 +182,7 @@ const translations = {
   },
   pt: {
     nav_features: "Funcionalidades", nav_tools: "Ferramentas", nav_install: "Instala\u00e7\u00e3o", nav_tech: "Tecnologias",
-    hero_badge: "v8.18.1 - Claude Code 2.1.168", hero_title_1: "Turbine o", hero_title_2: "com Conhecimento Especializado",
+    hero_badge: "v8.18.2 - Claude Code 2.1.168", hero_title_1: "Turbine o", hero_title_2: "com Conhecimento Especializado",
     hero_desc: "Um framework abrangente para desenvolvimento assistido por IA.", cta_get_started: "Come\u00e7ar", cta_docs: "Documenta\u00e7\u00e3o",
     feat_main_title: "Tudo para escalar", feat_main_desc: "Equipe o Claude com ferramentas conscientes do contexto.",
     feat_bmad_title: "Framework BMAD v6", feat_bmad_desc: "9 agentes Agent-as-Code, 5 Quality Gates.",
@@ -344,8 +344,8 @@ onMounted(() => {
           <p style="margin-top: 1rem; font-size: 1.25rem; color: #94a3b8;">{{ t('feat_main_desc') }}</p>
         </div>
         <div class="grid-3col" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 2rem;">
-          <FeatureCard icon="git-branch" color="cyan" :badge="'v8.18.1'" :title="t('feat_bmad_title')" :desc="t('feat_bmad_desc')" />
-          <FeatureCard icon="repeat" color="orange" :badge="'v8.18.1'" :title="t('feat_ralph_title')" :desc="t('feat_ralph_desc')" />
+          <FeatureCard icon="git-branch" color="cyan" :badge="'v8.18.2'" :title="t('feat_bmad_title')" :desc="t('feat_bmad_desc')" />
+          <FeatureCard icon="repeat" color="orange" :badge="'v8.18.2'" :title="t('feat_ralph_title')" :desc="t('feat_ralph_desc')" />
           <FeatureCard icon="globe" color="brand" :title="t('feat_1_title')" :desc="t('feat_1_desc')" />
           <FeatureCard icon="bot" color="blue" :title="t('feat_2_title')" :desc="t('feat_2_desc')" />
           <FeatureCard icon="sparkles" color="emerald" :title="t('feat_skills_title')" :desc="t('feat_skills_desc')" />

--- a/website/.vitepress/theme/components/AgentShowcase.vue
+++ b/website/.vitepress/theme/components/AgentShowcase.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 const agents = [
   { name: 'bmad-master', desc: 'BMAD orchestrator: routing, gates enforcement, sprint lifecycle, batch processing.', color: '#22d3ee', badge: 'BMAD v6', badgeBg: 'rgba(6,182,212,0.2)', borderColor: 'rgba(6,182,212,0.3)' },
-  { name: 'ralph-conductor', desc: 'v2.0: Adaptive profiles, hooks integration, health monitoring, and DoD templates.', color: '#fb923c', badge: 'v8.18.1', badgeBg: 'rgba(249,115,22,0.2)', borderColor: 'rgba(249,115,22,0.3)' },
+  { name: 'ralph-conductor', desc: 'v2.0: Adaptive profiles, hooks integration, health monitoring, and DoD templates.', color: '#fb923c', badge: 'v8.18.2', badgeBg: 'rgba(249,115,22,0.2)', borderColor: 'rgba(249,115,22,0.3)' },
   { name: 'uiux-orchestrator', desc: 'Coordinates UI, UX, and Accessibility experts for holistic design solutions.', color: '#f472b6', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },
   { name: 'product-owner', desc: 'Helps with user stories, backlog prioritization, and sprint planning.', color: '#fbbf24', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },
   { name: 'accessibility-expert', desc: 'Ensures WCAG 2.2 AAA compliance and ARIA best practices.', color: '#2dd4bf', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },


### PR DESCRIPTION
## Release v8.18.2

Patch release qui empaquette la garantie de descriptions de commandes (#115).

### Inclus
- **#115** — toutes les commandes (1110 fichiers, 4 layouts) exposent désormais une description parseable et non vide ; garde-fou `tests/scripts/command-descriptions.test.mjs` (échec CI si régression).

### Bump
- `package.json` 8.18.1 → 8.18.2
- chaînes de version : `.claude/CLAUDE.md`, `.claude/context-essentials.md`, website (`LandingPage.vue`, `AgentShowcase.vue`), `docs/QUICKSTART.md`, `docs/SKILLS.md`, `docs/MIGRATION.md`, comparison, guides `10-complete-workflow.md` (en/fr/es/de/pt)
- entrée CHANGELOG 8.18.2

### Vérifs
- `lint:versions` ✅ · `docs:check` ✅ · `tests/scripts` 246/246 ✅

> NPM publish déclenché par la CI sur le tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)