### PR TITLE
docs(training): align guides with v8.19.0 — Sonnet 5 + Claude Code 2.1.193

### DIFF
--- a/docs/guides/de/03-feature-development.md
+++ b/docs/guides/de/03-feature-development.md
@@ -56,6 +56,8 @@ Für Analysephasen, die tiefes Nachdenken erfordern, wählen Sie einen hohen Auf
 
 Verwenden Sie `/effort low` für einfache Nachschläge und `/effort medium` für Standard-Implementierungsarbeiten.
 
+> **Aktuelle Modelle (Juni 2026):** `low` → Haiku 4.5, `medium` → **Sonnet 5** (`claude-sonnet-5`, veröffentlicht am 2026-06-30 — agentisch, Einführungspreis $2/$10 pro Mio. Tokens bis 2026-08-31), `high`/`xhigh` → Opus 4.8. Der `model:`-Alias löst automatisch zur neuesten Version auf, daher verweist `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` jetzt auf Sonnet 5. Fable 5 ist ausgesetzt — nicht verwenden. Vollständige Preis-/Routing-Tabelle: [FAQ](../../FAQ.md).
+
 ### Den Analysebefehl verwenden
 
 ```bash

--- a/docs/guides/en/03-feature-development.md
+++ b/docs/guides/en/03-feature-development.md
@@ -56,6 +56,8 @@ For analysis phases that require deep reasoning, set high effort:
 
 Use `/effort low` for simple lookups and `/effort medium` for standard implementation work.
 
+> **Current models (June 2026):** `low` → Haiku 4.5, `medium` → **Sonnet 5** (`claude-sonnet-5`, released 2026-06-30 — agentic, intro $2/$10 per M tokens until 2026-08-31), `high`/`xhigh` → Opus 4.8. The `model:` alias auto-resolves to the latest, so `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` now maps to Sonnet 5. Fable 5 is suspended — do not use it. Full pricing/routing grid: [FAQ](../../FAQ.md#grille-de-prix--routage-modèle-par-tâche-juin-2026).
+
 ### Using the Analysis Command
 
 ```bash

--- a/docs/guides/es/03-feature-development.md
+++ b/docs/guides/es/03-feature-development.md
@@ -56,6 +56,8 @@ Para las fases de análisis que requieren razonamiento profundo, establece un es
 
 Usa `/effort low` para búsquedas simples y `/effort medium` para trabajo de implementación estándar.
 
+> **Modelos actuales (junio de 2026):** `low` → Haiku 4.5, `medium` → **Sonnet 5** (`claude-sonnet-5`, lanzado el 2026-06-30 — agéntico, precio inicial $2/$10 por M tokens hasta el 2026-08-31), `high`/`xhigh` → Opus 4.8. El alias `model:` se resuelve automáticamente a la última versión, así que `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` ahora apunta a Sonnet 5. Fable 5 está suspendido — no usarlo. Tabla completa de precios/enrutamiento: [FAQ](../../FAQ.md).
+
 ### Usar el Comando de Análisis
 
 ```bash

--- a/docs/guides/fr/03-feature-development.md
+++ b/docs/guides/fr/03-feature-development.md
@@ -58,6 +58,10 @@ Cette commande va :
 3. Lister les cas limites potentiels
 4. Suggérer une approche d'implémentation
 
+**Régler l'effort :** `/effort high` pour les phases d'analyse exigeant un raisonnement profond ; `/effort low` pour les recherches simples, `/effort medium` pour l'implémentation standard.
+
+> **Modèles courants (juin 2026) :** `low` → Haiku 4.5, `medium` → **Sonnet 5** (`claude-sonnet-5`, sorti le 2026-06-30 — agentique, prix intro $2/$10 par M tokens jusqu'au 2026-08-31), `high`/`xhigh` → Opus 4.8. L'alias `model:` se résout automatiquement vers la dernière version, donc `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` pointe désormais vers Sonnet 5. Fable 5 est suspendu — ne pas l'utiliser. Grille complète prix/routage : [FAQ](../../FAQ.md).
+
 ### Utiliser l'Agent de Recherche
 
 ```markdown

--- a/docs/guides/pt/03-feature-development.md
+++ b/docs/guides/pt/03-feature-development.md
@@ -56,6 +56,8 @@ Para fases de análise que exigem raciocínio profundo, defina alto esforço:
 
 Use `/effort low` para buscas simples e `/effort medium` para trabalho de implementação padrão.
 
+> **Modelos atuais (junho de 2026):** `low` → Haiku 4.5, `medium` → **Sonnet 5** (`claude-sonnet-5`, lançado em 2026-06-30 — agêntico, preço inicial $2/$10 por M tokens até 2026-08-31), `high`/`xhigh` → Opus 4.8. O alias `model:` resolve automaticamente para a versão mais recente, então `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` agora aponta para Sonnet 5. Fable 5 está suspenso — não usar. Tabela completa de preços/roteamento: [FAQ](../../FAQ.md).
+
 ### Usando o Comando de Análise
 
 ```bash


### PR DESCRIPTION
Aligns the training guides (`docs/guides`, 5 languages) with the v8.19.0 release.

The version/CC/RULES_LANG/references-layout fixes already shipped in v8.19.0 (#117). This adds the **current model lineup** to the effort section of guide 03 in all 5 languages:
- `low` → Haiku 4.5, `medium` → **Sonnet 5** (`claude-sonnet-5`, intro $2/$10 → $3/$15 on 2026-08-31), `high`/`xhigh` → Opus 4.8
- the `model: sonnet` alias now resolves to Sonnet 5; **Fable 5 is suspended** — do not use
- links to the FAQ pricing/routing grid

`LEARNING-PATHS.md` and `10-complete-workflow.md` use model aliases (version-agnostic) — already correct. i18n parity (count + size 0.80) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)