### PR TITLE
fix(scripts): restore awesome-claude-code duplicate check after upstream rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **`scripts/collect-claude-signals.mjs`** : le catalogue `awesome-claude-code` a été renommé upstream (`THE_RESOURCES_TABLE.csv` → `THE_RESOURCES_TABLE_NEW.csv`), l'URL historique renvoie 404. Le collecteur essaie les deux noms dans l'ordre. `scripts/awesome-claude-code-submit.mjs` porte encore l'URL périmée — à corriger séparément.
+- **`scripts/collect-claude-signals.mjs`** : le catalogue `awesome-claude-code` a été renommé upstream (`THE_RESOURCES_TABLE.csv` → `THE_RESOURCES_TABLE_NEW.csv`), l'URL historique renvoie 404. Le collecteur essaie les deux noms dans l'ordre.
+- **`scripts/awesome-claude-code-submit.mjs`** : même URL périmée, avec une conséquence plus sournoise — `findDuplicate()` retombe sur `{ status: 'unknown' }` à tout non-200, donc le contrôle anti-doublon était **inopérant sans le signaler**, et une ressource déjà présente au catalogue pouvait être soumise. Même repli à deux candidats. Le module expose désormais `findDuplicate`/`CSV_CANDIDATES` et n'exécute plus `main()` à l'import (garde `import.meta.url === process.argv[1]`, comme `track-adoption-metrics.mjs`), ce qui le rend testable : 6 tests de régression ajoutés.
 
 ## [8.22.0] - 2026-07-22
 

--- a/scripts/awesome-claude-code-submit.mjs
+++ b/scripts/awesome-claude-code-submit.mjs
@@ -35,7 +35,16 @@ const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 
 const UPSTREAM = 'https://github.com/hesreallyhim/awesome-claude-code';
 const ISSUE_FORM = `${UPSTREAM}/issues/new?template=recommend-resource.yml`;
-const CSV_RAW = 'https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/THE_RESOURCES_TABLE.csv';
+/**
+ * Catalogue upstream, essayé dans l'ordre. Le fichier a été renommé
+ * (`THE_RESOURCES_TABLE.csv` → `..._NEW.csv`) et l'ancien nom renvoie 404 : sans
+ * repli, `findDuplicate` retombe silencieusement sur `unknown` et le contrôle
+ * anti-doublon devient inopérant sans que rien ne le signale.
+ */
+export const CSV_CANDIDATES = [
+  'https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/THE_RESOURCES_TABLE_NEW.csv',
+  'https://raw.githubusercontent.com/hesreallyhim/awesome-claude-code/main/THE_RESOURCES_TABLE.csv',
+];
 
 const CATEGORY = 'Tooling';
 const SUBCATEGORY = 'General';
@@ -81,15 +90,21 @@ async function urlOk(url) {
   }
 }
 
-async function findDuplicate(displayName, primaryLink) {
+export async function findDuplicate(displayName, primaryLink) {
   let csv;
-  try {
-    const res = await fetch(CSV_RAW, { redirect: 'follow' });
-    if (!(res.status >= 200 && res.status < 300)) return { status: 'unknown' };
-    csv = await res.text();
-  } catch {
-    return { status: 'unknown' };
+  for (const url of CSV_CANDIDATES) {
+    try {
+      const res = await fetch(url, { redirect: 'follow' });
+      if (res.status >= 200 && res.status < 300) {
+        csv = await res.text();
+        break;
+      }
+    } catch {
+      // candidat injoignable : on tente le suivant
+    }
   }
+  // Aucun candidat n'a répondu : on ne prétend PAS qu'il n'y a pas de doublon.
+  if (csv === undefined) return { status: 'unknown' };
   const needle = primaryLink.toLowerCase();
   const hit = csv
     .split('\n')
@@ -241,7 +256,12 @@ async function main() {
   }
 }
 
-main().catch((err) => {
-  console.error(`✗ ${err.message}`);
-  process.exit(1);
-});
+// Garde d'exécution : sans elle, `main()` partirait au moindre import et rendrait
+// le module intestable (appels réseau + process.exit). Même motif que
+// scripts/track-adoption-metrics.mjs et scripts/collect-claude-signals.mjs.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((err) => {
+    console.error(`✗ ${err.message}`);
+    process.exit(1);
+  });
+}

