### PR TITLE
fix(deps): bump js-yaml to 5.2.3 and hono to 4.13.1 for CVEs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Security
+
+- **`js-yaml` 5.2.1 → 5.2.3** (GHSA-pm4m-ph32-ghv5, **haute**) : temps de parsing exponentiel sur les collections flow, exploitable en déni de service. Le paquet est sur le chemin critique du projet — `scripts/verify-versions.mjs`, `scripts/generate-references.mjs` et le parseur de frontmatter du serveur Kanban chargent tous du YAML.
+- **`hono` 4.12.28 → 4.13.1** (4 avis, modérés) : ReDoS dans le middleware CORS via `Access-Control-Request-Headers` (GHSA-8j4g-w8fx-2239), rétention de sortie SSR par `memo()` entre requêtes menant à une divulgation de données inter-utilisateurs (GHSA-f23p-vx2j-j53r), en-têtes listés dans `Connection` non retirés par le Proxy Helper (GHSA-79qm-7rj5-m7r9), et DoS algorithmique dans le middleware Language (GHSA-54fx-42gc-7vw4).
+
+  Les deux montées tiennent dans les plages semver déjà déclarées (`^5.2.0`, `^4.12.14`) : `package.json` est inchangé, seul le lockfile bouge. `npm audit --omit=dev --audit-level=moderate` repasse à 0 vulnérabilité.
+
 ### Added
 
 - **`/common:audit-claude-alignment`** : audit hebdomadaire d'alignement sur l'écosystème Claude lui-même — version du CLI Claude Code, identifiants et pricing des modèles, best practices Anthropic (prompt/context engineering), features de la plateforme (hooks, skills, sous-agents, MCP, plugins, settings), avis de sécurité, et pratiques de la communauté. Comble l'angle mort de `/common:audit-freshness`, qui ne couvre que les stacks applicatifs.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2654,9 +2654,9 @@
       }
     },
     "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {
@@ -3532,9 +3532,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.28",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.28.tgz",
-      "integrity": "sha512-YwUvVpSF7m1yOblFPrU3Hbo8XhPheBoiyfGuII6z19LnOr6JpDnyyp7LFNrfV56wS8tpvtBFGRISHN02pDdLOA==",
+      "version": "4.13.1",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.13.1.tgz",
+      "integrity": "sha512-kdJoFVv2xmayw6cY09H7AbMJMt8Jn5jdlEdXsP7AGBdF2DIptVlKlOLKXP41yPip4/a3yQPv9gVcJYI8YY04dw==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3779,9 +3779,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.1.tgz",
-      "integrity": "sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==",
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.3.tgz",
+      "integrity": "sha512-n+mUVyUX5bVv7G/G2zyIHOhdxfuU1dY2NOFzTQUWiMUbFss8b57NFlgCCaggU78wSw5KVS9cllzeLyzyR+n5nw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Pourquoi

`npm audit --omit=dev --audit-level=moderate` et Trivy échouent sur **toutes** les PR depuis quelques jours. Deux paquets sont en cause, aucun lié à une PR récente — ce sont des avis publiés depuis le dernier passage CI de `main`.

| Paquet | Sévérité | Avis |
|---|---|---|
| `js-yaml` ≤ 5.2.1 | **haute** | [GHSA-pm4m-ph32-ghv5](https://github.com/advisories/GHSA-pm4m-ph32-ghv5) — temps de parsing exponentiel sur les collections flow, exploitable en DoS |
| `hono` ≤ 4.12.33 | modérée | [GHSA-8j4g-w8fx-2239](https://github.com/advisories/GHSA-8j4g-w8fx-2239) — ReDoS middleware CORS via `Access-Control-Request-Headers` |
| `hono` ≤ 4.12.33 | modérée | [GHSA-f23p-vx2j-j53r](https://github.com/advisories/GHSA-f23p-vx2j-j53r) — `memo()` retient la sortie SSR entre requêtes → divulgation de données inter-utilisateurs |
| `hono` ≤ 4.12.33 | modérée | [GHSA-79qm-7rj5-m7r9](https://github.com/advisories/GHSA-79qm-7rj5-m7r9) — le Proxy Helper ne retire pas les en-têtes listés dans `Connection` |
| `hono` ≤ 4.12.33 | modérée | [GHSA-54fx-42gc-7vw4](https://github.com/advisories/GHSA-54fx-42gc-7vw4) — DoS algorithmique middleware Language |

`js-yaml` mérite l'attention : il est sur le **chemin critique** du projet — `scripts/verify-versions.mjs`, `scripts/generate-references.mjs` et le parseur de frontmatter du serveur Kanban chargent tous du YAML.

## Ce que change la PR

`js-yaml` 5.2.1 → 5.2.3, `hono` 4.12.28 → 4.13.1.

Les deux correctifs tombent **dans les plages semver déjà déclarées** (`^5.2.0`, `^4.12.14`) : `package.json` est inchangé, seul le lockfile bouge. Le `js-yaml` imbriqué de `cosmiconfig` suit en 4.3.0 → 4.3.1 comme effet de bord du même rafraîchissement — chemin dev-only, jamais dans la plage de l'avis.

## Vérification

Menée dans un conteneur propre (`node:24`, `node_modules` masqué par un volume anonyme pour ne pas réutiliser l'arbre de l'hôte) :

| Contrôle | Résultat |
|---|---|
| `npm audit --omit=dev --audit-level=moderate` | **0 vulnérabilité** (avant : 1 haute + 1 modérée) |
| Suite complète `vitest run` | **1133/1133** |

Le passage de `js-yaml` est le point sensible — la suite couvre `verify-versions`, `generate-references` et le parseur de frontmatter, tous verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaZY7kwqPQbE9y3x2TvsyM
