### PR TITLE
chore(ci): group codeql-action init/analyze dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,6 +34,10 @@ updates:
     labels:
       - "github-actions"
       - "automated"
+    groups:
+      codeql-action:
+        patterns:
+          - "github/codeql-action/*"
 
   - package-ecosystem: "docker"
     directory: "/tests/e2e/tools"


### PR DESCRIPTION
## Summary
- Fixes recurring CodeQL "configuration error" seen on #123 and #125: `github/codeql-action/init` and `github/codeql-action/analyze` were bumped by Dependabot in separate PRs, so merging one without the other left the two steps pinned to different codeql-action versions, which the CodeQL CLI rejects (`Loaded a configuration file for version X, but running version Y`).
- Adds a `groups: codeql-action:` block to the `github-actions` ecosystem in `.github/dependabot.yml` so `github/codeql-action/*` always bumps in a single PR going forward.

## Test plan
- [x] No workflow files touched, no runtime behavior change — only Dependabot config
- [x] Next weekly Dependabot run will show a single grouped PR for codeql-action instead of two (not verifiable synchronously)