### PR TITLE
feat(common): add /common:audit-claude-alignment weekly ecosystem audit

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,7 +2,7 @@
 
 **Version:** 8.22.0 | **Languages:** en, fr, es, de, pt
 
-A comprehensive AI-assisted development framework for Claude Code with 13 technology stacks, 33 specialized agents (+39 infra agents on-demand), 139 commands across 17 namespaces, and BMAD v6 project management.
+A comprehensive AI-assisted development framework for Claude Code with 13 technology stacks, 33 specialized agents (+39 infra agents on-demand), 140 commands across 17 namespaces, and BMAD v6 project management.
 
 ---
 

--- a/.claude/commands/common/aliases.md
+++ b/.claude/commands/common/aliases.md
@@ -19,6 +19,7 @@ These aliases reduce typing and improve productivity by providing short mnemonic
 | Alias | Full Command | Description |
 |-------|-------------|-------------|
 | `/ca` | `/common:audit-freshness` | Audit documentation freshness |
+| `/caa` | `/common:audit-claude-alignment` | Weekly Claude ecosystem alignment audit |
 | `/ci` | `/common:init` | Initialize Claude Craft |
 | `/cr` | `/common:release-checklist` | Pre-release verification checklist |
 | `/cs` | `/common:setup-project-context` | Setup project context for Claude |
@@ -123,6 +124,7 @@ Add to `~/.bashrc` or `~/.zshrc`:
 ```bash
 # Claude Craft Aliases
 alias ca='claude-code -p /common:audit-freshness'
+alias caa='claude-code -p /common:audit-claude-alignment'
 alias ci='claude-code -p /common:init'
 alias cr='claude-code -p /common:release-checklist'
 alias cs='claude-code -p /common:setup-project-context'
@@ -156,6 +158,7 @@ Add to `~/.config/fish/config.fish`:
 ```fish
 # Claude Craft Aliases
 alias ca 'claude-code -p /common:audit-freshness'
+alias caa 'claude-code -p /common:audit-claude-alignment'
 alias ci 'claude-code -p /common:init'
 alias cr 'claude-code -p /common:release-checklist'
 alias cs 'claude-code -p /common:setup-project-context'