--- a/tests/scripts/awesome-claude-code-submit.test.mjs
+++ b/tests/scripts/awesome-claude-code-submit.test.mjs
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import path from 'node:path';
+
+/**
+ * Régression : le catalogue upstream a été renommé
+ * (`THE_RESOURCES_TABLE.csv` → `THE_RESOURCES_TABLE_NEW.csv`), l'URL historique
+ * renvoie 404.
+ *
+ * Le danger n'est pas l'erreur visible mais son absence : `findDuplicate`
+ * retombe sur `{ status: 'unknown' }` en cas de non-200, donc le contrôle
+ * anti-doublon devient inopérant SANS que rien ne le signale. On pourrait
+ * soumettre une entrée déjà présente en croyant le contrôle passé.
+ */
+
+const PROJECT_ROOT = path.resolve(import.meta.dirname, '../..');
+const SCRIPT = path.join(PROJECT_ROOT, 'scripts', 'awesome-claude-code-submit.mjs');
+
+const CSV = [
+  'id,display_name,primary_link',
+  '1,Some Other Tool,https://github.com/someone/other',
+  '2,Claude Craft,https://github.com/TheBeardedBearSAS/claude-craft',
+].join('\n');
+
+/** @param {string[]} failing sous-chaînes d'URL qui doivent répondre 404 */
+function makeFetchMock(failing = []) {
+  return vi.fn((url) => {
+    if (failing.some((f) => url.includes(f))) {
+      return Promise.resolve({ status: 404, text: () => Promise.resolve('Not Found') });
+    }
+    if (url.includes('THE_RESOURCES_TABLE')) {
+      return Promise.resolve({ status: 200, text: () => Promise.resolve(CSV) });
+    }
+    return Promise.reject(new Error(`Unexpected URL: ${url}`));
+  });
+}
+
+describe('awesome-claude-code-submit', () => {
+  let findDuplicate;
+  let CSV_CANDIDATES;
+
+  beforeEach(async () => {
+    const mod = await import(`${SCRIPT}?t=${Date.now()}`);
+    findDuplicate = mod.findDuplicate;
+    CSV_CANDIDATES = mod.CSV_CANDIDATES;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("n'exécute pas main() à l'import (module importable sans effet de bord)", () => {
+    // Si main() tournait à l'import, le beforeEach aurait déjà déclenché des
+    // appels réseau et potentiellement un process.exit.
+    expect(findDuplicate).toBeTypeOf('function');
+  });
+
+  it('essaie le nom de fichier courant en premier', () => {
+    expect(CSV_CANDIDATES[0]).toMatch(/THE_RESOURCES_TABLE_NEW\.csv$/);
+    expect(CSV_CANDIDATES).toHaveLength(2);
+  });
+
+  it('détecte un doublon quand le catalogue répond', async () => {
+    globalThis.fetch = makeFetchMock();
+
+    const res = await findDuplicate('Claude Craft', 'https://github.com/TheBeardedBearSAS/claude-craft');
+
+    expect(res.status).toBe('duplicate');
+  });
+
+  it('bascule sur le nom de repli quand le nom courant a disparu', async () => {
+    globalThis.fetch = makeFetchMock(['THE_RESOURCES_TABLE_NEW.csv']);
+
+    const res = await findDuplicate('Claude Craft', 'https://github.com/TheBeardedBearSAS/claude-craft');
+
+    expect(res.status).toBe('duplicate');
+  });
+
+  it("conclut à l'absence quand l'entrée n'est pas au catalogue", async () => {
+    globalThis.fetch = makeFetchMock();
+
+    const res = await findDuplicate('Inconnu', 'https://github.com/nobody/nothing');
+
+    expect(res.status).toBe('absent');
+  });
+
+  it("reste sur 'unknown' quand AUCUN candidat ne répond", async () => {
+    // Dégradation explicite : on ne prétend pas qu'il n'y a pas de doublon.
+    globalThis.fetch = makeFetchMock(['THE_RESOURCES_TABLE']);
+
+    const res = await findDuplicate('Claude Craft', 'https://github.com/TheBeardedBearSAS/claude-craft');
+
+    expect(res.status).toBe('unknown');
+  });
+});


### PR DESCRIPTION
## Le bug

Le catalogue upstream a été renommé `THE_RESOURCES_TABLE.csv` → `THE_RESOURCES_TABLE_NEW.csv`. L'URL codée en dur renvoie donc 404.

**Le 404 n'est pas le vrai problème.** `findDuplicate()` transforme tout non-2xx en `{ status: 'unknown' }` : le contrôle s'est dégradé **en silence**. Le script continuait d'afficher sa ligne « Duplicate check » alors qu'il ne vérifiait plus rien — et une ressource déjà présente au catalogue pouvait être soumise.

Constaté en exécutant le script avant correction : le contrôle répondait `unknown`. Après correction, il tranche : `absent (ok to submit)`.

## Le correctif

Même motif que `scripts/collect-claude-signals.mjs` : essayer les deux noms de fichier dans l'ordre, et ne retomber sur `unknown` que si **aucun** candidat ne répond — pour qu'une vraie panne réseau continue de refuser d'affirmer qu'il n'y a pas de doublon.

Au passage, le module devient testable : `findDuplicate` et `CSV_CANDIDATES` sont exportés, et `main()` ne part plus à l'import (garde `import.meta.url === process.argv[1]`, même motif que `track-adoption-metrics.mjs`). Sans ça, importer le module déclenchait des appels réseau et pouvait appeler `process.exit()`.

## Vérification

Les 6 tests de régression ont été écrits **avant** le correctif et échouaient 6/6 sur l'ancien code.

| Contrôle | Résultat |
|---|---|
| Tests de régression | 6/6 (RED → GREEN vérifié) |
| Suite complète | 1139/1139 |
| `eslint cli/ scripts/` | propre |
| Chemin CLI (`node scripts/awesome-claude-code-submit.mjs`) | fonctionne, contrôle anti-doublon résolu |

## Note

Cette PR ne touche **pas** les compteurs de la description (`RESOURCE_DESCRIPTION`, `VALIDATE_CLAIMS`) — ils font l'objet d'un travail en cours séparé, laissé intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QaZY7kwqPQbE9y3x2TvsyM
