### PR TITLE
chore(release): v8.19.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,7 +2,7 @@
   "$schema": "https://claude.ai/schemas/plugin.json",
   "name": "claude-craft",
   "displayName": "Claude Craft",
-  "version": "8.19.0",
+  "version": "8.19.1",
   "description": "Multi-stack framework for Claude Code teams: 11 stacks, BMAD v6 sprint workflow, browser QA automation, and Kanban — for tech leads adopting Claude Code with their team.",
   "author": {
     "name": "Flavien Métivier",

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,6 +1,6 @@
 # Claude-Craft - Multi-Technology Framework
 
-**Version:** 8.19.0 | **Languages:** en, fr, es, de, pt
+**Version:** 8.19.1 | **Languages:** en, fr, es, de, pt
 
 A comprehensive AI-assisted development framework for Claude Code with 11 technology stacks, 31 specialized agents (+39 infra agents on-demand), 126 commands across 15 namespaces, and BMAD v6 project management.
 

--- a/.claude/COMPATIBILITY.md
+++ b/.claude/COMPATIBILITY.md
@@ -1,4 +1,4 @@
-# Claude Code Compatibility — Claude Craft v8.19.0
+# Claude Code Compatibility — Claude Craft v8.19.1
 
 **Minimum Version:** 2.1.97 (elevated from 2.1.47 — see [rationale](#why-we-elevated-minimum-from-2147-to-2197))
 **Recommended Version:** 2.1.193 (Opus 4.8, Artifacts, `claude mcp login`, `/cd`, nested subagents — Week 26, June 26, 2026)
@@ -266,7 +266,7 @@ Features available in Claude Code 2.1.119–2.1.145 and their adoption status in
 | Feature | Description | Adoption Claude Craft |
 |---------|-------------|----------------------|
 | `alwaysLoad` MCP server config | Servers non-différés (chargement immédiat) | **Not documented** |
-| PostToolUse replace tool output | Hooks peuvent remplacer l'output de **tous** les outils | **Adopté** (v8.19.0) — `templates/hooks/output-filter.json` tronque réellement les outputs >50KB via `hookSpecificOutput.updatedToolOutput` |
+| PostToolUse replace tool output | Hooks peuvent remplacer l'output de **tous** les outils | **Adopté** (v8.19.1) — `templates/hooks/output-filter.json` tronque réellement les outputs >50KB via `hookSpecificOutput.updatedToolOutput` |
 | `claude plugin prune` | Nettoyer les dépendances orphelines | **N/A** (user CLI) |
 | Type-to-filter dans `/skills` | Recherche dans le picker de skills | **N/A** (user feature) |
 
@@ -359,7 +359,7 @@ Features available in Claude Code 2.1.119–2.1.145 and their adoption status in
 | Feature | Description | Adoption Claude Craft |
 |---------|-------------|----------------------|
 | **Claude Opus 4.8** (`claude-opus-4-8`) | Nouveau modèle flagship, même prix qu'Opus 4.7, **défaut effort `high`** + `/effort xhigh` pour les tâches les plus dures. Disponible API/Bedrock/Vertex/Foundry | **Recommandé** — modèle cible pour agents `effort: xhigh`/`max` (security-auditor, migration-specialist, database-architect, ralph-conductor) |
-| **Dynamic Workflows** | Demander à Claude de créer un workflow qui orchestre **des dizaines à des centaines d'agents** en arrière-plan (cap 1000 subagents). Visible via `/workflows` | **Adopté** (v8.19.0) — skill [`dynamic-workflows`](../skills/dynamic-workflows/SKILL.md) : 3 paliers d'orchestration, patterns (fan-out, vérification adversariale, pipeline, loop-until-dry), monitoring `/workflows` |
+| **Dynamic Workflows** | Demander à Claude de créer un workflow qui orchestre **des dizaines à des centaines d'agents** en arrière-plan (cap 1000 subagents). Visible via `/workflows` | **Adopté** (v8.19.1) — skill [`dynamic-workflows`](../skills/dynamic-workflows/SKILL.md) : 3 paliers d'orchestration, patterns (fan-out, vérification adversariale, pipeline, loop-until-dry), monitoring `/workflows` |
 | Fast mode moins cher sur Opus 4.8 | 2× le tarif standard pour 2,5× la vitesse | **N/A** (user pricing) |
 | `effort: max` | 5ᵉ niveau d'effort (au-dessus de `xhigh`), disponible sur Opus 4.8 | **Documented** — voir docs/AGENTS.md tableau effort |
 | `/effort ultracode` | Nouveau palier effort introduit avec Dynamic Workflows / Opus 4.8 — mode optimisé débit code (vitesse maximale, idéal pipelines automatisés) ; équivalent `effort: max` en CLI | **Documented** — documenter dans `rules/12-context-management.md` tableau efforts |

--- a/.claude/context-essentials.md
+++ b/.claude/context-essentials.md
@@ -1,7 +1,7 @@
 # Claude Craft - Contexte Essentiel
 
 ## Projet
-- **Version:** 8.19.0
+- **Version:** 8.19.1
 - **Type:** Framework multi-technologie pour Claude Code
 - **Stacks:** 19 (Symfony, React, Flutter, Python, Angular, Vue.js, Laravel, React Native, C#/.NET, PHP, Paperclip, Docker, Coolify, Kubernetes, OpenTofu, Ansible, Hcloud, PgBouncer, FrankenPHP)
 - **Agents:** 72 | **Commandes:** 211 | **Namespaces:** 26

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.19.1] - 2026-07-01
+
+### Fixed
+
+- **Workflow SBOM** : pins corrigés (`@cyclonedx/cyclonedx-npm@5`, `sigstore/cosign-installer@v3.10.1` — les versions `@6`/`@v3.8.1` introduites en 8.19.0 n'existaient pas) ; étape de signature cosign keyless passée en `continue-on-error` (l'OIDC keyless n'est dispo que sur le dépôt upstream). Vérifié vert via `workflow_dispatch`. La publication NPM de 8.19.0 n'était pas affectée.
+
+### Changed
+
+- **Migration js-yaml 4 → 5** (`^4.2.0` → `^5.2.0`) : js-yaml 5 est ESM-only (exports nommés, plus de `default`) et **lève désormais une exception sur une entrée vide**. 7 fichiers passés à `import * as yaml from 'js-yaml'` ; `sprint-cache.js` et `frontmatter.js` traitent un fichier/frontmatter vide comme `null`/`{}` (le YAML malformé lève toujours). Remplace Dependabot #111.
+- **Bumps de dépendances** (Dependabot) : eslint 10.6.0, prettier 3.9.3, @commitlint 21.1.0 (dev) ; @playwright/test 1.61.1, @axe-core/playwright 4.12.1 (website) ; `actions/cache` 6.1.0 ; @hono/node-server 2.0.6.
+- **Formations** : lineup modèles courant ajouté à la section effort du guide 03 (5 langues) — Haiku 4.5 / **Sonnet 5** / Opus 4.8, alias `model: sonnet` = Sonnet 5, Fable 5 suspendu.
+
 ## [8.19.0] - 2026-06-30
 
 Audit exhaustif multi-agents (18 lentilles : 7 domaines + 11 stacks, vérification adverse — 70/90 findings confirmés). Rapport : `audit/2026-06-30/00-AUDIT-REPORT.md`.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -353,7 +353,7 @@ All 22 common and reviewer agents now include optimized frontmatter:
 
 - **Effort control**: Each agent specifies `effort: low|medium|high|xhigh|max` to optimize reasoning depth (`xhigh`/`max` since Claude Code 2.1.111+/2.1.154 with Opus 4.8)
 - **Persistent memory**: 18 agents use `memory: user` or `memory: project` for cross-session knowledge
-- **Model distribution** (31 agent files): **4 opus + xhigh** (critical reasoning — database-architect, migration-specialist, ralph-conductor, security-auditor), **12 sonnet** (standard common agents + tdd-coach, moved off Opus in v8.19.0 for cost-efficiency), **15 haiku + low** (all 11 tech reviewers + accessibility-expert, cost-optimizer, performance-auditor, research-assistant). Opus reserved for high-stakes work; reviewers stay on haiku for cost-efficient read-only review.
+- **Model distribution** (31 agent files): **4 opus + xhigh** (critical reasoning — database-architect, migration-specialist, ralph-conductor, security-auditor), **12 sonnet** (standard common agents + tdd-coach, moved off Opus in v8.19.1 for cost-efficiency), **15 haiku + low** (all 11 tech reviewers + accessibility-expert, cost-optimizer, performance-auditor, research-assistant). Opus reserved for high-stakes work; reviewers stay on haiku for cost-efficient read-only review.
 
 ## Advanced Frontmatter (Claude Code 2.1.119+)
 

--- a/docs/MIGRATION.md
+++ b/docs/MIGRATION.md
@@ -9,7 +9,7 @@
 > | v6.x → v7 | [MIGRATION-v7.md](MIGRATION-v7.md) |
 > | v7.x → v8 | [MIGRATION-v7-to-v8.md](MIGRATION-v7-to-v8.md) |
 >
-> Always upgrade one major version at a time. The current release is **v8.19.0**.
+> Always upgrade one major version at a time. The current release is **v8.19.1**.
 
 This guide explains how to migrate from the legacy rules format to the official Claude Code skills format.
 

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -60,7 +60,7 @@ Replace `react` with your technology: `symfony`, `flutter`, `python`, `angular`,
 **What you should see:**
 
 ```
-  Claude Craft v8.19.0 - AI Development Framework
+  Claude Craft v8.19.1 - AI Development Framework
 
   Installing react rules to /home/user/my-project...
   [OK] Common rules installed

--- a/docs/SKILLS.md
+++ b/docs/SKILLS.md
@@ -270,7 +270,7 @@ ls ~/my-project/.claude/skills/
 | **Total unique** | **55** |
 | **With i18n (×5)** | **275** |
 
-> **Note :** Skills are counted across the full distribution (55 unique skills as of v8.19.0). The table above groups them by primary audience; many common skills (e.g. `security`, `testing`, `solid-principles`) are applicable to all stacks.
+> **Note :** Skills are counted across the full distribution (55 unique skills as of v8.19.1). The table above groups them by primary audience; many common skills (e.g. `security`, `testing`, `solid-principles`) are applicable to all stacks.
 
 The 55 skills include: `adapter-development`, `aggregates`, `api-gateway`, `architect`, `architecture`, `architecture-clean-ddd`, `architecture-paperclip`, `async`, `atomic-tasks`, `coding-standards`, `coding-standards-ts`, `cqrs`, `ddd-patterns`, `debug-methodical`, `design-md-convention`, `docker-hadolint`, `doctrine-extensions`, `documentation`, `domain-events`, `ecosystem-tools`, `edge-computing`, `event-driven`, `git-workflow`, `graphql`, `i18n`, `kiss-dry-yagni`, `monorepo`, `multitenant`, `navigation`, `observability`, `paperclip-onboarding`, `parallel-worktrees`, `performance`, `quality-tools`, `remotion`, `security`, `security-flutter`, `security-paperclip`, `security-react`, `security-reactnative`, `security-symfony`, `socratic-brainstorm`, `solid-principles`, `state-management`, `testing`, `testing-flutter`, `testing-paperclip`, `testing-python`, `testing-react`, `testing-reactnative`, `testing-symfony`, `tooling`, `value-objects`, `wasm`, `workflow-analysis`.
 

--- a/docs/comparison-claude-craft-vs-superclaude.md
+++ b/docs/comparison-claude-craft-vs-superclaude.md
@@ -2,7 +2,7 @@
 
 > **TL;DR :** SuperClaude is a viral, single-prompt persona library optimised for individual developers. Claude Craft is a multi-stack, team-oriented framework with sprint workflow and browser-based QA. They solve different problems for different audiences. This page compares them honestly so you can pick the right tool.
 
-**Last updated :** 2026-06-27 | **Claude Craft v8.19.0** | **SuperClaude v4.x (snapshot 2026-06)**
+**Last updated :** 2026-06-27 | **Claude Craft v8.19.1** | **SuperClaude v4.x (snapshot 2026-06)**
 
 > **Looking for the broader market picture?** This page is the user-facing, single-competitor comparison. For the full strategic landscape (all competitors, SWOT, roadmap), see the maintainer doc [`COMPETITIVE-ANALYSIS.md`](COMPETITIVE-ANALYSIS.md).
 

--- a/docs/guides/de/10-complete-workflow.md
+++ b/docs/guides/de/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Was wir bauen:** *TaskFlow* — ein kleines SaaS zur Aufgabenverfolgung im Team mit einer REST-API (Python / FastAPI) und einem React-Web-Client. Einfach genug, um es in einer Sitzung nachzuvollziehen, real genug, um den gesamten Workflow zu durchlaufen.
 >
-> **Claude Craft v8.19.0** · Geschätzte Lese- und Übungszeit: 60–90 Minuten.
+> **Claude Craft v8.19.1** · Geschätzte Lese- und Übungszeit: 60–90 Minuten.
 
 ---
 

--- a/docs/guides/en/10-complete-workflow.md
+++ b/docs/guides/en/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **What we build:** *TaskFlow* — a small team task-tracking SaaS with a REST API (Python / FastAPI) and a React web client. It is simple enough to follow in one sitting, real enough to exercise the whole workflow.
 >
-> **Claude Craft v8.19.0** · Estimated reading + doing time: 60–90 minutes.
+> **Claude Craft v8.19.1** · Estimated reading + doing time: 60–90 minutes.
 
 ---
 

--- a/docs/guides/es/10-complete-workflow.md
+++ b/docs/guides/es/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Qué construimos:** *TaskFlow* — un SaaS de seguimiento de tareas para equipos pequeños con una API REST (Python / FastAPI) y un cliente web en React. Es lo suficientemente sencillo para seguirlo en una sola sesión, y lo suficientemente real para ejercitar todo el flujo de trabajo.
 >
-> **Claude Craft v8.19.0** · Tiempo estimado de lectura + práctica: 60–90 minutos.
+> **Claude Craft v8.19.1** · Tiempo estimado de lectura + práctica: 60–90 minutos.
 
 ---
 

--- a/docs/guides/fr/10-complete-workflow.md
+++ b/docs/guides/fr/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **Ce qu'on construit :** *TaskFlow* — un petit SaaS de suivi des tâches d'équipe avec une API REST (Python / FastAPI) et un client web React. Suffisamment simple pour être suivi en une séance, suffisamment réel pour exercer l'ensemble du workflow.
 >
-> **Claude Craft v8.19.0** · Durée estimée de lecture + pratique : 60–90 minutes.
+> **Claude Craft v8.19.1** · Durée estimée de lecture + pratique : 60–90 minutes.
 
 ---
 

--- a/docs/guides/pt/10-complete-workflow.md
+++ b/docs/guides/pt/10-complete-workflow.md
@@ -4,7 +4,7 @@
 >
 > **O que vamos construir:** *TaskFlow* — um pequeno SaaS de acompanhamento de tarefas para equipes, com uma API REST (Python / FastAPI) e um cliente web em React. É simples o suficiente para seguir em uma única sessão e real o suficiente para exercitar todo o fluxo de trabalho.
 >
-> **Claude Craft v8.19.0** · Tempo estimado de leitura + execução: 60–90 minutos.
+> **Claude Craft v8.19.1** · Tempo estimado de leitura + execução: 60–90 minutos.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@the-bearded-bear/claude-craft",
-  "version": "8.19.0",
+  "version": "8.19.1",
   "description": "A comprehensive framework for AI-assisted development with Claude Code. Install standardized rules, agents, and commands for your projects.",
   "type": "module",
   "main": "cli/index.js",

--- a/website/.vitepress/theme/LandingPage.vue
+++ b/website/.vitepress/theme/LandingPage.vue
@@ -17,7 +17,7 @@ const translations = {
     nav_tools: "Tools",
     nav_install: "Install",
     nav_tech: "Tech Stack",
-    hero_badge: "v8.19.0 - Claude Code 2.1.193",
+    hero_badge: "v8.19.1 - Claude Code 2.1.193",
     hero_title_1: "Supercharge",
     hero_title_2: "with Expert Knowledge",
     hero_desc: "A comprehensive framework for AI-assisted development. Install standardized rules, agents, and commands for your projects across multiple technology stacks.",
@@ -73,7 +73,7 @@ const translations = {
     nav_tools: "Outils",
     nav_install: "Installation",
     nav_tech: "Technologies",
-    hero_badge: "v8.19.0 - Claude Code 2.1.193",
+    hero_badge: "v8.19.1 - Claude Code 2.1.193",
     hero_title_1: "Superchargez",
     hero_title_2: "d'une Expertise Technique",
     hero_desc: "Un framework complet pour le d\u00e9veloppement assist\u00e9 par IA. Installez des r\u00e8gles, agents et commandes standardis\u00e9s pour vos projets.",
@@ -126,7 +126,7 @@ const translations = {
   },
   es: {
     nav_features: "Caracter\u00edsticas", nav_tools: "Herramientas", nav_install: "Instalaci\u00f3n", nav_tech: "Tecnolog\u00edas",
-    hero_badge: "v8.19.0 - Claude Code 2.1.193", hero_title_1: "Potencia", hero_title_2: "con Conocimiento Experto",
+    hero_badge: "v8.19.1 - Claude Code 2.1.193", hero_title_1: "Potencia", hero_title_2: "con Conocimiento Experto",
     hero_desc: "Un marco integral para el desarrollo asistido por IA.", cta_get_started: "Empezar", cta_docs: "Documentaci\u00f3n",
     feat_main_title: "Todo lo que necesitas para escalar", feat_main_desc: "Equipa a Claude con herramientas conscientes del contexto.",
     feat_bmad_title: "Framework BMAD v6", feat_bmad_desc: "9 agentes Agent-as-Code, 5 Quality Gates.",
@@ -154,7 +154,7 @@ const translations = {
   },
   de: {
     nav_features: "Funktionen", nav_tools: "Werkzeuge", nav_install: "Installation", nav_tech: "Technologien",
-    hero_badge: "v8.19.0 - Claude Code 2.1.193", hero_title_1: "Laden Sie", hero_title_2: "mit Expertenwissen auf",
+    hero_badge: "v8.19.1 - Claude Code 2.1.193", hero_title_1: "Laden Sie", hero_title_2: "mit Expertenwissen auf",
     hero_desc: "Ein umfassendes Framework f\u00fcr KI-gest\u00fctzte Entwicklung.", cta_get_started: "Loslegen", cta_docs: "Dokumentation",
     feat_main_title: "Alles f\u00fcr skalierbare KI-Entwicklung", feat_main_desc: "Statten Sie Claude mit kontextbezogenen Tools aus.",
     feat_bmad_title: "BMAD v6 Framework", feat_bmad_desc: "9 Agent-as-Code Personas, 5 Quality Gates.",
@@ -182,7 +182,7 @@ const translations = {
   },
   pt: {
     nav_features: "Funcionalidades", nav_tools: "Ferramentas", nav_install: "Instala\u00e7\u00e3o", nav_tech: "Tecnologias",
-    hero_badge: "v8.19.0 - Claude Code 2.1.193", hero_title_1: "Turbine o", hero_title_2: "com Conhecimento Especializado",
+    hero_badge: "v8.19.1 - Claude Code 2.1.193", hero_title_1: "Turbine o", hero_title_2: "com Conhecimento Especializado",
     hero_desc: "Um framework abrangente para desenvolvimento assistido por IA.", cta_get_started: "Come\u00e7ar", cta_docs: "Documenta\u00e7\u00e3o",
     feat_main_title: "Tudo para escalar", feat_main_desc: "Equipe o Claude com ferramentas conscientes do contexto.",
     feat_bmad_title: "Framework BMAD v6", feat_bmad_desc: "9 agentes Agent-as-Code, 5 Quality Gates.",
@@ -344,8 +344,8 @@ onMounted(() => {
           <p style="margin-top: 1rem; font-size: 1.25rem; color: #94a3b8;">{{ t('feat_main_desc') }}</p>
         </div>
         <div class="grid-3col" style="display: grid; grid-template-columns: repeat(3, 1fr); gap: 2rem;">
-          <FeatureCard icon="git-branch" color="cyan" :badge="'v8.19.0'" :title="t('feat_bmad_title')" :desc="t('feat_bmad_desc')" />
-          <FeatureCard icon="repeat" color="orange" :badge="'v8.19.0'" :title="t('feat_ralph_title')" :desc="t('feat_ralph_desc')" />
+          <FeatureCard icon="git-branch" color="cyan" :badge="'v8.19.1'" :title="t('feat_bmad_title')" :desc="t('feat_bmad_desc')" />
+          <FeatureCard icon="repeat" color="orange" :badge="'v8.19.1'" :title="t('feat_ralph_title')" :desc="t('feat_ralph_desc')" />
           <FeatureCard icon="globe" color="brand" :title="t('feat_1_title')" :desc="t('feat_1_desc')" />
           <FeatureCard icon="bot" color="blue" :title="t('feat_2_title')" :desc="t('feat_2_desc')" />
           <FeatureCard icon="sparkles" color="emerald" :title="t('feat_skills_title')" :desc="t('feat_skills_desc')" />

--- a/website/.vitepress/theme/components/AgentShowcase.vue
+++ b/website/.vitepress/theme/components/AgentShowcase.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 const agents = [
   { name: 'bmad-master', desc: 'BMAD orchestrator: routing, gates enforcement, sprint lifecycle, batch processing.', color: '#22d3ee', badge: 'BMAD v6', badgeBg: 'rgba(6,182,212,0.2)', borderColor: 'rgba(6,182,212,0.3)' },
-  { name: 'ralph-conductor', desc: 'v2.0: Adaptive profiles, hooks integration, health monitoring, and DoD templates.', color: '#fb923c', badge: 'v8.19.0', badgeBg: 'rgba(249,115,22,0.2)', borderColor: 'rgba(249,115,22,0.3)' },
+  { name: 'ralph-conductor', desc: 'v2.0: Adaptive profiles, hooks integration, health monitoring, and DoD templates.', color: '#fb923c', badge: 'v8.19.1', badgeBg: 'rgba(249,115,22,0.2)', borderColor: 'rgba(249,115,22,0.3)' },
   { name: 'uiux-orchestrator', desc: 'Coordinates UI, UX, and Accessibility experts for holistic design solutions.', color: '#f472b6', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },
   { name: 'product-owner', desc: 'Helps with user stories, backlog prioritization, and sprint planning.', color: '#fbbf24', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },
   { name: 'accessibility-expert', desc: 'Ensures WCAG 2.2 AAA compliance and ARIA best practices.', color: '#2dd4bf', badge: null, badgeBg: null, borderColor: 'rgba(51,65,85,1)' },


### PR DESCRIPTION
Dependency + supply-chain follow-up release to v8.19.0.

- **SBOM workflow fixed**: corrected the non-existent pins from 8.19.0 (`cyclonedx@5`, `cosign-installer@v3.10.1`) + keyless sign step `continue-on-error`. Verified green via `workflow_dispatch`. The **next tag now produces a green SBOM** natively.
- **js-yaml 4 → 5 migration** (supersedes Dependabot #111): ESM-only named exports, empty-input now throws → `import * as yaml`, empty file/frontmatter handled gracefully.
- **Dependabot bumps merged**: eslint 10.6, prettier 3.9.3, commitlint 21.1.0, @playwright/test 1.61.1, @axe-core/playwright 4.12.1, actions/cache 6.1.0, @hono/node-server 2.0.6.
- **Training**: guide 03 current-model lineup (Sonnet 5) in 5 languages.

✅ verify-versions, i18n parity, 1117/1117 vitest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)