--- a/.claude/commands/common/audit-claude-alignment.md
+++ b/.claude/commands/common/audit-claude-alignment.md
@@ -1,0 +1,201 @@
+---
+description: "Audit hebdomadaire d'alignement sur l'écosystème Claude (CLI, modèles, best practices Anthropic, communauté) via équipe d'agents + PR de correction"
+argument-hint: "[--quick|--full] [--lens=<nom>] [--since=YYYY-MM-DD] [--dry-run] [--no-pr]"
+model: sonnet
+---
+
+# Audit d'alignement Claude — claude-craft
+
+Vérifie que claude-craft reste aligné sur l'état réel de l'écosystème Claude : version du CLI Claude Code, modèles et pricing, best practices Anthropic, features de la plateforme, avis de sécurité, et pratiques de la communauté.
+
+Complémentaire de `/common:audit-freshness`, qui couvre les stacks applicatifs (React, Symfony, Flutter…) et **jamais Claude Code lui-même**.
+
+**Résultat :** rapport `docs/audit/claude-alignment/<date>.md` + `<date>.json`, et une **PR** portant uniquement les corrections mécaniques. Tout ce qui demande un jugement part en checklist dans le corps de la PR, jamais en édition automatique.
+
+## Arguments
+
+$ARGUMENTS
+
+- `--quick` (défaut) : n'audite que les lentilles dont la source externe a bougé depuis la baseline
+- `--full` : force les 7 lentilles, effort `high` sur sécurité et modèles — cadence mensuelle
+- `--lens=<nom>` : une seule lentille (`cli-release`, `models-pricing`, `prompt-context`, `cc-features`, `security-cve`, `community`, `internal-conformance`)
+- `--since=YYYY-MM-DD` : force la date de baseline — rattrapage après un trou de cadence
+- `--dry-run` : pré-collecte + liste des agents qui seraient lancés. **Aucun agent, aucune écriture**
+- `--no-pr` : rapport seul, ni branche ni PR
+
+## MISSION
+
+### Étape 0 — Pré-vol et pré-collecte
+
+1. **Worktree propre obligatoire.** `git status --porcelain` ; si la sortie n'est pas vide, **arrêter** et le signaler. Des agents d'audit ont déjà pollué le worktree par le passé — on ne construit pas une PR par-dessus des modifications non validées.
+2. Lancer la pré-collecte déterministe (coût LLM nul) :
+   ```bash
+   node scripts/collect-claude-signals.mjs [--since=<date>] [--dry-run]
+   ```
+   Elle lit `config/claude-alignment-baseline.json`, interroge le registry npm, les avis de sécurité GitHub, le catalogue communautaire et les pages de doc suivies par empreinte, puis écrit `docs/audit/claude-alignment/signals-<date>.json`.
+3. Lire ce fichier. Le champ **`agents_to_launch`** est la liste exacte des lentilles à réveiller. Une lentille absente n'est **pas** auditée : écrire `✅ aucun changement depuis <baseline.last_run>` dans le rapport, sans lancer d'agent. C'est le principal levier de coût de cette commande.
+4. Calculer l'âge du dernier run (`baseline.last_run` → aujourd'hui). Au-delà de **10 jours**, ouvrir le rapport par un avertissement de cadence.
+5. En `--full`, ignorer `agents_to_launch` et retenir les 7 lentilles. En `--lens=<nom>`, ne retenir que celle-là. En `--dry-run`, s'arrêter ici en affichant la liste retenue et le coût estimé.
+
+### Étape 1 — Gates locaux (0 token)
+
+Lancer, et consigner le résultat de chacun dans le rapport :
+
+```bash
+npm run lint:versions   # cohérence tech-registry ↔ versions.yaml + denylist dans les fichiers vitrine
+npm run lint:includes   # liens @<path> fantômes
+npm run docs:check      # dérive des références générées
+npm run lint:i18n       # parité i18n (comptage + taille)
+```
+
+Un gate rouge est un finding **P1** au minimum. Ne pas le corriger ici : il alimente le patch-plan de l'étape 3.
+
+### Étape 2 — Équipe d'agents (un seul message, N appels Task en parallèle)
+
+Lancer **en un seul message** un agent par lentille retenue. Le routing modèle n'est pas négociable : il est ce qui rend l'audit hebdomadaire soutenable.
+
+| Lentille | `subagent_type` | `model` | `effort` |
+|---|---|---|---|
+| `cli-release` | `general-purpose` | `sonnet` | `medium` |
+| `models-pricing` | `general-purpose` | `sonnet` | `medium` (`high` en `--full`) |
+| `cc-features` | `claude-code-guide` | *(défaut de l'agent)* | — |
+| `prompt-context` | `general-purpose` | `sonnet` | `medium` |
+| `security-cve` | `general-purpose` | `sonnet` | `medium` (`high` en `--full`) |
+| `community` | `general-purpose` | `sonnet` | `medium` |
+| `internal-conformance` | `general-purpose` | `haiku` | `low` |
+
+`internal-conformance` est un scan mécanique 100 % local : son prompt lui **interdit explicitement** WebSearch et WebFetch. Les six autres reçoivent les URLs exactes issues de `signals-<date>.json` — ils font du WebFetch ciblé, pas de la découverte par WebSearch (non déterministe et multi-requêtes).
+
+**Socle commun à injecter dans chaque prompt d'agent :**
+
+```
+Tu audites la lentille "<LENTILLE>" du dépôt claude-craft (framework Claude Code, v<version de package.json>).
+
+CONTEXTE PRÉ-COLLECTÉ (ne pas re-chercher ce qui est déjà donné) :
+<coller le bloc lenses["<LENTILLE>"] de docs/audit/claude-alignment/signals-<date>.json>
+Baseline du dernier audit : <baseline.last_run>
+
+ÉTAPES :
+1. Lire les fichiers du dépôt listés ci-dessous : <PATHS>
+2. Confronter au réel via les sources fournies (WebFetch sur les URLs exactes ci-dessus).
+   Ne remonter QUE ce qui a changé depuis la baseline.
+3. Retourner EXACTEMENT ce format (< 300 mots) :
+
+## <LENTILLE>
+- **État déclaré dans le repo** : <valeur> (source: <path>:<ligne>)
+- **État réel observé** : <valeur> (source: <URL>)
+- **Écart** : aucun | mineur | majeur | critique
+- **Findings** :
+  - [<sévérité P0-P3>] <constat> — source: <URL>
+- **PATCH** : (uniquement les substitutions mécaniques sûres, une par ligne)
+  - <chemin> | <valeur actuelle> | <valeur cible> | <raison>
+- **JUGEMENT REQUIS** : (ce qui demande un arbitrage humain, jamais de PATCH)
+  - <point> — pourquoi ça ne peut pas être automatisé
+
+CONTRAINTES :
+- Citer une source pour CHAQUE affirmation. Si une info est introuvable, écrire "non trouvé".
+- Ne rien inventer, ne pas extrapoler une version depuis un numéro voisin.
+- Ne JAMAIS modifier un fichier. Tu es en lecture seule.
+- Un PATCH n'est légitime que si la substitution est littérale et sans ambiguïté
+  (numéro de version, identifiant de modèle, date). Toute reformulation de prose
+  va en JUGEMENT REQUIS.
+```
+
+**Cibles par lentille :**
+
+| Lentille | Fichiers du dépôt à confronter |
+|---|---|
+| `cli-release` | `config/versions.yaml` (`claudeCode.*`), `.claude/COMPATIBILITY.md`, `.claude/rules/12-context-management.md`, `docs/PREREQUISITES.md` |
+| `models-pricing` | `config/versions.yaml` (`claudeCode.models`, `denylist`), `.claude/rules/12-context-management.md`, `.claude/settings.json`, `.claude/settings.local.json.example` — charger le skill `claude-api` pour la référence modèles/pricing |
+| `cc-features` | `.claude/COMPATIBILITY.md`, `.claude/settings.json`, `.claude-plugin/plugin.json`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md` — identifier les features de la plateforme non encore adoptées |
+| `prompt-context` | `.claude/rules/12-context-management.md`, `.claude/rules/23-karpathy-principles.md`, `.claude/CLAUDE.md` |
+| `security-cve` | `.claude/rules/11-security.md`, `.claude/settings.json` (permissions), `.claude/COMPATIBILITY.md` (section CVE) |
+| `community` | `.claude/skills/ecosystem-tools/SKILL.md`, `docs/ECOSYSTEM.md` |
+| `internal-conformance` | Les 3 inventaires : `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `.claude/commands/**/*.md`. Vérifier : frontmatter YAML parsable et `description` non vide ; `context: fork` présent sur tout skill de plus de 60 lignes ; cohérence `model:`/`effort:` (un agent `haiku` ne doit pas être en `effort: xhigh`) ; hooks lisant leur payload sur **stdin via `jq`** et jamais via `$TOOL_INPUT` ; aucun token de `denylist` hors fichiers vitrine |
+
+### Étape 3 — Synthèse, rapport, patch-plan
+
+1. Agréger les retours. Un agent qui a échoué laisse `⚠️ audit incomplet : <raison>` — ne jamais inventer sa section.
+2. Écrire `docs/audit/claude-alignment/<date>.md` :
+
+```markdown
+# Audit d'alignement Claude — <date>
+
+**Version claude-craft** : <package.json>
+**Mode** : quick | full
+**Baseline** : <date> (<N> jours) <⚠️ si > 10 jours>
+**Lentilles auditées** : <n>/7 — <liste> (les autres inchangées depuis la baseline)
+
+## Résumé exécutif
+
+| Sévérité | Nombre |
+|----------|--------|
+| 🔴 P0 | N |
+| 🟠 P1 | N |
+| 🟡 P2 | N |
+| 🔵 P3 | N |
+
+## Gates locaux
+
+| Gate | Résultat |
+|------|----------|
+| lint:versions | ✅ / ❌ <extrait> |
+| lint:includes | … |
+| docs:check | … |
+| lint:i18n | … |
+
+## Findings par lentille
+<coller chaque rapport d'agent>
+
+## Patch-plan appliqué
+| Fichier | Avant | Après | Raison |
+|---|---|---|---|
+
+## Jugement humain requis
+- [ ] <point> — <pourquoi>
+
+## Méthodologie
+- Pré-collecte : `scripts/collect-claude-signals.mjs` (npm registry, GitHub advisories, empreintes de pages, catalogue communautaire)
+- Agents : <n> (routing sonnet/haiku documenté dans la commande)
+- Sources : toutes citées dans les sections ci-dessus
+```
+
+3. Écrire le jumeau structuré `docs/audit/claude-alignment/<date>.json` : `{ audit_date, mode, baseline, lenses{}, summary{P0..P3}, patch_plan[], human_decisions_required[], gates{} }`.
+
+### Étape 4 — Branche et PR
+
+Sauter entièrement cette étape si `--no-pr`, `--dry-run`, ou si le patch-plan est vide.
+
+1. `git checkout -b chore/claude-alignment-<date>` depuis `main` à jour.
+2. Appliquer **uniquement** les entrées du patch-plan, et **uniquement** dans l'allowlist :
+   - `config/versions.yaml` — `claudeCode.recommended|testedUpTo|models.*`, `meta.lastUpdated`, ajouts en `denylist`
+   - `.claude/COMPATIBILITY.md` — bandeau d'en-tête et ajout de lignes dans la table `Version Requirements`
+   - Substitutions de version littérales dans les fichiers de `SHOWCASE_FILES` (`scripts/verify-versions.mjs`)
+   - `Dev/i18n/<lang>/Common/templates/settings.json.template` et `Dev/i18n/<lang>/Common/rules/12-context-management.md` (les 5 langues, en une seule passe cohérente)
+   - `config/claude-alignment-baseline.json` — remplacer par `next_baseline` du fichier de signaux
+3. **Interdit, sans exception** : `.github/workflows/` (le token `gh` n'a pas le scope `workflow`, la PR deviendrait non mergeable), tout fichier hors allowlist, toute reformulation de prose, tout fichier `.md` de documentation générée (`docs/*-FULL-REFERENCE.md` : passer par `npm run docs:generate`).
+4. Rejouer les 4 gates. **Un seul rouge ⇒ pas de PR** : laisser la branche en place et l'expliquer dans le rapport.
+5. `git add` limité aux fichiers de l'allowlist effectivement modifiés, puis commit en Conventional Commits :
+   `chore(alignment): sync Claude Code <ancienne> → <nouvelle> + modèles`
+6. `gh pr create` avec, dans le corps : le résumé exécutif, le tableau du patch-plan, et la checklist « jugement humain requis ». **Jamais de merge automatique.**
+7. Revenir sur `main` et confirmer à l'utilisateur l'URL de la PR.
+
+## Règles strictes
+
+- **Worktree propre** en préalable absolu ; sinon, arrêt immédiat.
+- **Aucune édition hors allowlist**, et aucune édition du tout tant que les gates ne sont pas verts.
+- **Toute affirmation de version cite une source** (URL ou `path:ligne`).
+- **Fail-open assumé** : une source injoignable rend la lentille « à auditer », jamais « rien à signaler ».
+- **Un agent en échec** laisse `⚠️ audit incomplet : <raison>` — pas de section inventée.
+- **Parallélisme obligatoire** : un seul message contenant tous les appels Task de l'étape 2.
+- **Langue du rapport** : français, avec accents.
+
+## Exemples
+
+```
+/common:audit-claude-alignment                          # rituel hebdomadaire
+/common:audit-claude-alignment --dry-run                # quelles lentilles bougeraient ? coût nul
+/common:audit-claude-alignment --full                   # passage mensuel approfondi
+/common:audit-claude-alignment --lens=cli-release --no-pr
+/common:audit-claude-alignment --since=2026-06-30       # rattrapage après un trou de cadence
+```

--- a/.claude/commands/common/search.md
+++ b/.claude/commands/common/search.md
@@ -102,7 +102,8 @@ When a user invokes `/common:search <keyword>`:
 | `architecture` | architecture skill, @database-architect |
 | `react` | /react:* commands, @react-reviewer |
 | `symfony` | /symfony:* commands, @symfony-reviewer |
-| `audit` | /team:audit, /common:audit-freshness |
+| `audit` | /team:audit, /common:audit-freshness, /common:audit-claude-alignment |
+| `claude code` | /common:audit-claude-alignment, .claude/COMPATIBILITY.md |
 | `workflow` | /workflow:* commands, workflow-analysis skill |
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`/common:audit-claude-alignment`** : audit hebdomadaire d'alignement sur l'écosystème Claude lui-même — version du CLI Claude Code, identifiants et pricing des modèles, best practices Anthropic (prompt/context engineering), features de la plateforme (hooks, skills, sous-agents, MCP, plugins, settings), avis de sécurité, et pratiques de la communauté. Comble l'angle mort de `/common:audit-freshness`, qui ne couvre que les stacks applicatifs.
+  - `scripts/collect-claude-signals.mjs` : pré-collecte déterministe (registry npm, GitHub Security Advisories, catalogue `awesome-claude-code`, empreintes SHA-256 des pages de doc sans API). Elle décide, sans appeler de modèle, quelles lentilles méritent un sous-agent — une lentille dont la source n'a pas bougé n'en déclenche aucun. Conception fail-open : une source injoignable rend la lentille « à auditer », jamais « rien à signaler ».
+  - Équipe de 7 lentilles avec routing modèle explicite : `haiku`/`effort: low` pour le scan de conformité local, `sonnet`/`medium` pour l'interprétation de changelogs et d'advisories, agent `claude-code-guide` pour les features de la plateforme. Aucun agent `opus`.
+  - Sortie : rapport `docs/audit/claude-alignment/<date>.md` + jumeau JSON, et une PR portant **uniquement** des substitutions de version littérales sur une allowlist (`config/versions.yaml`, `.claude/COMPATIBILITY.md`, fichiers vitrine, templates i18n). Tout ce qui demande un arbitrage part en checklist dans la PR. Garde-fous : worktree propre exigé, `.github/workflows/` interdit, 4 gates CI verts avant ouverture, jamais de merge automatique.
+  - État incrémental versionné dans `config/claude-alignment-baseline.json` ; cible `make audit-claude-alignment` pour le rituel hebdomadaire.
+  - Première exécution : dérive réelle constatée de **2.1.193 → 2.1.227** sur le CLI Claude Code (`config/versions.yaml` et `.claude/COMPATIBILITY.md` figés au 2026-06-30).
+
+### Fixed
+
+- **`scripts/collect-claude-signals.mjs`** : le catalogue `awesome-claude-code` a été renommé upstream (`THE_RESOURCES_TABLE.csv` → `THE_RESOURCES_TABLE_NEW.csv`), l'URL historique renvoie 404. Le collecteur essaie les deux noms dans l'ordre. `scripts/awesome-claude-code-submit.mjs` porte encore l'URL périmée — à corriger séparément.
+
 ## [8.22.0] - 2026-07-22
 
 ### Added

--- a/Dev/i18n/base/Common/commands/aliases.md
+++ b/Dev/i18n/base/Common/commands/aliases.md
@@ -19,6 +19,7 @@ These aliases reduce typing and improve productivity by providing short mnemonic
 | Alias | Full Command | Description |
 |-------|-------------|-------------|
 | `/ca` | `/common:audit-freshness` | Audit documentation freshness |
+| `/caa` | `/common:audit-claude-alignment` | Weekly Claude ecosystem alignment audit |
 | `/ci` | `/common:init` | Initialize Claude Craft |
 | `/cr` | `/common:release-checklist` | Pre-release verification checklist |
 | `/cs` | `/common:setup-project-context` | Setup project context for Claude |
@@ -123,6 +124,7 @@ Add to `~/.bashrc` or `~/.zshrc`:
 ```bash
 # Claude Craft Aliases
 alias ca='claude-code -p /common:audit-freshness'
+alias caa='claude-code -p /common:audit-claude-alignment'
 alias ci='claude-code -p /common:init'
 alias cr='claude-code -p /common:release-checklist'
 alias cs='claude-code -p /common:setup-project-context'
@@ -156,6 +158,7 @@ Add to `~/.config/fish/config.fish`:
 ```fish
 # Claude Craft Aliases
 alias ca 'claude-code -p /common:audit-freshness'
+alias caa 'claude-code -p /common:audit-claude-alignment'
 alias ci 'claude-code -p /common:init'
 alias cr 'claude-code -p /common:release-checklist'
 alias cs 'claude-code -p /common:setup-project-context'

--- a/Dev/i18n/base/Common/commands/audit-claude-alignment.md
+++ b/Dev/i18n/base/Common/commands/audit-claude-alignment.md
@@ -1,0 +1,201 @@
+---
+description: "Audit hebdomadaire d'alignement sur l'écosystème Claude (CLI, modèles, best practices Anthropic, communauté) via équipe d'agents + PR de correction"
+argument-hint: "[--quick|--full] [--lens=<nom>] [--since=YYYY-MM-DD] [--dry-run] [--no-pr]"
+model: sonnet
+---
+
+# Audit d'alignement Claude — claude-craft
+
+Vérifie que claude-craft reste aligné sur l'état réel de l'écosystème Claude : version du CLI Claude Code, modèles et pricing, best practices Anthropic, features de la plateforme, avis de sécurité, et pratiques de la communauté.
+
+Complémentaire de `/common:audit-freshness`, qui couvre les stacks applicatifs (React, Symfony, Flutter…) et **jamais Claude Code lui-même**.
+
+**Résultat :** rapport `docs/audit/claude-alignment/<date>.md` + `<date>.json`, et une **PR** portant uniquement les corrections mécaniques. Tout ce qui demande un jugement part en checklist dans le corps de la PR, jamais en édition automatique.
+
+## Arguments
+
+$ARGUMENTS
+
+- `--quick` (défaut) : n'audite que les lentilles dont la source externe a bougé depuis la baseline
+- `--full` : force les 7 lentilles, effort `high` sur sécurité et modèles — cadence mensuelle
+- `--lens=<nom>` : une seule lentille (`cli-release`, `models-pricing`, `prompt-context`, `cc-features`, `security-cve`, `community`, `internal-conformance`)
+- `--since=YYYY-MM-DD` : force la date de baseline — rattrapage après un trou de cadence
+- `--dry-run` : pré-collecte + liste des agents qui seraient lancés. **Aucun agent, aucune écriture**
+- `--no-pr` : rapport seul, ni branche ni PR
+
+## MISSION
+
+### Étape 0 — Pré-vol et pré-collecte
+
+1. **Worktree propre obligatoire.** `git status --porcelain` ; si la sortie n'est pas vide, **arrêter** et le signaler. Des agents d'audit ont déjà pollué le worktree par le passé — on ne construit pas une PR par-dessus des modifications non validées.
+2. Lancer la pré-collecte déterministe (coût LLM nul) :
+   ```bash
+   node scripts/collect-claude-signals.mjs [--since=<date>] [--dry-run]
+   ```
+   Elle lit `config/claude-alignment-baseline.json`, interroge le registry npm, les avis de sécurité GitHub, le catalogue communautaire et les pages de doc suivies par empreinte, puis écrit `docs/audit/claude-alignment/signals-<date>.json`.
+3. Lire ce fichier. Le champ **`agents_to_launch`** est la liste exacte des lentilles à réveiller. Une lentille absente n'est **pas** auditée : écrire `✅ aucun changement depuis <baseline.last_run>` dans le rapport, sans lancer d'agent. C'est le principal levier de coût de cette commande.
+4. Calculer l'âge du dernier run (`baseline.last_run` → aujourd'hui). Au-delà de **10 jours**, ouvrir le rapport par un avertissement de cadence.
+5. En `--full`, ignorer `agents_to_launch` et retenir les 7 lentilles. En `--lens=<nom>`, ne retenir que celle-là. En `--dry-run`, s'arrêter ici en affichant la liste retenue et le coût estimé.
+
+### Étape 1 — Gates locaux (0 token)
+
+Lancer, et consigner le résultat de chacun dans le rapport :
+
+```bash
+npm run lint:versions   # cohérence tech-registry ↔ versions.yaml + denylist dans les fichiers vitrine
+npm run lint:includes   # liens @<path> fantômes
+npm run docs:check      # dérive des références générées
+npm run lint:i18n       # parité i18n (comptage + taille)
+```
+
+Un gate rouge est un finding **P1** au minimum. Ne pas le corriger ici : il alimente le patch-plan de l'étape 3.
+
+### Étape 2 — Équipe d'agents (un seul message, N appels Task en parallèle)
+
+Lancer **en un seul message** un agent par lentille retenue. Le routing modèle n'est pas négociable : il est ce qui rend l'audit hebdomadaire soutenable.
+
+| Lentille | `subagent_type` | `model` | `effort` |
+|---|---|---|---|
+| `cli-release` | `general-purpose` | `sonnet` | `medium` |
+| `models-pricing` | `general-purpose` | `sonnet` | `medium` (`high` en `--full`) |
+| `cc-features` | `claude-code-guide` | *(défaut de l'agent)* | — |
+| `prompt-context` | `general-purpose` | `sonnet` | `medium` |
+| `security-cve` | `general-purpose` | `sonnet` | `medium` (`high` en `--full`) |
+| `community` | `general-purpose` | `sonnet` | `medium` |
+| `internal-conformance` | `general-purpose` | `haiku` | `low` |
+
+`internal-conformance` est un scan mécanique 100 % local : son prompt lui **interdit explicitement** WebSearch et WebFetch. Les six autres reçoivent les URLs exactes issues de `signals-<date>.json` — ils font du WebFetch ciblé, pas de la découverte par WebSearch (non déterministe et multi-requêtes).
+
+**Socle commun à injecter dans chaque prompt d'agent :**
+
+```
+Tu audites la lentille "<LENTILLE>" du dépôt claude-craft (framework Claude Code, v<version de package.json>).
+
+CONTEXTE PRÉ-COLLECTÉ (ne pas re-chercher ce qui est déjà donné) :
+<coller le bloc lenses["<LENTILLE>"] de docs/audit/claude-alignment/signals-<date>.json>
+Baseline du dernier audit : <baseline.last_run>
+
+ÉTAPES :
+1. Lire les fichiers du dépôt listés ci-dessous : <PATHS>
+2. Confronter au réel via les sources fournies (WebFetch sur les URLs exactes ci-dessus).
+   Ne remonter QUE ce qui a changé depuis la baseline.
+3. Retourner EXACTEMENT ce format (< 300 mots) :
+
+## <LENTILLE>
+- **État déclaré dans le repo** : <valeur> (source: <path>:<ligne>)
+- **État réel observé** : <valeur> (source: <URL>)
+- **Écart** : aucun | mineur | majeur | critique
+- **Findings** :
+  - [<sévérité P0-P3>] <constat> — source: <URL>
+- **PATCH** : (uniquement les substitutions mécaniques sûres, une par ligne)
+  - <chemin> | <valeur actuelle> | <valeur cible> | <raison>
+- **JUGEMENT REQUIS** : (ce qui demande un arbitrage humain, jamais de PATCH)
+  - <point> — pourquoi ça ne peut pas être automatisé
+
+CONTRAINTES :
+- Citer une source pour CHAQUE affirmation. Si une info est introuvable, écrire "non trouvé".
+- Ne rien inventer, ne pas extrapoler une version depuis un numéro voisin.
+- Ne JAMAIS modifier un fichier. Tu es en lecture seule.
+- Un PATCH n'est légitime que si la substitution est littérale et sans ambiguïté
+  (numéro de version, identifiant de modèle, date). Toute reformulation de prose
+  va en JUGEMENT REQUIS.
+```
+
+**Cibles par lentille :**
+
+| Lentille | Fichiers du dépôt à confronter |
+|---|---|
+| `cli-release` | `config/versions.yaml` (`claudeCode.*`), `.claude/COMPATIBILITY.md`, `.claude/rules/12-context-management.md`, `docs/PREREQUISITES.md` |
+| `models-pricing` | `config/versions.yaml` (`claudeCode.models`, `denylist`), `.claude/rules/12-context-management.md`, `.claude/settings.json`, `.claude/settings.local.json.example` — charger le skill `claude-api` pour la référence modèles/pricing |
+| `cc-features` | `.claude/COMPATIBILITY.md`, `.claude/settings.json`, `.claude-plugin/plugin.json`, `.claude/agents/*.md`, `.claude/skills/*/SKILL.md` — identifier les features de la plateforme non encore adoptées |
+| `prompt-context` | `.claude/rules/12-context-management.md`, `.claude/rules/23-karpathy-principles.md`, `.claude/CLAUDE.md` |
+| `security-cve` | `.claude/rules/11-security.md`, `.claude/settings.json` (permissions), `.claude/COMPATIBILITY.md` (section CVE) |
+| `community` | `.claude/skills/ecosystem-tools/SKILL.md`, `docs/ECOSYSTEM.md` |
+| `internal-conformance` | Les 3 inventaires : `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`, `.claude/commands/**/*.md`. Vérifier : frontmatter YAML parsable et `description` non vide ; `context: fork` présent sur tout skill de plus de 60 lignes ; cohérence `model:`/`effort:` (un agent `haiku` ne doit pas être en `effort: xhigh`) ; hooks lisant leur payload sur **stdin via `jq`** et jamais via `$TOOL_INPUT` ; aucun token de `denylist` hors fichiers vitrine |
+
+### Étape 3 — Synthèse, rapport, patch-plan
+
+1. Agréger les retours. Un agent qui a échoué laisse `⚠️ audit incomplet : <raison>` — ne jamais inventer sa section.
+2. Écrire `docs/audit/claude-alignment/<date>.md` :
+
+```markdown
+# Audit d'alignement Claude — <date>
+
+**Version claude-craft** : <package.json>
+**Mode** : quick | full
+**Baseline** : <date> (<N> jours) <⚠️ si > 10 jours>
+**Lentilles auditées** : <n>/7 — <liste> (les autres inchangées depuis la baseline)
+
+## Résumé exécutif
+
+| Sévérité | Nombre |
+|----------|--------|
+| 🔴 P0 | N |
+| 🟠 P1 | N |
+| 🟡 P2 | N |
+| 🔵 P3 | N |
+
+## Gates locaux
+
+| Gate | Résultat |
+|------|----------|
+| lint:versions | ✅ / ❌ <extrait> |
+| lint:includes | … |
+| docs:check | … |
+| lint:i18n | … |
+
+## Findings par lentille
+<coller chaque rapport d'agent>
+
+## Patch-plan appliqué
+| Fichier | Avant | Après | Raison |
+|---|---|---|---|
+
+## Jugement humain requis
+- [ ] <point> — <pourquoi>
+
+## Méthodologie
+- Pré-collecte : `scripts/collect-claude-signals.mjs` (npm registry, GitHub advisories, empreintes de pages, catalogue communautaire)
+- Agents : <n> (routing sonnet/haiku documenté dans la commande)
+- Sources : toutes citées dans les sections ci-dessus
+```
+
+3. Écrire le jumeau structuré `docs/audit/claude-alignment/<date>.json` : `{ audit_date, mode, baseline, lenses{}, summary{P0..P3}, patch_plan[], human_decisions_required[], gates{} }`.
+
+### Étape 4 — Branche et PR
+
+Sauter entièrement cette étape si `--no-pr`, `--dry-run`, ou si le patch-plan est vide.
+
+1. `git checkout -b chore/claude-alignment-<date>` depuis `main` à jour.
+2. Appliquer **uniquement** les entrées du patch-plan, et **uniquement** dans l'allowlist :
+   - `config/versions.yaml` — `claudeCode.recommended|testedUpTo|models.*`, `meta.lastUpdated`, ajouts en `denylist`
+   - `.claude/COMPATIBILITY.md` — bandeau d'en-tête et ajout de lignes dans la table `Version Requirements`
+   - Substitutions de version littérales dans les fichiers de `SHOWCASE_FILES` (`scripts/verify-versions.mjs`)
+   - `Dev/i18n/<lang>/Common/templates/settings.json.template` et `Dev/i18n/<lang>/Common/rules/12-context-management.md` (les 5 langues, en une seule passe cohérente)
+   - `config/claude-alignment-baseline.json` — remplacer par `next_baseline` du fichier de signaux
+3. **Interdit, sans exception** : `.github/workflows/` (le token `gh` n'a pas le scope `workflow`, la PR deviendrait non mergeable), tout fichier hors allowlist, toute reformulation de prose, tout fichier `.md` de documentation générée (`docs/*-FULL-REFERENCE.md` : passer par `npm run docs:generate`).
+4. Rejouer les 4 gates. **Un seul rouge ⇒ pas de PR** : laisser la branche en place et l'expliquer dans le rapport.
+5. `git add` limité aux fichiers de l'allowlist effectivement modifiés, puis commit en Conventional Commits :
+   `chore(alignment): sync Claude Code <ancienne> → <nouvelle> + modèles`
+6. `gh pr create` avec, dans le corps : le résumé exécutif, le tableau du patch-plan, et la checklist « jugement humain requis ». **Jamais de merge automatique.**
+7. Revenir sur `main` et confirmer à l'utilisateur l'URL de la PR.
+
+## Règles strictes
+
+- **Worktree propre** en préalable absolu ; sinon, arrêt immédiat.
+- **Aucune édition hors allowlist**, et aucune édition du tout tant que les gates ne sont pas verts.
+- **Toute affirmation de version cite une source** (URL ou `path:ligne`).
+- **Fail-open assumé** : une source injoignable rend la lentille « à auditer », jamais « rien à signaler ».
+- **Un agent en échec** laisse `⚠️ audit incomplet : <raison>` — pas de section inventée.
+- **Parallélisme obligatoire** : un seul message contenant tous les appels Task de l'étape 2.
+- **Langue du rapport** : français, avec accents.
+
+## Exemples
+
+```
+/common:audit-claude-alignment                          # rituel hebdomadaire
+/common:audit-claude-alignment --dry-run                # quelles lentilles bougeraient ? coût nul
+/common:audit-claude-alignment --full                   # passage mensuel approfondi
+/common:audit-claude-alignment --lens=cli-release --no-pr
+/common:audit-claude-alignment --since=2026-06-30       # rattrapage après un trou de cadence
+```

--- a/Dev/i18n/base/Common/commands/search.md
+++ b/Dev/i18n/base/Common/commands/search.md
@@ -102,7 +102,8 @@ When a user invokes `/common:search <keyword>`:
 | `architecture` | architecture skill, @database-architect |
 | `react` | /react:* commands, @react-reviewer |
 | `symfony` | /symfony:* commands, @symfony-reviewer |
-| `audit` | /team:audit, /common:audit-freshness |
+| `audit` | /team:audit, /common:audit-freshness, /common:audit-claude-alignment |
+| `claude code` | /common:audit-claude-alignment, .claude/COMPATIBILITY.md |
 | `workflow` | /workflow:* commands, workflow-analysis skill |
 
 ---

--- a/Makefile
+++ b/Makefile
@@ -149,6 +149,22 @@ test-all: ## Lance tous les tests (vitest + bats)
 	@npm test && $(MAKE) test-bats
 
 #===============================================================================
+# Audit d'alignement Claude (rituel hebdomadaire)
+#===============================================================================
+
+# Pre-collecte deterministe : decide quelles lentilles d'audit meritent un agent
+# cette semaine. Cout LLM nul. L'audit complet se lance ensuite dans Claude Code
+# via /common:audit-claude-alignment.
+audit-claude-signals: ## Collecte les signaux Claude (npm, advisories, empreintes de pages)
+	@node scripts/collect-claude-signals.mjs $(if $(SINCE),--since=$(SINCE))
+
+audit-claude-alignment: ## Rituel hebdo : affiche les lentilles a auditer puis la commande a lancer
+	@node scripts/collect-claude-signals.mjs --dry-run $(if $(SINCE),--since=$(SINCE)) | head -3
+	@echo ""
+	@echo "Lancer ensuite dans Claude Code :"
+	@echo "  /common:audit-claude-alignment$(if $(SINCE), --since=$(SINCE))"
+
+#===============================================================================
 # Configuration YAML
 #===============================================================================
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Plus **11 stack-specific reviewers** (@symfony-reviewer, @react-reviewer, @pytho
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Mutation testing badge](https://img.shields.io/endpoint?style=flat&url=https%3A%2F%2Fbadge-api.stryker-mutator.io%2Fgithub.com%2FTheBeardedBearSAS%2Fclaude-craft%2Fmain)](https://dashboard.stryker-mutator.io/reports/github.com/TheBeardedBearSAS/claude-craft/main)
 
-A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **33 specialized agents (+39 infra agents on-demand), 139 commands across 17 namespaces (233 total), 55 skills**, all token-optimized via `context: fork` and sub-agent model routing.
+A comprehensive framework for AI-assisted development with [Claude Code](https://claude.ai/code). Install standardized rules, agents, and commands for your projects across multiple technology stacks — **33 specialized agents (+39 infra agents on-demand), 140 commands across 17 namespaces (234 total), 55 skills**, all token-optimized via `context: fork` and sub-agent model routing.
 
 ## What's New in v8.18.0
 

--- a/config/claude-alignment-baseline.json
+++ b/config/claude-alignment-baseline.json
@@ -1,0 +1,13 @@
+{
+  "_comment": "État incrémental de /common:audit-claude-alignment. Écrit par la commande à la fin d'un run validé, lu par scripts/collect-claude-signals.mjs pour ne réveiller que les lentilles dont la source a bougé. Ne pas éditer à la main hors amorçage.",
+  "schema_version": 1,
+  "last_run": "2026-06-30",
+  "cli_version_seen": "2.1.193",
+  "page_hashes": {
+    "models-pricing": null,
+    "prompt-context": null,
+    "cc-features": null
+  },
+  "community_csv_hash": null,
+  "advisories_seen": []
+}

--- a/docs/COMMANDS-FULL-REFERENCE.md
+++ b/docs/COMMANDS-FULL-REFERENCE.md
@@ -9,7 +9,7 @@
 |-----------|-------|
 | `/angular:*` | 6 |
 | `/ansible:*` | 5 |
-| `/common:*` | 19 |
+| `/common:*` | 20 |
 | `/coolify:*` | 5 |
 | `/csharp:*` | 6 |
 | `/docker:*` | 5 |
@@ -36,7 +36,7 @@
 | `/vite:*` | 7 |
 | `/vuejs:*` | 6 |
 | `/workflow:*` | 10 |
-| **Total** | **233** |
+| **Total** | **234** |
 
 ## `/angular:*`
 
@@ -66,6 +66,7 @@
 | [`/common:add-technology`](../.claude/commands/common/add-technology.md) | Ajouter une nouvelle technologie à claude-craft avec les best practices de Context7 et recherche web |
 | [`/common:aliases`](../.claude/commands/common/aliases.md) | CLI aliases for frequently used commands |
 | [`/common:architecture-decision`](../.claude/commands/common/architecture-decision.md) | Architecture Decision Record (ADR) |
+| [`/common:audit-claude-alignment`](../.claude/commands/common/audit-claude-alignment.md) | Audit hebdomadaire d'alignement sur l'écosystème Claude (CLI, modèles, best practices Anthropic, communauté) via équipe d'agents + PR de correction |
 | [`/common:audit-freshness`](../.claude/commands/common/audit-freshness.md) | Audit de fraîcheur multi-stack (versions + best practices) via équipe d'agents parallèles Context7 + Web |
 | [`/common:daily-standup`](../.claude/commands/common/daily-standup.md) | Génération Résumé Daily Stand-up |
 | [`/common:generate-changelog`](../.claude/commands/common/generate-changelog.md) | Génération Automatique du Changelog |

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "commitlint": "commitlint --edit",
     "prepublishOnly": "node -e \"import{readFileSync}from'node:fs';const p=JSON.parse(readFileSync('./package.json','utf8'));if(!/^\\d+\\.\\d+\\.\\d+(-[a-z0-9.]+)?$/i.test(p.version)){console.error('Invalid version format');process.exit(1)}\"",
     "metrics:adoption": "node scripts/track-adoption-metrics.mjs",
+    "audit:claude-signals": "node scripts/collect-claude-signals.mjs",
     "mutation": "stryker run",
     "mutation:ci": "stryker run --reporters progress,json",
     "test:e2e:tools": "cd tests/e2e/tools && docker compose -f docker-compose.test.yml up --abort-on-container-exit --exit-code-from e2e-runner",

--- a/scripts/collect-claude-signals.mjs
+++ b/scripts/collect-claude-signals.mjs
@@ -1,0 +1,322 @@
+#!/usr/bin/env node
+/**
+ * collect-claude-signals.mjs — pré-collecte déterministe pour
+ * `/common:audit-claude-alignment`.
+ *
+ * Rôle : décider, SANS appeler de modèle, quelles lentilles d'audit méritent un
+ * sous-agent cette semaine. Chaque lentille dont la source externe n'a pas bougé
+ * depuis la baseline est court-circuitée : la commande écrit « aucun changement »
+ * dans le rapport et n'invoque aucun agent. C'est le principal levier de coût de
+ * l'audit hebdomadaire.
+ *
+ * Conception fail-open : une source injoignable marque la lentille « à auditer »
+ * plutôt que « rien à signaler ». Une panne réseau ne doit jamais se traduire par
+ * un angle mort silencieux.
+ *
+ * Usage :
+ *   node scripts/collect-claude-signals.mjs [--since=YYYY-MM-DD] [--dry-run]
+ *   npm run audit:claude-signals
+ *
+ * @module scripts/collect-claude-signals
+ */
+import { createHash } from 'node:crypto';
+import { mkdir, writeFile } from 'node:fs/promises';
+import { existsSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const PROJECT_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const DEFAULT_BASELINE = path.join(PROJECT_ROOT, 'config', 'claude-alignment-baseline.json');
+const DEFAULT_OUT_DIR = path.join(PROJECT_ROOT, 'docs', 'audit', 'claude-alignment');
+
+const NPM_REGISTRY = 'https://registry.npmjs.org/@anthropic-ai/claude-code';
+const ADVISORIES = 'https://api.github.com/repos/anthropics/claude-code/security-advisories';
+/**
+ * Catalogue communautaire. Le nom du fichier a déjà bougé upstream
+ * (`THE_RESOURCES_TABLE.csv` → `..._NEW.csv`) : on essaie les candidats dans
+ * l'ordre plutôt que de fail-open chaque semaine sur un 404 permanent, ce qui
+ * coûterait un agent par run sans jamais rien apprendre.
+ */
+const COMMUNITY_CSV_CANDIDATES = [
+  'https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/THE_RESOURCES_TABLE_NEW.csv',
+  'https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/THE_RESOURCES_TABLE.csv',
+];
+
+/**
+ * Pages sans API structurée : on suit leur contenu par empreinte. Modifier une
+ * URL ici suffit à réorienter la lentille correspondante.
+ *
+ * Suffixe `.md` obligatoire — c'est la source markdown servie par la doc. Le
+ * HTML rendu embarque un nonce qui change à CHAQUE requête : deux fetchs à
+ * quelques secondes d'intervalle donnent la même taille mais deux empreintes
+ * différentes, ce qui ferait croire à un changement toutes les semaines et
+ * réveillerait un agent pour rien. Le markdown est stable, et 30× plus léger
+ * (27 Ko contre 873 Ko) — les agents le récupèrent aussi à moindre coût.
+ */
+const WATCHED_PAGES = {
+  'models-pricing': 'https://docs.claude.com/en/docs/about-claude/models/overview.md',
+  'prompt-context': 'https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/overview.md',
+  'cc-features': 'https://docs.claude.com/en/docs/claude-code/settings.md',
+};
+
+/** Ordre canonique des lentilles — dicte l'ordre de `agents_to_launch`. */
+const LENSES = [
+  'cli-release',
+  'models-pricing',
+  'prompt-context',
+  'cc-features',
+  'security-cve',
+  'community',
+  'internal-conformance',
+];
+
+const UA = { 'User-Agent': 'claude-craft-alignment/1.0' };
+
+/**
+ * Empreinte stable d'un contenu textuel, insensible à la mise en forme.
+ * Tronquée à 16 caractères : suffisant pour de la détection de changement,
+ * lisible dans la baseline versionnée.
+ */
+export function hashOf(text) {
+  const normalized = String(text).replace(/\s+/g, ' ').trim();
+  return createHash('sha256').update(normalized).digest('hex').slice(0, 16);
+}
+
+/**
+ * Compare deux versions segment par segment, numériquement.
+ * Indispensable : en comparaison de chaînes, '2.1.9' passerait pour plus récent
+ * que '2.1.193'.
+ *
+ * @returns {number} > 0 si `a` est plus récente, < 0 si plus ancienne, 0 si égales
+ */
+export function compareVersions(a, b) {
+  const parse = (v) =>
+    String(v)
+      .split('.')
+      .map((seg) => parseInt(seg, 10) || 0);
+  const left = parse(a);
+  const right = parse(b);
+  const len = Math.max(left.length, right.length);
+  for (let i = 0; i < len; i += 1) {
+    const diff = (left[i] ?? 0) - (right[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+async function fetchJson(url) {
+  const res = await fetch(url, { headers: { ...UA, Accept: 'application/vnd.github+json' } });
+  if (!res.ok) throw new Error(`${url} → ${res.status} ${res.statusText}`);
+  return res.json();
+}
+
+async function fetchText(url) {
+  const res = await fetch(url, { headers: UA });
+  if (!res.ok) throw new Error(`${url} → ${res.status} ${res.statusText}`);
+  return res.text();
+}
+
+/** Premier candidat qui répond. Échoue avec l'erreur du dernier essai. */
+async function fetchFirstOk(urls) {
+  let last;
+  for (const url of urls) {
+    try {
+      return { url, text: await fetchText(url) };
+    } catch (err) {
+      last = err;
+    }
+  }
+  throw last;
+}
+
+function readBaseline(baselinePath) {
+  if (!existsSync(baselinePath)) return null;
+  return JSON.parse(readFileSync(baselinePath, 'utf8'));
+}
+
+/** Version de Claude Code actuellement déclarée par la source de vérité du repo. */
+function declaredCliVersion(baseline) {
+  return baseline?.cli_version_seen ?? null;
+}
+
+/**
+ * Collecte les signaux et calcule le delta vs baseline.
+ *
+ * @param {object} opts
+ * @param {string} [opts.baselinePath] chemin de la baseline versionnée
+ * @param {string} [opts.outDir] répertoire du fichier de signaux daté
+ * @param {Date}   [opts.now] horloge injectable (tests)
+ * @param {string} [opts.since] force la date de baseline (rattrapage de cadence)
+ * @param {boolean}[opts.write] false pour ne rien écrire (--dry-run)
+ */
+export async function collectSignals(opts = {}) {
+  const baselinePath = opts.baselinePath ?? DEFAULT_BASELINE;
+  const outDir = opts.outDir ?? DEFAULT_OUT_DIR;
+  const now = opts.now ?? new Date();
+  const write = opts.write !== false;
+  const date = now.toISOString().slice(0, 10);
+
+  const stored = readBaseline(baselinePath);
+  const baselineMissing = stored === null;
+  const baseline = {
+    schema_version: 1,
+    last_run: null,
+    cli_version_seen: null,
+    page_hashes: {},
+    community_csv_hash: null,
+    advisories_seen: [],
+    ...(stored ?? {}),
+  };
+  if (opts.since) baseline.last_run = opts.since;
+
+  const lenses = {};
+  const errors = {};
+
+  /** Marque une lentille « à auditer » sans pouvoir conclure (fail-open). */
+  const failOpen = (lens, err) => {
+    errors[lens] = err.message;
+    lenses[lens] = { changed: true, reason: 'collecte impossible — lentille à auditer par précaution' };
+  };
+
+  const [npmRes, advisoriesRes, csvRes, ...pageResults] = await Promise.allSettled([
+    fetchJson(NPM_REGISTRY),
+    fetchJson(ADVISORIES),
+    fetchFirstOk(COMMUNITY_CSV_CANDIDATES),
+    ...Object.values(WATCHED_PAGES).map((url) => fetchText(url)),
+  ]);
+
+  // --- Lentille 1 : version du CLI Claude Code ---------------------------------
+  const declared = declaredCliVersion(baseline);
+  if (npmRes.status === 'fulfilled') {
+    const observed = npmRes.value?.['dist-tags']?.latest ?? null;
+    const changed = baselineMissing || !declared || !observed || compareVersions(observed, declared) > 0;
+    lenses['cli-release'] = {
+      changed,
+      declared,
+      observed,
+      sources: [NPM_REGISTRY, 'https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md'],
+    };
+  } else {
+    failOpen('cli-release', npmRes.reason);
+    lenses['cli-release'].declared = declared;
+  }
+
+  // --- Lentilles 2-4 : pages suivies par empreinte -----------------------------
+  Object.keys(WATCHED_PAGES).forEach((lens, i) => {
+    const result = pageResults[i];
+    if (result.status !== 'fulfilled') {
+      failOpen(lens, result.reason);
+      lenses[lens].sources = [WATCHED_PAGES[lens]];
+      return;
+    }
+    const before = baseline.page_hashes?.[lens] ?? null;
+    const after = hashOf(result.value);
+    lenses[lens] = {
+      changed: baselineMissing || before === null || before !== after,
+      hash_before: before,
+      hash_after: after,
+      sources: [WATCHED_PAGES[lens]],
+    };
+  });
+
+  // --- Lentille 5 : advisories de sécurité -------------------------------------
+  if (advisoriesRes.status === 'fulfilled') {
+    const seen = new Set(baseline.advisories_seen ?? []);
+    const all = Array.isArray(advisoriesRes.value) ? advisoriesRes.value : [];
+    const ids = all.map((a) => a.ghsa_id).filter(Boolean);
+    const fresh = ids.filter((id) => !seen.has(id));
+    lenses['security-cve'] = {
+      changed: baselineMissing || fresh.length > 0,
+      new_advisories: fresh,
+      known_count: ids.length,
+      sources: [ADVISORIES],
+    };
+  } else {
+    failOpen('security-cve', advisoriesRes.reason);
+    lenses['security-cve'].sources = [ADVISORIES];
+  }
+
+  // --- Lentille 6 : catalogue communautaire ------------------------------------
+  if (csvRes.status === 'fulfilled') {
+    const before = baseline.community_csv_hash ?? null;
+    const after = hashOf(csvRes.value.text);
+    lenses.community = {
+      changed: baselineMissing || before === null || before !== after,
+      hash_before: before,
+      hash_after: after,
+      row_count: csvRes.value.text.split('\n').filter((l) => l.trim() !== '').length,
+      sources: [csvRes.value.url],
+    };
+  } else {
+    failOpen('community', csvRes.reason);
+    lenses.community.sources = COMMUNITY_CSV_CANDIDATES;
+  }
+
+  // --- Lentille 7 : conformité interne -----------------------------------------
+  // Scan local pur (frontmatters, context: fork, cohérence model/effort). Aucune
+  // source réseau, coût quasi nul en haiku : toujours lancée.
+  lenses['internal-conformance'] = {
+    changed: true,
+    reason: 'scan local systématique — indépendant de toute source externe',
+    sources: [],
+  };
+
+  const agentsToLaunch = LENSES.filter((lens) => lenses[lens]?.changed);
+
+  // Baseline suivante : on ne fige que ce qu'on a réellement pu observer, pour
+  // éviter qu'une panne réseau n'écrase un état connu par du vide.
+  const nextBaseline = {
+    schema_version: 1,
+    last_run: date,
+    cli_version_seen: lenses['cli-release'].observed ?? baseline.cli_version_seen,
+    page_hashes: Object.fromEntries(
+      Object.keys(WATCHED_PAGES).map((lens) => [lens, lenses[lens].hash_after ?? baseline.page_hashes?.[lens] ?? null])
+    ),
+    community_csv_hash: lenses.community.hash_after ?? baseline.community_csv_hash,
+    advisories_seen:
+      advisoriesRes.status === 'fulfilled'
+        ? [...new Set([...(baseline.advisories_seen ?? []), ...lenses['security-cve'].new_advisories])]
+        : (baseline.advisories_seen ?? []),
+  };
+
+  const result = {
+    generated_at: now.toISOString(),
+    date,
+    baseline_missing: baselineMissing,
+    baseline: { last_run: baseline.last_run, cli_version_seen: baseline.cli_version_seen },
+    lenses,
+    agents_to_launch: agentsToLaunch,
+    errors,
+    next_baseline: nextBaseline,
+  };
+
+  if (write) {
+    await mkdir(outDir, { recursive: true });
+    await writeFile(path.join(outDir, `signals-${date}.json`), `${JSON.stringify(result, null, 2)}\n`, 'utf8');
+  }
+
+  return result;
+}
+
+function parseArgs(argv) {
+  const opts = {};
+  for (const arg of argv) {
+    if (arg === '--dry-run') opts.write = false;
+    else if (arg.startsWith('--since=')) opts.since = arg.slice('--since='.length);
+    else if (arg.startsWith('--baseline=')) opts.baselinePath = arg.slice('--baseline='.length);
+    else if (arg.startsWith('--out=')) opts.outDir = arg.slice('--out='.length);
+  }
+  return opts;
+}
+
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  const result = await collectSignals(parseArgs(process.argv.slice(2)));
+  const skipped = LENSES.filter((l) => !result.agents_to_launch.includes(l));
+  console.log(`Signaux Claude — ${result.date} (baseline : ${result.baseline.last_run ?? 'aucune'})`);
+  console.log(`  À auditer  : ${result.agents_to_launch.join(', ') || 'aucune lentille'}`);
+  console.log(`  Inchangées : ${skipped.join(', ') || 'aucune'}`);
+  for (const [lens, message] of Object.entries(result.errors)) {
+    console.warn(`  ⚠️  ${lens} : ${message}`);
+  }
+  console.log(JSON.stringify(result, null, 2));
+}

--- a/tests/scripts/collect-claude-signals.test.mjs
+++ b/tests/scripts/collect-claude-signals.test.mjs
@@ -1,0 +1,387 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { rmSync, existsSync, readFileSync, mkdirSync, writeFileSync } from 'node:fs';
+import path from 'node:path';
+
+/**
+ * Garde-fou du collecteur de signaux de `/common:audit-claude-alignment`.
+ *
+ * Le collecteur est le seul composant déterministe de la commande : c'est lui
+ * qui décide quelles lentilles méritent un sous-agent cette semaine. Une
+ * régression ici se paie soit en tokens (on relance 7 agents pour rien), soit
+ * en angle mort (on rate une sortie de CLI). Les deux cas sont testés.
+ */
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, '../..');
+const TEST_TMP_DIR = path.join(PROJECT_ROOT, '.test-tmp', 'claude-signals');
+const SCRIPT = path.join(PROJECT_ROOT, 'scripts', 'collect-claude-signals.mjs');
+
+const BASELINE = {
+  schema_version: 1,
+  last_run: '2026-06-30',
+  cli_version_seen: '2.1.193',
+  page_hashes: {
+    'models-pricing': 'hash-models-v1',
+    'prompt-context': 'hash-prompt-v1',
+    'cc-features': 'hash-features-v1',
+  },
+  community_csv_hash: 'hash-csv-v1',
+  advisories_seen: ['GHSA-old-0001'],
+};
+
+/**
+ * Le hash réel est calculé par le script sur le texte normalisé. Pour piloter
+ * les tests on renvoie un corps de page stable et on aligne la baseline sur le
+ * hash produit lors d'un premier passage (cf. `hashOf`).
+ */
+const PAGE_BODY_STABLE = 'contenu de page inchangé';
+const PAGE_BODY_CHANGED = 'contenu de page mis à jour avec une nouvelle section';
+const CSV_STABLE = 'id,name\n1,outil-a\n2,outil-b\n';
+const CSV_CHANGED = 'id,name\n1,outil-a\n2,outil-b\n3,outil-c\n';
+
+function makeFetchMock({
+  cliVersion = '2.1.193',
+  pageBody = PAGE_BODY_STABLE,
+  csv = CSV_STABLE,
+  advisories = [{ ghsa_id: 'GHSA-old-0001', summary: 'déjà vue', published_at: '2026-05-01T00:00:00Z' }],
+  failing = [],
+} = {}) {
+  return vi.fn((url) => {
+    const fail = failing.find((f) => url.includes(f));
+    if (fail) {
+      return Promise.resolve({ ok: false, status: 503, statusText: 'Service Unavailable' });
+    }
+    if (url.includes('registry.npmjs.org')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ 'dist-tags': { latest: cliVersion } }),
+      });
+    }
+    if (url.includes('/security-advisories')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(advisories) });
+    }
+    if (url.includes('THE_RESOURCES_TABLE')) {
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(csv) });
+    }
+    if (url.includes('docs.claude.com') || url.includes('anthropic.com')) {
+      return Promise.resolve({ ok: true, text: () => Promise.resolve(pageBody) });
+    }
+    return Promise.reject(new Error(`Unexpected URL: ${url}`));
+  });
+}
+
+function writeBaseline(overrides = {}) {
+  const file = path.join(TEST_TMP_DIR, 'baseline.json');
+  writeFileSync(file, JSON.stringify({ ...BASELINE, ...overrides }, null, 2));
+  return file;
+}
+
+describe('collect-claude-signals', () => {
+  let collectSignals;
+  let compareVersions;
+  let hashOf;
+
+  beforeEach(async () => {
+    mkdirSync(TEST_TMP_DIR, { recursive: true });
+    const mod = await import(`${SCRIPT}?t=${Date.now()}`);
+    collectSignals = mod.collectSignals;
+    compareVersions = mod.compareVersions;
+    hashOf = mod.hashOf;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    if (existsSync(TEST_TMP_DIR)) {
+      rmSync(TEST_TMP_DIR, { recursive: true, force: true });
+    }
+  });
+
+  describe('compareVersions', () => {
+    it('compares numerically, not lexicographically', () => {
+      // Le piège : '2.1.9' > '2.1.193' en comparaison de chaînes.
+      expect(compareVersions('2.1.193', '2.1.9')).toBeGreaterThan(0);
+      expect(compareVersions('2.1.9', '2.1.193')).toBeLessThan(0);
+      expect(compareVersions('2.1.193', '2.1.193')).toBe(0);
+      expect(compareVersions('2.2.0', '2.1.999')).toBeGreaterThan(0);
+    });
+
+    it('tolerates missing segments and non-numeric suffixes', () => {
+      expect(compareVersions('2.2', '2.1.5')).toBeGreaterThan(0);
+      expect(compareVersions('2.1.200-beta.1', '2.1.193')).toBeGreaterThan(0);
+    });
+  });
+
+  describe('semaine calme (aucun delta)', () => {
+    it('ne signale aucune lentille web et ne demande aucun agent web', async () => {
+      globalThis.fetch = makeFetchMock();
+      const stableHash = hashOf(PAGE_BODY_STABLE);
+      const baselinePath = writeBaseline({
+        page_hashes: {
+          'models-pricing': stableHash,
+          'prompt-context': stableHash,
+          'cc-features': stableHash,
+        },
+        community_csv_hash: hashOf(CSV_STABLE),
+      });
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses['cli-release'].changed).toBe(false);
+      expect(result.lenses['models-pricing'].changed).toBe(false);
+      expect(result.lenses['prompt-context'].changed).toBe(false);
+      expect(result.lenses['cc-features'].changed).toBe(false);
+      expect(result.lenses['security-cve'].changed).toBe(false);
+      expect(result.lenses.community.changed).toBe(false);
+
+      // La conformité interne est un scan local : toujours lancée, elle ne
+      // dépend d'aucun signal réseau.
+      expect(result.lenses['internal-conformance'].changed).toBe(true);
+      expect(result.agents_to_launch).toEqual(['internal-conformance']);
+    });
+  });
+
+  describe('sortie de CLI', () => {
+    it('détecte une version npm plus récente que celle déclarée', async () => {
+      globalThis.fetch = makeFetchMock({ cliVersion: '2.1.210' });
+      const stableHash = hashOf(PAGE_BODY_STABLE);
+      const baselinePath = writeBaseline({
+        page_hashes: {
+          'models-pricing': stableHash,
+          'prompt-context': stableHash,
+          'cc-features': stableHash,
+        },
+        community_csv_hash: hashOf(CSV_STABLE),
+      });
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses['cli-release'].changed).toBe(true);
+      expect(result.lenses['cli-release'].declared).toBe('2.1.193');
+      expect(result.lenses['cli-release'].observed).toBe('2.1.210');
+      expect(result.agents_to_launch).toContain('cli-release');
+    });
+
+    it('ne signale rien quand npm renvoie la version déjà connue', async () => {
+      globalThis.fetch = makeFetchMock({ cliVersion: '2.1.193' });
+      const baselinePath = writeBaseline();
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses['cli-release'].changed).toBe(false);
+      expect(result.agents_to_launch).not.toContain('cli-release');
+    });
+  });
+
+  describe('pages sans API (comparaison de hash)', () => {
+    it('signale la lentille dont le contenu de page a bougé', async () => {
+      globalThis.fetch = makeFetchMock({ pageBody: PAGE_BODY_CHANGED });
+      const baselinePath = writeBaseline({
+        page_hashes: {
+          'models-pricing': hashOf(PAGE_BODY_STABLE),
+          'prompt-context': hashOf(PAGE_BODY_STABLE),
+          'cc-features': hashOf(PAGE_BODY_STABLE),
+        },
+      });
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses['models-pricing'].changed).toBe(true);
+      expect(result.lenses['models-pricing'].hash_before).toBe(hashOf(PAGE_BODY_STABLE));
+      expect(result.lenses['models-pricing'].hash_after).toBe(hashOf(PAGE_BODY_CHANGED));
+      expect(result.agents_to_launch).toContain('models-pricing');
+    });
+
+    it('ignore les différences de pur espacement', async () => {
+      globalThis.fetch = makeFetchMock({ pageBody: `  ${PAGE_BODY_STABLE}\n\n\t` });
+      const baselinePath = writeBaseline({
+        page_hashes: {
+          'models-pricing': hashOf(PAGE_BODY_STABLE),
+          'prompt-context': hashOf(PAGE_BODY_STABLE),
+          'cc-features': hashOf(PAGE_BODY_STABLE),
+        },
+      });
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses['models-pricing'].changed).toBe(false);
+    });
+  });
+
+  describe('sécurité', () => {
+    it('signale une advisory jamais vue', async () => {
+      globalThis.fetch = makeFetchMock({
+        advisories: [
+          { ghsa_id: 'GHSA-old-0001', summary: 'déjà vue', published_at: '2026-05-01T00:00:00Z' },
+          { ghsa_id: 'GHSA-new-0002', summary: 'nouvelle', published_at: '2026-08-05T00:00:00Z' },
+        ],
+      });
+      const baselinePath = writeBaseline();
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses['security-cve'].changed).toBe(true);
+      expect(result.lenses['security-cve'].new_advisories).toEqual(['GHSA-new-0002']);
+      expect(result.agents_to_launch).toContain('security-cve');
+    });
+  });
+
+  describe('communauté', () => {
+    it('signale un catalogue awesome-claude-code modifié', async () => {
+      globalThis.fetch = makeFetchMock({ csv: CSV_CHANGED });
+      const baselinePath = writeBaseline({ community_csv_hash: hashOf(CSV_STABLE) });
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses.community.changed).toBe(true);
+      expect(result.agents_to_launch).toContain('community');
+    });
+
+    it('bascule sur le nom de fichier de repli quand le premier candidat a été renommé', async () => {
+      // Cas réel constaté le 2026-08-11 : l'upstream a renommé THE_RESOURCES_TABLE.csv.
+      // Sans repli, la lentille fail-open coûterait un agent chaque semaine sans
+      // jamais rien apprendre.
+      globalThis.fetch = makeFetchMock({ failing: ['THE_RESOURCES_TABLE_NEW.csv'] });
+      const baselinePath = writeBaseline({ community_csv_hash: hashOf(CSV_STABLE) });
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.errors.community).toBeUndefined();
+      expect(result.lenses.community.changed).toBe(false);
+      expect(result.lenses.community.sources[0]).toMatch(/THE_RESOURCES_TABLE\.csv$/);
+    });
+
+    it('fail-open quand aucun candidat de catalogue ne répond', async () => {
+      globalThis.fetch = makeFetchMock({ failing: ['THE_RESOURCES_TABLE'] });
+      const baselinePath = writeBaseline({ community_csv_hash: hashOf(CSV_STABLE) });
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses.community.changed).toBe(true);
+      expect(result.errors.community).toMatch(/503/);
+    });
+  });
+
+  describe('robustesse réseau (fail-open)', () => {
+    it('marque la lentille comme à auditer quand sa source est injoignable', async () => {
+      // Choix de conception : une panne réseau ne doit JAMAIS produire un faux
+      // « rien à signaler ». On dégrade vers « à auditer », pas vers le silence.
+      globalThis.fetch = makeFetchMock({ failing: ['registry.npmjs.org'] });
+      const baselinePath = writeBaseline();
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.lenses['cli-release'].changed).toBe(true);
+      expect(result.lenses['cli-release'].reason).toMatch(/collecte/i);
+      expect(result.errors['cli-release']).toMatch(/503/);
+      expect(result.agents_to_launch).toContain('cli-release');
+    });
+  });
+
+  describe('baseline et sortie', () => {
+    it('utilise --since pour surcharger la date de baseline', async () => {
+      globalThis.fetch = makeFetchMock();
+      const baselinePath = writeBaseline();
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+        since: '2026-05-01',
+      });
+
+      expect(result.baseline.last_run).toBe('2026-05-01');
+    });
+
+    it('repart de zéro (tout à auditer) quand la baseline est absente', async () => {
+      globalThis.fetch = makeFetchMock();
+
+      const result = await collectSignals({
+        baselinePath: path.join(TEST_TMP_DIR, 'inexistant.json'),
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      expect(result.baseline_missing).toBe(true);
+      expect(result.agents_to_launch).toContain('cli-release');
+      expect(result.agents_to_launch).toContain('models-pricing');
+      expect(result.agents_to_launch).toContain('community');
+    });
+
+    it('écrit le fichier de signaux daté et propose la prochaine baseline', async () => {
+      globalThis.fetch = makeFetchMock({ cliVersion: '2.1.210' });
+      const baselinePath = writeBaseline();
+
+      const result = await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+      });
+
+      const outPath = path.join(TEST_TMP_DIR, 'signals-2026-08-11.json');
+      expect(existsSync(outPath)).toBe(true);
+
+      const parsed = JSON.parse(readFileSync(outPath, 'utf8'));
+      expect(parsed.date).toBe('2026-08-11');
+      expect(parsed.lenses['cli-release'].observed).toBe('2.1.210');
+
+      // La baseline suivante est pré-calculée pour que la commande n'ait qu'à
+      // l'écrire une fois le rapport validé.
+      expect(result.next_baseline.cli_version_seen).toBe('2.1.210');
+      expect(result.next_baseline.last_run).toBe('2026-08-11');
+      expect(result.next_baseline.schema_version).toBe(1);
+    });
+
+    it("n'écrit rien en mode dry-run", async () => {
+      globalThis.fetch = makeFetchMock();
+      const baselinePath = writeBaseline();
+
+      await collectSignals({
+        baselinePath,
+        outDir: TEST_TMP_DIR,
+        now: new Date('2026-08-11T09:00:00Z'),
+        write: false,
+      });
+
+      expect(existsSync(path.join(TEST_TMP_DIR, 'signals-2026-08-11.json'))).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Pourquoi

Claude Craft porte l'écosystème Claude Code dans ~40 fichiers (`config/versions.yaml`, `.claude/COMPATIBILITY.md`, fichiers vitrine, templates i18n) mais **rien ne le surveillait** : `/common:audit-freshness` couvre les 15 stacks applicatifs et jamais Claude Code lui-même.

Résultat constaté au premier run : la version CLI déclarée avait dérivé de **2.1.193 → 2.1.227** sans que personne ne le voie, depuis le 2026-06-30.

## Ce que fait la commande

Audite 7 lentilles : version du CLI, modèles/pricing, prompt & context engineering Anthropic, features de la plateforme, avis de sécurité, conformité interne des frontmatters, pratiques de la communauté.

## Économie de tokens — la contrainte de conception

La commande a vocation à tourner **chaque semaine**, donc le coût par run est le critère structurant :

- `scripts/collect-claude-signals.mjs` pré-collecte de façon déterministe (registry npm, GitHub Security Advisories, catalogue communautaire, empreintes SHA-256 des pages de doc) et décide **sans appeler de modèle** quelles lentilles méritent un sous-agent. Une lentille dont la source n'a pas bougé n'en déclenche aucun. Mesuré sur un run N+1 simulé : **7 lentilles → 1**.
- Les gates existants (`lint:versions`, `lint:includes`, `docs:check`, `lint:i18n`) tournent en Bash au lieu de consommer deux agents.
- Routing modèle explicite : `haiku`/`low` pour le scan mécanique local (aucun accès web), `sonnet`/`medium` pour l'interprétation de changelogs et d'advisories, `claude-code-guide` pour les features plateforme. **Aucun sous-agent `opus`.**
- **Fail-open** : une source injoignable rend la lentille « à auditer », jamais « rien à signaler » — une panne réseau ne peut pas devenir un angle mort silencieux.

## Un piège trouvé en route

Les pages suivies utilisent les endpoints `.md`, pas le HTML : le HTML rendu embarque un **nonce par requête**, donc deux fetchs à quelques secondes d'intervalle donnent la même taille mais deux empreintes différentes. Laissé sur le HTML, ça aurait réveillé deux agents `sonnet` chaque semaine pour rien. Le markdown est stable et **30× plus léger** (27 Ko contre 873 Ko), ce qui réduit aussi le coût du WebFetch des agents eux-mêmes.

## Sortie et garde-fous

Rapport local + PR portant **uniquement** des substitutions de version littérales sur une allowlist stricte. Garde-fous :

- worktree propre exigé en préalable
- `.github/workflows/` interdit (le token `gh` n'a pas le scope `workflow`)
- les 4 gates verts avant ouverture de la PR
- jamais de merge automatique
- tout ce qui demande un arbitrage part en checklist dans le corps de la PR, jamais en édition

## Portée

Commande interne : `.claude/` + `Dev/i18n/base/` seulement, comme `audit-freshness` — outillage de maintenance du dépôt, hors gate de parité i18n, donc zéro dette de traduction.

## Vérification

| Contrôle | Résultat |
|---|---|
| Tests unitaires du collecteur | 16 verts |
| Suite `tests/scripts/` complète | 262/262 |
| `lint:versions` / `lint:includes` / `docs:check` / `lint:i18n` / `eslint` | verts |
| Lentille `internal-conformance` exécutée end-to-end | dépôt conforme, 1 dérive documentaire P3 remontée |
| Fast-exit sur run N+1 simulé | 7 → 1 lentille |

## À corriger séparément

`scripts/awesome-claude-code-submit.mjs` pointe encore sur `THE_RESOURCES_TABLE.csv`, renommé upstream en `THE_RESOURCES_TABLE_NEW.csv` → 404. Hors périmètre ici (fichier avec des modifications en cours), noté dans le CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaZY7kwqPQbE9y3x2TvsyM
